### PR TITLE
refactor: various improvements to async image

### DIFF
--- a/src/ui/screens/logs.rs
+++ b/src/ui/screens/logs.rs
@@ -50,6 +50,7 @@ impl Screen for LogsScreen {
     }
 
     fn before_show(&mut self, _client: &mut impl MpdClient, _status: &mut Status, _config: &Config) -> Result<()> {
+        self.scrolling_state.last();
         Ok(())
     }
 


### PR DESCRIPTION
Fixes various edge cases (user is on a tab other than queue and changes current song) and avoids clone of the whole image on render