### PR TITLE
Only test tmux passthrough if TERM_PROGRAM=tmux

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -101,7 +101,7 @@ impl ErrorExt for anyhow::Error {
 #[allow(dead_code)]
 pub mod tmux {
     pub fn is_inside_tmux() -> bool {
-        std::env::var("TERM_PROGRAM").is_ok_and(|v| !v.is_empty())
+        std::env::var("TERM_PROGRAM").is_ok_and(|v| v == "tmux")
     }
 
     pub fn wrap(input: &str) -> String {


### PR DESCRIPTION
I tried running this on ghostty, and got the same error as #29.

I don't have tmux installed, and the error was occurring when trying to spawn a `tmux` process.

Ghostty sets `TERM_PROGRAM=ghostty`, so it detected a running tmux even though I wasn't running tmux. This fixes that.