### PR TITLE
docs: update Arch Linux instructions

### DIFF
--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -47,9 +47,9 @@ Minimum supported MPD version is 0.23.5. Other versions may work, but you are on
 ### Arch Linux
 
 ```bash frame=none showLineNumbers=false
-yay -S rmpc-git
+pacman -S rmpc
 # or
-yay -S rmpc
+yay -S rmpc-git
 ```
 
 ### openSUSE Tumbleweed


### PR DESCRIPTION
Now packaged in the official repositories: <https://archlinux.org/packages/extra/x86_64/rmpc/> 🥳
