### PR TITLE
refactor: simplify key event results

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -51,6 +51,10 @@ impl AppContext {
         })
     }
 
+    pub fn render(&self) -> Result<(), std::sync::mpsc::SendError<AppEvent>> {
+        self.app_event_sender.send(AppEvent::RequestRender(false))
+    }
+
     pub fn find_current_song_in_queue(&self) -> Option<(usize, &Song)> {
         self.status
             .songid

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,21 +19,7 @@ pub struct AppContext {
     pub supported_commands: HashSet<String>,
     pub app_event_sender: Sender<AppEvent>,
     pub work_sender: Sender<WorkRequest>,
-    needs_render: Cell<bool>,
-}
-
-impl Default for AppContext {
-    fn default() -> Self {
-        Self {
-            status: Status::default(),
-            config: Box::leak(Box::default()),
-            queue: Vec::default(),
-            app_event_sender: std::sync::mpsc::channel().0,
-            work_sender: std::sync::mpsc::channel().0,
-            supported_commands: HashSet::new(),
-            needs_render: Cell::new(false),
-        }
-    }
+    pub needs_render: Cell<bool>,
 }
 
 impl AppContext {

--- a/src/main.rs
+++ b/src/main.rs
@@ -377,16 +377,12 @@ fn main_task<B: Backend + std::io::Write>(
         if let Some(event) = event {
             match event {
                 AppEvent::UserKeyInput(key) => match ui.handle_key(key, &mut context, &mut client) {
-                    Ok(ui::KeyHandleResult::SkipRender) => continue,
+                    Ok(ui::KeyHandleResult::None) => continue,
                     Ok(ui::KeyHandleResult::Quit) => {
                         if let Err(err) = ui.on_event(UiEvent::Exit, &mut context, &mut client) {
                             error!(error:? = err, event:?; "Ui failed to handle quit event");
                         }
                         break;
-                    }
-                    Ok(ui::KeyHandleResult::FullRenderRequested) => {
-                        render_wanted = true;
-                        full_rerender_wanted = true;
                     }
                     Err(err) => {
                         status_error!(err:?; "Error: {}", err.to_status());
@@ -394,17 +390,7 @@ fn main_task<B: Backend + std::io::Write>(
                     }
                 },
                 AppEvent::UserMouseInput(ev) => match ui.handle_mouse_event(ev, &mut client, &mut context) {
-                    Ok(ui::KeyHandleResult::SkipRender) => continue,
-                    Ok(ui::KeyHandleResult::Quit) => {
-                        if let Err(err) = ui.on_event(UiEvent::Exit, &mut context, &mut client) {
-                            error!(error:? = err, event:?; "Ui failed to handle quit event");
-                        }
-                        break;
-                    }
-                    Ok(ui::KeyHandleResult::FullRenderRequested) => {
-                        render_wanted = true;
-                        full_rerender_wanted = true;
-                    }
+                    Ok(()) => {}
                     Err(err) => {
                         status_error!(err:?; "Error: {}", err.to_status());
                         render_wanted = true;
@@ -466,18 +452,7 @@ fn main_task<B: Backend + std::io::Write>(
                     render_wanted = true;
                 }
                 AppEvent::UiAppEvent(event) => match ui.on_ui_app_event(event, &mut context, &mut client) {
-                    Ok(ui::KeyHandleResult::SkipRender) => continue,
-                    Ok(ui::KeyHandleResult::Quit) => {
-                        if let Err(err) = ui.on_event(UiEvent::Exit, &mut context, &mut client) {
-                            error!(error:? = err; "Ui failed to handle ui app event");
-                            // error!(error:? = err, event:?; "Ui failed to handle quit event");
-                        }
-                        break;
-                    }
-                    Ok(ui::KeyHandleResult::FullRenderRequested) => {
-                        render_wanted = true;
-                        full_rerender_wanted = true;
-                    }
+                    Ok(()) => {}
                     Err(err) => {
                         status_error!(err:?; "Error: {}", err.to_status());
                         render_wanted = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -376,7 +376,7 @@ fn main_task<B: Backend + std::io::Write>(
 
         if let Some(event) = event {
             match event {
-                AppEvent::UserKeyInput(key) => match ui.handle_key(key, &mut context, &mut client) {
+                AppEvent::UserKeyInput(key) => match ui.handle_key(&mut key.into(), &mut context, &mut client) {
                     Ok(ui::KeyHandleResult::None) => continue,
                     Ok(ui::KeyHandleResult::Quit) => {
                         if let Err(err) = ui.on_event(UiEvent::Exit, &mut context, &mut client) {
@@ -481,6 +481,8 @@ fn main_task<B: Backend + std::io::Write>(
             if let Err(err) = ui.post_render(&mut terminal.get_frame(), &mut context) {
                 error!(error:? = err; "Failed handle post render phase");
             };
+
+            context.finish_frame();
             last_render = now;
             render_wanted = false;
         }

--- a/src/shared/ext.rs
+++ b/src/shared/ext.rs
@@ -42,7 +42,6 @@ pub mod duration {
 }
 
 pub mod mpsc {
-    #[allow(dead_code)]
     pub trait RecvLast<T> {
         fn recv_last(&self) -> Result<T, std::sync::mpsc::RecvError>;
         fn try_recv_last(&self) -> Result<T, std::sync::mpsc::TryRecvError>;

--- a/src/shared/key_event.rs
+++ b/src/shared/key_event.rs
@@ -32,36 +32,52 @@ impl KeyEvent {
         self.already_handled = true;
     }
 
-    pub fn as_common_action(&self, context: &AppContext) -> Option<CommonAction> {
+    pub fn abandon(&mut self) {
+        self.already_handled = false;
+    }
+
+    pub fn as_common_action(&mut self, context: &AppContext) -> Option<CommonAction> {
         if self.already_handled {
             None
+        } else if let Some(action) = context.config.keybinds.navigation.get(&self.inner.into()) {
+            self.already_handled = true;
+            Some(*action)
         } else {
-            context.config.keybinds.navigation.get(&self.inner.into()).copied()
+            None
         }
     }
 
-    pub fn as_global_action(&self, context: &AppContext) -> Option<GlobalAction> {
+    pub fn as_global_action(&mut self, context: &AppContext) -> Option<GlobalAction> {
         if self.already_handled {
             None
+        } else if let Some(action) = context.config.keybinds.global.get(&self.inner.into()) {
+            self.already_handled = true;
+            Some(*action)
         } else {
-            context.config.keybinds.global.get(&self.inner.into()).copied()
+            None
         }
     }
 
     #[cfg(debug_assertions)]
-    pub fn as_logs_action(&self, context: &AppContext) -> Option<LogsActions> {
+    pub fn as_logs_action(&mut self, context: &AppContext) -> Option<LogsActions> {
         if self.already_handled {
             None
+        } else if let Some(action) = context.config.keybinds.logs.get(&self.inner.into()) {
+            self.already_handled = true;
+            Some(*action)
         } else {
-            context.config.keybinds.logs.get(&self.inner.into()).copied()
+            None
         }
     }
 
-    pub fn as_queue_action(&self, context: &AppContext) -> Option<QueueActions> {
+    pub fn as_queue_action(&mut self, context: &AppContext) -> Option<QueueActions> {
         if self.already_handled {
             None
+        } else if let Some(action) = context.config.keybinds.queue.get(&self.inner.into()) {
+            self.already_handled = true;
+            Some(*action)
         } else {
-            context.config.keybinds.queue.get(&self.inner.into()).copied()
+            None
         }
     }
 }

--- a/src/shared/key_event.rs
+++ b/src/shared/key_event.rs
@@ -1,0 +1,67 @@
+use crossterm::event::{KeyCode, KeyEvent as CKeyEvent};
+
+use crate::{
+    config::keys::{CommonAction, GlobalAction, QueueActions},
+    context::AppContext,
+};
+
+#[cfg(debug_assertions)]
+use crate::config::keys::LogsActions;
+
+#[derive(Debug, Clone)]
+pub struct KeyEvent {
+    inner: CKeyEvent,
+    already_handled: bool,
+}
+
+impl From<CKeyEvent> for KeyEvent {
+    fn from(value: CKeyEvent) -> Self {
+        Self {
+            inner: value,
+            already_handled: false,
+        }
+    }
+}
+
+impl KeyEvent {
+    pub fn code(&self) -> KeyCode {
+        self.inner.code
+    }
+
+    pub fn stop_propagation(&mut self) {
+        self.already_handled = true;
+    }
+
+    pub fn as_common_action(&self, context: &AppContext) -> Option<CommonAction> {
+        if self.already_handled {
+            None
+        } else {
+            context.config.keybinds.navigation.get(&self.inner.into()).copied()
+        }
+    }
+
+    pub fn as_global_action(&self, context: &AppContext) -> Option<GlobalAction> {
+        if self.already_handled {
+            None
+        } else {
+            context.config.keybinds.global.get(&self.inner.into()).copied()
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    pub fn as_logs_action(&self, context: &AppContext) -> Option<LogsActions> {
+        if self.already_handled {
+            None
+        } else {
+            context.config.keybinds.logs.get(&self.inner.into()).copied()
+        }
+    }
+
+    pub fn as_queue_action(&self, context: &AppContext) -> Option<QueueActions> {
+        if self.already_handled {
+            None
+        } else {
+            context.config.keybinds.queue.get(&self.inner.into()).copied()
+        }
+    }
+}

--- a/src/shared/macros.rs
+++ b/src/shared/macros.rs
@@ -53,33 +53,28 @@ macro_rules! status_warn {
         }};
     }
 
-macro_rules! status_trace {
-        ($($t:tt)*) => {{
-            log::trace!($($t)*);
-            log::trace!(target: "{status_bar}", $($t)*);
-        }};
-    }
+macro_rules! modal {
+    ( $i:ident, $e:expr ) => {{
+        $i.app_event_sender
+            .send(crate::AppEvent::UiAppEvent(crate::ui::UiAppEvent::Modal(
+                crate::ui::ModalWrapper(Box::new($e)),
+            )))?;
+    }};
+}
 
-macro_rules! status_debug {
-        ($($t:tt)*) => {{
-            log::debug!($($t)*);
-            log::debug!(target: "{status_bar}", $($t)*);
-        }};
-    }
+macro_rules! pop_modal {
+    ( $i:ident ) => {{
+        $i.app_event_sender
+            .send(crate::AppEvent::UiAppEvent(crate::ui::UiAppEvent::PopModal))?;
+    }};
+}
 
-#[allow(unused_imports)]
-pub(crate) use status_debug;
-#[allow(unused_imports)]
+pub(crate) use modal;
+pub(crate) use pop_modal;
+
 pub(crate) use status_error;
-#[allow(unused_imports)]
 pub(crate) use status_info;
-#[allow(unused_imports)]
-pub(crate) use status_trace;
-#[allow(unused_imports)]
 pub(crate) use status_warn;
-#[allow(unused_imports)]
 pub(crate) use try_cont;
-#[allow(unused_imports)]
 pub(crate) use try_ret;
-#[allow(unused_imports)]
 pub(crate) use try_skip;

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -4,6 +4,7 @@ pub mod ext;
 pub mod geometry;
 pub mod id;
 pub mod image;
+pub mod key_event;
 pub mod logging;
 pub mod macros;
 pub mod mouse_event;

--- a/src/tests/fixtures/mod.rs
+++ b/src/tests/fixtures/mod.rs
@@ -1,5 +1,3 @@
-use std::{collections::HashSet, sync::mpsc::channel};
-
 use ratatui::{backend::TestBackend, Terminal};
 use rstest::fixture;
 
@@ -14,14 +12,7 @@ pub fn status() -> Status {
 
 #[fixture]
 pub fn app_context() -> AppContext {
-    AppContext {
-        status: Status::default(),
-        config: Box::leak(Box::default()),
-        queue: Vec::default(),
-        app_event_sender: channel().0,
-        work_sender: channel().0,
-        supported_commands: HashSet::new(),
-    }
+    AppContext::default()
 }
 
 #[fixture]

--- a/src/tests/fixtures/mod.rs
+++ b/src/tests/fixtures/mod.rs
@@ -1,7 +1,13 @@
+use std::{cell::Cell, collections::HashSet, sync::mpsc::channel};
+
 use ratatui::{backend::TestBackend, Terminal};
 use rstest::fixture;
 
-use crate::{config::Config, context::AppContext, mpd::commands::Status};
+use crate::{
+    config::{Config, ConfigFile, Leak},
+    context::AppContext,
+    mpd::commands::Status,
+};
 
 pub mod mpd_client;
 
@@ -12,7 +18,23 @@ pub fn status() -> Status {
 
 #[fixture]
 pub fn app_context() -> AppContext {
-    AppContext::default()
+    let chan1 = channel();
+    let chan2 = channel();
+    chan1.1.leak();
+    chan2.1.leak();
+    let config = ConfigFile::default()
+        .into_config(None, None, None, true)
+        .expect("Test default config to convert correctly")
+        .leak();
+    AppContext {
+        status: Status::default(),
+        config,
+        queue: Vec::default(),
+        app_event_sender: chan1.0,
+        work_sender: chan2.0,
+        supported_commands: HashSet::new(),
+        needs_render: Cell::new(false),
+    }
 }
 
 #[fixture]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashMap, io::Stdout, ops::AddAssign, time::Duration};
 
+#[cfg(debug_assertions)]
+use crate::config::tabs::PaneType;
 use anyhow::{anyhow, Context, Result};
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture, KeyCode},
@@ -10,10 +12,13 @@ use enum_map::{enum_map, Enum, EnumMap};
 use itertools::Itertools;
 use modals::{keybinds::KeybindsModal, outputs::OutputsModal, song_info::SongInfoModal};
 use panes::{PaneContainer, Panes};
+#[cfg(debug_assertions)]
+use ratatui::style::Stylize;
+
 use ratatui::{
     layout::Rect,
     prelude::{Backend, Constraint, CrosstermBackend, Layout},
-    style::{Color, Style, Stylize},
+    style::{Color, Style},
     symbols::border,
     text::Text,
     widgets::{Block, Borders, Paragraph},
@@ -27,7 +32,7 @@ use crate::{
     config::{
         cli::Args,
         keys::{CommonAction, GlobalAction},
-        tabs::{PaneType, TabName},
+        tabs::TabName,
         Config,
     },
     mpd::{

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -13,7 +13,7 @@ use panes::{PaneContainer, Panes};
 use ratatui::{
     layout::Rect,
     prelude::{Backend, Constraint, CrosstermBackend, Layout},
-    style::{Color, Style},
+    style::{Color, Style, Stylize},
     symbols::border,
     text::Text,
     widgets::{Block, Borders, Paragraph},
@@ -212,10 +212,18 @@ impl<'ui> Ui<'ui> {
         }
 
         #[cfg(debug_assertions)]
-        frame.render_widget(
-            Paragraph::new(format!("{} frames", self.rendered_frames_count)),
-            self.areas[Areas::Bar],
-        );
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            let text = format!("{} frames", self.rendered_frames_count);
+            let mut area = self.areas[Areas::Bar];
+            area.width = text.chars().count() as u16;
+            frame.render_widget(
+                Text::from(text)
+                    .fg(context.config.theme.text_color.unwrap_or_default())
+                    .bg(context.config.theme.background_color.unwrap_or_default()),
+                area,
+            );
+        }
 
         let content_area = self.areas[Areas::Content];
 
@@ -313,8 +321,8 @@ impl<'ui> Ui<'ui> {
         context: &mut AppContext,
         client: &mut Client<'_>,
     ) -> Result<KeyHandleResult> {
-        let action = key.as_common_action(context);
         if let Some(ref mut command) = self.command {
+            let action = key.as_common_action(context);
             if let Some(CommonAction::Close) = action {
                 self.command = None;
                 context.render()?;

--- a/src/ui/modals/add_to_playlist.rs
+++ b/src/ui/modals/add_to_playlist.rs
@@ -10,6 +10,7 @@ use crate::{
     config::keys::CommonAction,
     context::AppContext,
     mpd::mpd_client::MpdClient,
+    shared::macros::pop_modal,
     ui::{
         dirstack::DirState,
         widgets::button::{Button, ButtonGroup, ButtonGroupState},
@@ -155,7 +156,9 @@ impl Modal for AddToPlaylistModal {
                             }
                         }
                     }
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Up => {
                     match self.focused {
@@ -176,28 +179,35 @@ impl Modal for AddToPlaylistModal {
                             }
                         }
                     }
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Confirm => match self.focused {
                     FocusedComponent::Playlists => {
                         self.focused = FocusedComponent::Buttons;
                         self.button_group.first();
-                        Ok(KeyHandleResultInternal::RenderRequested)
+
+                        context.render()?;
+                        Ok(KeyHandleResultInternal::SkipRender)
                     }
                     FocusedComponent::Buttons if self.button_group.selected == 0 => {
                         if let Some(selected) = self.scrolling_state.get_selected() {
                             client.add_to_playlist(&self.playlists[selected], &self.uri, None)?;
                         }
-                        Ok(KeyHandleResultInternal::Modal(None))
+                        pop_modal!(context);
+                        Ok(KeyHandleResultInternal::SkipRender)
                     }
                     FocusedComponent::Buttons => {
                         self.button_group = ButtonGroupState::default();
-                        Ok(KeyHandleResultInternal::Modal(None))
+                        pop_modal!(context);
+                        Ok(KeyHandleResultInternal::SkipRender)
                     }
                 },
                 CommonAction::Close => {
                     self.button_group = ButtonGroupState::default();
-                    Ok(KeyHandleResultInternal::Modal(None))
+                    pop_modal!(context);
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::MoveDown => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::MoveUp => Ok(KeyHandleResultInternal::SkipRender),

--- a/src/ui/modals/add_to_playlist.rs
+++ b/src/ui/modals/add_to_playlist.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use crossterm::event::KeyEvent;
 use itertools::Itertools;
 use ratatui::{
     prelude::{Constraint, Layout},
@@ -13,7 +12,7 @@ use crate::{
     config::keys::CommonAction,
     context::AppContext,
     mpd::{client::Client, mpd_client::MpdClient},
-    shared::macros::pop_modal,
+    shared::{key_event::KeyEvent, macros::pop_modal},
     ui::{
         dirstack::DirState,
         widgets::button::{Button, ButtonGroup, ButtonGroupState},
@@ -128,8 +127,8 @@ impl Modal for AddToPlaylistModal {
         Ok(())
     }
 
-    fn handle_key(&mut self, key: KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
-        if let Some(action) = context.config.keybinds.navigation.get(&key.into()) {
+    fn handle_key(&mut self, key: &mut KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
+        if let Some(action) = key.as_common_action(context) {
             match action {
                 CommonAction::Down => {
                     match self.focused {

--- a/src/ui/modals/confirm_modal.rs
+++ b/src/ui/modals/confirm_modal.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use crossterm::event::KeyEvent;
 use ratatui::{
     prelude::{Constraint, Layout, Margin},
     style::Style,
@@ -12,7 +11,7 @@ use crate::{
     config::keys::CommonAction,
     context::AppContext,
     mpd::{client::Client, mpd_client::MpdClient},
-    shared::macros::pop_modal,
+    shared::{key_event::KeyEvent, macros::pop_modal},
     ui::widgets::button::{Button, ButtonGroup, ButtonGroupState},
 };
 
@@ -92,8 +91,8 @@ impl Modal for ConfirmModal {
         Ok(())
     }
 
-    fn handle_key(&mut self, key: KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
-        if let Some(action) = context.config.keybinds.navigation.get(&key.into()) {
+    fn handle_key(&mut self, key: &mut KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
+        if let Some(action) = key.as_common_action(context) {
             match action {
                 CommonAction::Down => {
                     self.button_group.next();

--- a/src/ui/modals/confirm_modal.rs
+++ b/src/ui/modals/confirm_modal.rs
@@ -16,7 +16,7 @@ use crate::{
     ui::widgets::button::{Button, ButtonGroup, ButtonGroupState},
 };
 
-use super::{KeyHandleResultInternal, RectExt};
+use super::RectExt;
 
 use super::Modal;
 
@@ -45,7 +45,7 @@ impl ConfirmModal {
 }
 
 impl Modal for ConfirmModal {
-    fn render(&mut self, frame: &mut Frame, app: &mut crate::context::AppContext) -> Result<()> {
+    fn render(&mut self, frame: &mut Frame, app: &mut AppContext) -> Result<()> {
         let block = Block::default()
             .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
             .border_set(border::ROUNDED)
@@ -92,30 +92,22 @@ impl Modal for ConfirmModal {
         Ok(())
     }
 
-    fn handle_key(
-        &mut self,
-        key: KeyEvent,
-        client: &mut Client<'_>,
-        context: &mut AppContext,
-    ) -> Result<KeyHandleResultInternal> {
+    fn handle_key(&mut self, key: KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
         if let Some(action) = context.config.keybinds.navigation.get(&key.into()) {
             match action {
                 CommonAction::Down => {
                     self.button_group.next();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Up => {
                     self.button_group.prev();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Close => {
                     self.button_group = ButtonGroupState::default();
                     pop_modal!(context);
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Confirm => {
                     if self.button_group.selected == 0 {
@@ -123,32 +115,11 @@ impl Modal for ConfirmModal {
                     }
                     self.button_group = ButtonGroupState::default();
                     pop_modal!(context);
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
-                CommonAction::MoveDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::MoveUp => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::DownHalf => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::UpHalf => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Right => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Left => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Top => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Bottom => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::EnterSearch => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::NextResult => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PreviousResult => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Select => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Add => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::AddAll => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Delete => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Rename => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::FocusInput => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneUp => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneRight => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneLeft => Ok(KeyHandleResultInternal::SkipRender),
+                _ => {}
             }
-        } else {
-            Ok(KeyHandleResultInternal::SkipRender)
-        }
+        };
+
+        Ok(())
     }
 }

--- a/src/ui/modals/confirm_modal.rs
+++ b/src/ui/modals/confirm_modal.rs
@@ -12,6 +12,7 @@ use crate::{
     config::keys::CommonAction,
     context::AppContext,
     mpd::{client::Client, mpd_client::MpdClient},
+    shared::macros::pop_modal,
     ui::widgets::button::{Button, ButtonGroup, ButtonGroupState},
 };
 
@@ -95,28 +96,34 @@ impl Modal for ConfirmModal {
         &mut self,
         key: KeyEvent,
         client: &mut Client<'_>,
-        app: &mut AppContext,
+        context: &mut AppContext,
     ) -> Result<KeyHandleResultInternal> {
-        if let Some(action) = app.config.keybinds.navigation.get(&key.into()) {
+        if let Some(action) = context.config.keybinds.navigation.get(&key.into()) {
             match action {
                 CommonAction::Down => {
                     self.button_group.next();
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Up => {
                     self.button_group.prev();
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Close => {
                     self.button_group = ButtonGroupState::default();
-                    Ok(KeyHandleResultInternal::Modal(None))
+                    pop_modal!(context);
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Confirm => {
                     if self.button_group.selected == 0 {
                         client.clear()?;
                     }
                     self.button_group = ButtonGroupState::default();
-                    Ok(KeyHandleResultInternal::Modal(None))
+                    pop_modal!(context);
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::MoveDown => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::MoveUp => Ok(KeyHandleResultInternal::SkipRender),

--- a/src/ui/modals/confirm_queue_clear.rs
+++ b/src/ui/modals/confirm_queue_clear.rs
@@ -16,7 +16,7 @@ use crate::{
     ui::widgets::button::{Button, ButtonGroup, ButtonGroupState},
 };
 
-use super::{KeyHandleResultInternal, RectExt};
+use super::RectExt;
 
 use super::Modal;
 
@@ -32,7 +32,7 @@ pub struct ConfirmQueueClearModal {
 }
 
 impl Modal for ConfirmQueueClearModal {
-    fn render(&mut self, frame: &mut Frame, app: &mut crate::context::AppContext) -> Result<()> {
+    fn render(&mut self, frame: &mut Frame, app: &mut AppContext) -> Result<()> {
         let block = Block::default()
             .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
             .border_set(border::ROUNDED)
@@ -80,30 +80,22 @@ impl Modal for ConfirmQueueClearModal {
         Ok(())
     }
 
-    fn handle_key(
-        &mut self,
-        key: KeyEvent,
-        client: &mut Client<'_>,
-        context: &mut AppContext,
-    ) -> Result<KeyHandleResultInternal> {
+    fn handle_key(&mut self, key: KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
         if let Some(action) = context.config.keybinds.navigation.get(&key.into()) {
             match action {
                 CommonAction::Down => {
                     self.button_group.next();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Up => {
                     self.button_group.prev();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Close => {
                     self.button_group = ButtonGroupState::default();
                     pop_modal!(context);
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Confirm => {
                     if self.button_group.selected == 0 {
@@ -111,32 +103,11 @@ impl Modal for ConfirmQueueClearModal {
                     }
                     self.button_group = ButtonGroupState::default();
                     pop_modal!(context);
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
-                CommonAction::MoveDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::MoveUp => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::DownHalf => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::UpHalf => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Right => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Left => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Top => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Bottom => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::EnterSearch => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::NextResult => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PreviousResult => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Select => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Add => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::AddAll => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Delete => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Rename => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::FocusInput => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneUp => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneRight => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneLeft => Ok(KeyHandleResultInternal::SkipRender),
+                _ => {}
             }
-        } else {
-            Ok(KeyHandleResultInternal::SkipRender)
-        }
+        };
+
+        Ok(())
     }
 }

--- a/src/ui/modals/confirm_queue_clear.rs
+++ b/src/ui/modals/confirm_queue_clear.rs
@@ -12,6 +12,7 @@ use crate::{
     config::keys::CommonAction,
     context::AppContext,
     mpd::{client::Client, mpd_client::MpdClient},
+    shared::macros::pop_modal,
     ui::widgets::button::{Button, ButtonGroup, ButtonGroupState},
 };
 
@@ -83,28 +84,34 @@ impl Modal for ConfirmQueueClearModal {
         &mut self,
         key: KeyEvent,
         client: &mut Client<'_>,
-        app: &mut AppContext,
+        context: &mut AppContext,
     ) -> Result<KeyHandleResultInternal> {
-        if let Some(action) = app.config.keybinds.navigation.get(&key.into()) {
+        if let Some(action) = context.config.keybinds.navigation.get(&key.into()) {
             match action {
                 CommonAction::Down => {
                     self.button_group.next();
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Up => {
                     self.button_group.prev();
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Close => {
                     self.button_group = ButtonGroupState::default();
-                    Ok(KeyHandleResultInternal::Modal(None))
+                    pop_modal!(context);
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Confirm => {
                     if self.button_group.selected == 0 {
                         client.clear()?;
                     }
                     self.button_group = ButtonGroupState::default();
-                    Ok(KeyHandleResultInternal::Modal(None))
+                    pop_modal!(context);
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::MoveDown => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::MoveUp => Ok(KeyHandleResultInternal::SkipRender),

--- a/src/ui/modals/confirm_queue_clear.rs
+++ b/src/ui/modals/confirm_queue_clear.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use crossterm::event::KeyEvent;
 use ratatui::{
     prelude::{Constraint, Layout, Margin},
     style::Style,
@@ -12,7 +11,7 @@ use crate::{
     config::keys::CommonAction,
     context::AppContext,
     mpd::{client::Client, mpd_client::MpdClient},
-    shared::macros::pop_modal,
+    shared::{key_event::KeyEvent, macros::pop_modal},
     ui::widgets::button::{Button, ButtonGroup, ButtonGroupState},
 };
 
@@ -80,8 +79,8 @@ impl Modal for ConfirmQueueClearModal {
         Ok(())
     }
 
-    fn handle_key(&mut self, key: KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
-        if let Some(action) = context.config.keybinds.navigation.get(&key.into()) {
+    fn handle_key(&mut self, key: &mut KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
+        if let Some(action) = key.as_common_action(context) {
             match action {
                 CommonAction::Down => {
                     self.button_group.next();

--- a/src/ui/modals/keybinds.rs
+++ b/src/ui/modals/keybinds.rs
@@ -1,11 +1,14 @@
+use anyhow::Result;
 use std::{borrow::Cow, collections::HashMap, fmt::Display};
 
 use crate::{
     config::keys::{CommonAction, Key, ToDescription},
     context::AppContext,
+    mpd::client::Client,
     shared::macros::pop_modal,
 };
 use anyhow::bail;
+use crossterm::event::KeyEvent;
 use ratatui::{
     layout::{Constraint, Layout, Margin},
     style::Style,
@@ -15,7 +18,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::ui::{dirstack::DirState, KeyHandleResultInternal};
+use crate::ui::dirstack::DirState;
 
 use super::{Modal, RectExt};
 
@@ -54,7 +57,7 @@ fn add_binds<'a, V: Display + ToDescription>(
 }
 
 impl KeybindsModal<'_> {
-    pub fn new(app: &mut crate::context::AppContext) -> Self {
+    pub fn new(app: &mut AppContext) -> Self {
         let keybinds = &app.config.keybinds;
         let header_style = app.config.theme.current_item_style;
 
@@ -77,7 +80,7 @@ impl KeybindsModal<'_> {
 }
 
 impl Modal for KeybindsModal<'_> {
-    fn render(&mut self, frame: &mut Frame, app: &mut crate::context::AppContext) -> anyhow::Result<()> {
+    fn render(&mut self, frame: &mut Frame, app: &mut AppContext) -> Result<()> {
         let popup_area = frame.area().centered(90, 90);
         frame.render_widget(Clear, popup_area);
         if let Some(bg_color) = app.config.theme.modal_background_color {
@@ -154,77 +157,48 @@ impl Modal for KeybindsModal<'_> {
         return Ok(());
     }
 
-    fn handle_key(
-        &mut self,
-        key: crossterm::event::KeyEvent,
-        _client: &mut crate::mpd::client::Client<'_>,
-        context: &mut AppContext,
-    ) -> anyhow::Result<KeyHandleResultInternal> {
+    fn handle_key(&mut self, key: KeyEvent, _client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
         if let Some(action) = context.config.keybinds.navigation.get(&key.into()) {
             match action {
                 CommonAction::DownHalf => {
                     self.scrolling_state.next_half_viewport(context.config.scrolloff);
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::UpHalf => {
                     self.scrolling_state.prev_half_viewport(context.config.scrolloff);
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Up => {
                     self.scrolling_state
                         .prev(context.config.scrolloff, context.config.wrap_navigation);
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Down => {
                     self.scrolling_state
                         .next(context.config.scrolloff, context.config.wrap_navigation);
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Bottom => {
                     self.scrolling_state.last();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Top => {
                     self.scrolling_state.first();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
-                CommonAction::Right => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Left => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::EnterSearch => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::NextResult => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PreviousResult => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Add => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::AddAll => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Select => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Delete => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Rename => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::MoveUp => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::MoveDown => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::Close => {
                     pop_modal!(context);
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
-                CommonAction::Confirm => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::FocusInput => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneUp => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneRight => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneLeft => Ok(KeyHandleResultInternal::SkipRender),
+                _ => {}
             }
-        } else {
-            Ok(KeyHandleResultInternal::KeyNotHandled)
-        }
+        };
+
+        Ok(())
     }
 }

--- a/src/ui/modals/keybinds.rs
+++ b/src/ui/modals/keybinds.rs
@@ -3,6 +3,7 @@ use std::{borrow::Cow, collections::HashMap, fmt::Display};
 use crate::{
     config::keys::{CommonAction, Key, ToDescription},
     context::AppContext,
+    shared::macros::pop_modal,
 };
 use anyhow::bail;
 use ratatui::{
@@ -163,29 +164,41 @@ impl Modal for KeybindsModal<'_> {
             match action {
                 CommonAction::DownHalf => {
                     self.scrolling_state.next_half_viewport(context.config.scrolloff);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::UpHalf => {
                     self.scrolling_state.prev_half_viewport(context.config.scrolloff);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Up => {
                     self.scrolling_state
                         .prev(context.config.scrolloff, context.config.wrap_navigation);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Down => {
                     self.scrolling_state
                         .next(context.config.scrolloff, context.config.wrap_navigation);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Bottom => {
                     self.scrolling_state.last();
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Top => {
                     self.scrolling_state.first();
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Right => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::Left => Ok(KeyHandleResultInternal::SkipRender),
@@ -199,7 +212,10 @@ impl Modal for KeybindsModal<'_> {
                 CommonAction::Rename => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::MoveUp => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::MoveDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Close => Ok(KeyHandleResultInternal::Modal(None)),
+                CommonAction::Close => {
+                    pop_modal!(context);
+                    Ok(KeyHandleResultInternal::SkipRender)
+                }
                 CommonAction::Confirm => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::FocusInput => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::PaneDown => Ok(KeyHandleResultInternal::SkipRender),

--- a/src/ui/modals/keybinds.rs
+++ b/src/ui/modals/keybinds.rs
@@ -5,10 +5,9 @@ use crate::{
     config::keys::{CommonAction, Key, ToDescription},
     context::AppContext,
     mpd::client::Client,
-    shared::macros::pop_modal,
+    shared::{key_event::KeyEvent, macros::pop_modal},
 };
 use anyhow::bail;
-use crossterm::event::KeyEvent;
 use ratatui::{
     layout::{Constraint, Layout, Margin},
     style::Style,
@@ -157,8 +156,8 @@ impl Modal for KeybindsModal<'_> {
         return Ok(());
     }
 
-    fn handle_key(&mut self, key: KeyEvent, _client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
-        if let Some(action) = context.config.keybinds.navigation.get(&key.into()) {
+    fn handle_key(&mut self, key: &mut KeyEvent, _client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
+        if let Some(action) = key.as_common_action(context) {
             match action {
                 CommonAction::DownHalf => {
                     self.scrolling_state.next_half_viewport(context.config.scrolloff);

--- a/src/ui/modals/mod.rs
+++ b/src/ui/modals/mod.rs
@@ -1,11 +1,10 @@
 use anyhow::Result;
-use crossterm::event::KeyEvent;
 use ratatui::{
     prelude::{Constraint, Layout, Rect},
     Frame,
 };
 
-use crate::{context::AppContext, mpd::client::Client};
+use crate::{context::AppContext, mpd::client::Client, shared::key_event::KeyEvent};
 
 pub mod add_to_playlist;
 pub mod confirm_modal;
@@ -19,7 +18,7 @@ pub mod song_info;
 pub(super) trait Modal: std::fmt::Debug {
     fn render(&mut self, frame: &mut Frame, _app: &mut crate::context::AppContext) -> Result<()>;
 
-    fn handle_key(&mut self, key: KeyEvent, _client: &mut Client<'_>, _app: &mut AppContext) -> Result<()>;
+    fn handle_key(&mut self, key: &mut KeyEvent, _client: &mut Client<'_>, _app: &mut AppContext) -> Result<()>;
 }
 
 #[allow(dead_code)]

--- a/src/ui/modals/mod.rs
+++ b/src/ui/modals/mod.rs
@@ -7,8 +7,6 @@ use ratatui::{
 
 use crate::{context::AppContext, mpd::client::Client};
 
-use super::KeyHandleResultInternal;
-
 pub mod add_to_playlist;
 pub mod confirm_modal;
 pub mod confirm_queue_clear;
@@ -21,12 +19,7 @@ pub mod song_info;
 pub(super) trait Modal: std::fmt::Debug {
     fn render(&mut self, frame: &mut Frame, _app: &mut crate::context::AppContext) -> Result<()>;
 
-    fn handle_key(
-        &mut self,
-        key: KeyEvent,
-        _client: &mut Client<'_>,
-        _app: &mut AppContext,
-    ) -> Result<KeyHandleResultInternal>;
+    fn handle_key(&mut self, key: KeyEvent, _client: &mut Client<'_>, _app: &mut AppContext) -> Result<()>;
 }
 
 #[allow(dead_code)]

--- a/src/ui/modals/outputs.rs
+++ b/src/ui/modals/outputs.rs
@@ -9,6 +9,7 @@ use crate::{
     config::keys::CommonAction,
     context::AppContext,
     mpd::{commands::Output, mpd_client::MpdClient},
+    shared::macros::pop_modal,
     ui::{dirstack::DirState, KeyHandleResultInternal},
 };
 
@@ -107,29 +108,41 @@ impl Modal for OutputsModal {
             match action {
                 CommonAction::DownHalf => {
                     self.scrolling_state.next_half_viewport(context.config.scrolloff);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::UpHalf => {
                     self.scrolling_state.prev_half_viewport(context.config.scrolloff);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Up => {
                     self.scrolling_state
                         .prev(context.config.scrolloff, context.config.wrap_navigation);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Down => {
                     self.scrolling_state
                         .next(context.config.scrolloff, context.config.wrap_navigation);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Bottom => {
                     self.scrolling_state.last();
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Top => {
                     self.scrolling_state.first();
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Confirm => {
                     let Some(idx) = self.scrolling_state.get_selected() else {
@@ -159,7 +172,10 @@ impl Modal for OutputsModal {
                 CommonAction::Rename => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::MoveUp => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::MoveDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Close => Ok(KeyHandleResultInternal::Modal(None)),
+                CommonAction::Close => {
+                    pop_modal!(context);
+                    Ok(KeyHandleResultInternal::SkipRender)
+                }
                 CommonAction::FocusInput => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::PaneDown => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::PaneUp => Ok(KeyHandleResultInternal::SkipRender),

--- a/src/ui/modals/outputs.rs
+++ b/src/ui/modals/outputs.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use crossterm::event::KeyEvent;
 use ratatui::{
     layout::{Constraint, Margin},
     style::Style,
@@ -11,7 +10,7 @@ use crate::{
     config::keys::CommonAction,
     context::AppContext,
     mpd::{client::Client, commands::Output, mpd_client::MpdClient},
-    shared::macros::pop_modal,
+    shared::{key_event::KeyEvent, macros::pop_modal},
     ui::dirstack::DirState,
 };
 
@@ -100,8 +99,8 @@ impl Modal for OutputsModal {
         Ok(())
     }
 
-    fn handle_key(&mut self, key: KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
-        if let Some(action) = context.config.keybinds.navigation.get(&key.into()) {
+    fn handle_key(&mut self, key: &mut KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
+        if let Some(action) = key.as_common_action(context) {
             match action {
                 CommonAction::DownHalf => {
                     self.scrolling_state.next_half_viewport(context.config.scrolloff);

--- a/src/ui/modals/rename_playlist.rs
+++ b/src/ui/modals/rename_playlist.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::KeyCode;
 use ratatui::{
     prelude::{Constraint, Layout},
     style::{Style, Stylize},
@@ -12,7 +12,10 @@ use crate::{
     config::keys::CommonAction,
     context::AppContext,
     mpd::{client::Client, mpd_client::MpdClient},
-    shared::macros::{pop_modal, status_info},
+    shared::{
+        key_event::KeyEvent,
+        macros::{pop_modal, status_info},
+    },
     ui::widgets::{
         button::{Button, ButtonGroup, ButtonGroupState},
         input::Input,
@@ -104,8 +107,8 @@ impl Modal for RenamePlaylistModal {
         Ok(())
     }
 
-    fn handle_key(&mut self, key: KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
-        let action = context.config.keybinds.navigation.get(&key.into());
+    fn handle_key(&mut self, key: &mut KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
+        let action = key.as_common_action(context);
         if self.input_focused {
             if let Some(CommonAction::Close) = action {
                 self.input_focused = false;
@@ -122,7 +125,7 @@ impl Modal for RenamePlaylistModal {
                 return Ok(());
             }
 
-            match key.code {
+            match key.code() {
                 KeyCode::Char(c) => {
                     self.new_name.push(c);
 

--- a/src/ui/modals/rename_playlist.rs
+++ b/src/ui/modals/rename_playlist.rs
@@ -19,7 +19,7 @@ use crate::{
     },
 };
 
-use super::{KeyHandleResultInternal, RectExt};
+use super::RectExt;
 
 use super::Modal;
 
@@ -54,7 +54,7 @@ impl RenamePlaylistModal {
 }
 
 impl Modal for RenamePlaylistModal {
-    fn render(&mut self, frame: &mut Frame, app: &mut crate::context::AppContext) -> Result<()> {
+    fn render(&mut self, frame: &mut Frame, app: &mut AppContext) -> Result<()> {
         let block = Block::default()
             .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
             .border_set(border::ROUNDED)
@@ -104,19 +104,14 @@ impl Modal for RenamePlaylistModal {
         Ok(())
     }
 
-    fn handle_key(
-        &mut self,
-        key: KeyEvent,
-        client: &mut Client<'_>,
-        context: &mut AppContext,
-    ) -> Result<KeyHandleResultInternal> {
+    fn handle_key(&mut self, key: KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
         let action = context.config.keybinds.navigation.get(&key.into());
         if self.input_focused {
             if let Some(CommonAction::Close) = action {
                 self.input_focused = false;
 
                 context.render()?;
-                return Ok(KeyHandleResultInternal::SkipRender);
+                return Ok(());
             } else if let Some(CommonAction::Confirm) = action {
                 if self.button_group.selected == 0 && self.playlist_name != self.new_name {
                     client.rename_playlist(&self.playlist_name, &self.new_name)?;
@@ -124,7 +119,7 @@ impl Modal for RenamePlaylistModal {
                 }
                 self.on_hide();
                 pop_modal!(context);
-                return Ok(KeyHandleResultInternal::SkipRender);
+                return Ok(());
             }
 
             match key.code {
@@ -132,15 +127,13 @@ impl Modal for RenamePlaylistModal {
                     self.new_name.push(c);
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 KeyCode::Backspace => {
                     self.new_name.pop();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
-                _ => Ok(KeyHandleResultInternal::SkipRender),
+                _ => {}
             }
         } else if let Some(action) = action {
             match action {
@@ -148,18 +141,15 @@ impl Modal for RenamePlaylistModal {
                     self.button_group.next();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Up => {
                     self.button_group.next();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Close => {
                     self.on_hide();
                     pop_modal!(context);
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Confirm => {
                     if self.button_group.selected == 0 && self.playlist_name != self.new_name {
@@ -168,37 +158,16 @@ impl Modal for RenamePlaylistModal {
                     }
                     self.on_hide();
                     pop_modal!(context);
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::FocusInput => {
                     self.input_focused = true;
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
-                CommonAction::MoveDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::MoveUp => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::DownHalf => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::UpHalf => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Right => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Left => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Top => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Bottom => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::EnterSearch => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::NextResult => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PreviousResult => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Select => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Add => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::AddAll => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Delete => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Rename => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneUp => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneRight => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneLeft => Ok(KeyHandleResultInternal::SkipRender),
+                _ => {}
             }
-        } else {
-            Ok(KeyHandleResultInternal::SkipRender)
-        }
+        };
+
+        Ok(())
     }
 }

--- a/src/ui/modals/save_queue.rs
+++ b/src/ui/modals/save_queue.rs
@@ -19,7 +19,7 @@ use crate::{
     },
 };
 
-use super::{KeyHandleResultInternal, RectExt};
+use super::RectExt;
 
 use super::Modal;
 
@@ -55,7 +55,7 @@ impl SaveQueueModal {
 }
 
 impl Modal for SaveQueueModal {
-    fn render(&mut self, frame: &mut Frame, app: &mut crate::context::AppContext) -> Result<()> {
+    fn render(&mut self, frame: &mut Frame, app: &mut AppContext) -> Result<()> {
         let popup_area = frame.area().centered_exact(50, 7);
         let [body_area, buttons_area] =
             *Layout::vertical([Constraint::Length(4), Constraint::Max(3)]).split(popup_area)
@@ -106,19 +106,14 @@ impl Modal for SaveQueueModal {
         Ok(())
     }
 
-    fn handle_key(
-        &mut self,
-        key: KeyEvent,
-        client: &mut Client<'_>,
-        context: &mut AppContext,
-    ) -> Result<KeyHandleResultInternal> {
+    fn handle_key(&mut self, key: KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
         let action = context.config.keybinds.navigation.get(&key.into());
         if self.input_focused {
             if let Some(CommonAction::Close) = action {
                 self.input_focused = false;
 
                 context.render()?;
-                return Ok(KeyHandleResultInternal::SkipRender);
+                return Ok(());
             } else if let Some(CommonAction::Confirm) = action {
                 if self.button_group.selected == 0 {
                     match client.save_queue_as_playlist(&self.name, None) {
@@ -132,7 +127,7 @@ impl Modal for SaveQueueModal {
                 }
                 self.on_hide();
                 pop_modal!(context);
-                return Ok(KeyHandleResultInternal::SkipRender);
+                return Ok(());
             }
 
             match key.code {
@@ -140,15 +135,13 @@ impl Modal for SaveQueueModal {
                     self.name.push(c);
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 KeyCode::Backspace => {
                     self.name.pop();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
-                _ => Ok(KeyHandleResultInternal::SkipRender),
+                _ => {}
             }
         } else if let Some(action) = action {
             match action {
@@ -156,18 +149,15 @@ impl Modal for SaveQueueModal {
                     self.button_group.next();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Up => {
                     self.button_group.next();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Close => {
                     self.on_hide();
                     pop_modal!(context);
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Confirm => {
                     if self.button_group.selected == 0 {
@@ -175,35 +165,14 @@ impl Modal for SaveQueueModal {
                         status_info!("Playlist '{}' saved", self.name);
                     }
                     pop_modal!(context);
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::FocusInput => {
                     self.input_focused = true;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
-                CommonAction::MoveDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::MoveUp => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::DownHalf => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::UpHalf => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Right => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Left => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Top => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Bottom => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::EnterSearch => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::NextResult => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PreviousResult => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Select => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Add => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::AddAll => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Delete => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Rename => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneUp => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneRight => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneLeft => Ok(KeyHandleResultInternal::SkipRender),
+                _ => {}
             }
-        } else {
-            Ok(KeyHandleResultInternal::SkipRender)
-        }
+        };
+
+        Ok(())
     }
 }

--- a/src/ui/modals/save_queue.rs
+++ b/src/ui/modals/save_queue.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::KeyCode;
 use ratatui::{
     prelude::{Constraint, Layout},
     style::{Style, Stylize},
@@ -12,7 +12,10 @@ use crate::{
     config::keys::CommonAction,
     context::AppContext,
     mpd::{client::Client, mpd_client::MpdClient},
-    shared::macros::{pop_modal, status_error, status_info},
+    shared::{
+        key_event::KeyEvent,
+        macros::{pop_modal, status_error, status_info},
+    },
     ui::widgets::{
         button::{Button, ButtonGroup, ButtonGroupState},
         input::Input,
@@ -106,8 +109,8 @@ impl Modal for SaveQueueModal {
         Ok(())
     }
 
-    fn handle_key(&mut self, key: KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
-        let action = context.config.keybinds.navigation.get(&key.into());
+    fn handle_key(&mut self, key: &mut KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
+        let action = key.as_common_action(context);
         if self.input_focused {
             if let Some(CommonAction::Close) = action {
                 self.input_focused = false;
@@ -130,7 +133,7 @@ impl Modal for SaveQueueModal {
                 return Ok(());
             }
 
-            match key.code {
+            match key.code() {
                 KeyCode::Char(c) => {
                     self.name.push(c);
 

--- a/src/ui/modals/song_info.rs
+++ b/src/ui/modals/song_info.rs
@@ -2,10 +2,9 @@ use crate::{
     config::keys::CommonAction,
     context::AppContext,
     mpd::{client::Client, commands::Song},
-    shared::macros::pop_modal,
+    shared::{key_event::KeyEvent, macros::pop_modal},
 };
 use anyhow::Result;
-use crossterm::event::KeyEvent;
 use ratatui::{
     layout::{Constraint, Layout, Margin},
     style::Style,
@@ -160,8 +159,8 @@ impl Modal for SongInfoModal {
         return Ok(());
     }
 
-    fn handle_key(&mut self, key: KeyEvent, _client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
-        if let Some(action) = context.config.keybinds.navigation.get(&key.into()) {
+    fn handle_key(&mut self, key: &mut KeyEvent, _client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
+        if let Some(action) = key.as_common_action(context) {
             match action {
                 CommonAction::DownHalf => {
                     self.scrolling_state.next_half_viewport(context.config.scrolloff);

--- a/src/ui/modals/song_info.rs
+++ b/src/ui/modals/song_info.rs
@@ -1,4 +1,4 @@
-use crate::{config::keys::CommonAction, context::AppContext, mpd::commands::Song};
+use crate::{config::keys::CommonAction, context::AppContext, mpd::commands::Song, shared::macros::pop_modal};
 use ratatui::{
     layout::{Constraint, Layout, Margin},
     style::Style,
@@ -163,29 +163,41 @@ impl Modal for SongInfoModal {
             match action {
                 CommonAction::DownHalf => {
                     self.scrolling_state.next_half_viewport(context.config.scrolloff);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::UpHalf => {
                     self.scrolling_state.prev_half_viewport(context.config.scrolloff);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Up => {
                     self.scrolling_state
                         .prev(context.config.scrolloff, context.config.wrap_navigation);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Down => {
                     self.scrolling_state
                         .next(context.config.scrolloff, context.config.wrap_navigation);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Bottom => {
                     self.scrolling_state.last();
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Top => {
                     self.scrolling_state.first();
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Right => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::Left => Ok(KeyHandleResultInternal::SkipRender),
@@ -199,7 +211,10 @@ impl Modal for SongInfoModal {
                 CommonAction::Rename => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::MoveUp => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::MoveDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Close => Ok(KeyHandleResultInternal::Modal(None)),
+                CommonAction::Close => {
+                    pop_modal!(context);
+                    Ok(KeyHandleResultInternal::SkipRender)
+                }
                 CommonAction::Confirm => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::FocusInput => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::PaneDown => Ok(KeyHandleResultInternal::SkipRender),

--- a/src/ui/modals/song_info.rs
+++ b/src/ui/modals/song_info.rs
@@ -1,4 +1,11 @@
-use crate::{config::keys::CommonAction, context::AppContext, mpd::commands::Song, shared::macros::pop_modal};
+use crate::{
+    config::keys::CommonAction,
+    context::AppContext,
+    mpd::{client::Client, commands::Song},
+    shared::macros::pop_modal,
+};
+use anyhow::Result;
+use crossterm::event::KeyEvent;
 use ratatui::{
     layout::{Constraint, Layout, Margin},
     style::Style,
@@ -8,7 +15,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::ui::{dirstack::DirState, KeyHandleResultInternal};
+use crate::ui::dirstack::DirState;
 
 use super::{Modal, RectExt};
 
@@ -36,7 +43,7 @@ impl SongInfoModal {
 }
 
 impl Modal for SongInfoModal {
-    fn render(&mut self, frame: &mut Frame, app: &mut crate::context::AppContext) -> anyhow::Result<()> {
+    fn render(&mut self, frame: &mut Frame, app: &mut AppContext) -> Result<()> {
         let popup_area = frame.area().centered(80, 80);
         frame.render_widget(Clear, popup_area);
         if let Some(bg_color) = app.config.theme.modal_background_color {
@@ -153,77 +160,48 @@ impl Modal for SongInfoModal {
         return Ok(());
     }
 
-    fn handle_key(
-        &mut self,
-        key: crossterm::event::KeyEvent,
-        _client: &mut crate::mpd::client::Client<'_>,
-        context: &mut AppContext,
-    ) -> anyhow::Result<KeyHandleResultInternal> {
+    fn handle_key(&mut self, key: KeyEvent, _client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
         if let Some(action) = context.config.keybinds.navigation.get(&key.into()) {
             match action {
                 CommonAction::DownHalf => {
                     self.scrolling_state.next_half_viewport(context.config.scrolloff);
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::UpHalf => {
                     self.scrolling_state.prev_half_viewport(context.config.scrolloff);
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Up => {
                     self.scrolling_state
                         .prev(context.config.scrolloff, context.config.wrap_navigation);
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Down => {
                     self.scrolling_state
                         .next(context.config.scrolloff, context.config.wrap_navigation);
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Bottom => {
                     self.scrolling_state.last();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Top => {
                     self.scrolling_state.first();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
-                CommonAction::Right => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Left => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::EnterSearch => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::NextResult => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PreviousResult => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Add => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::AddAll => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Select => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Delete => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Rename => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::MoveUp => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::MoveDown => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::Close => {
                     pop_modal!(context);
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
-                CommonAction::Confirm => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::FocusInput => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneUp => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneRight => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneLeft => Ok(KeyHandleResultInternal::SkipRender),
+                _ => {}
             }
-        } else {
-            Ok(KeyHandleResultInternal::KeyNotHandled)
-        }
+        };
+
+        Ok(())
     }
 }

--- a/src/ui/panes/album_art.rs
+++ b/src/ui/panes/album_art.rs
@@ -1,12 +1,11 @@
 use crate::{
     context::AppContext,
     mpd::mpd_client::MpdClient,
-    shared::{image::ImageProtocol, macros::try_skip},
+    shared::{image::ImageProtocol, key_event::KeyEvent, macros::try_skip},
     ui::{image::facade::AlbumArtFacade, UiEvent},
     AppEvent,
 };
 use anyhow::Result;
-use crossterm::event::KeyEvent;
 use ratatui::{layout::Rect, Frame};
 
 use super::Pane;
@@ -57,7 +56,12 @@ impl Pane for AlbumArtPane {
         Ok(())
     }
 
-    fn handle_action(&mut self, _event: KeyEvent, _client: &mut impl MpdClient, _context: &AppContext) -> Result<()> {
+    fn handle_action(
+        &mut self,
+        _event: &mut KeyEvent,
+        _client: &mut impl MpdClient,
+        _context: &AppContext,
+    ) -> Result<()> {
         Ok(())
     }
 

--- a/src/ui/panes/album_art.rs
+++ b/src/ui/panes/album_art.rs
@@ -111,7 +111,9 @@ impl Pane for AlbumArtPane {
                         let album_art = client.find_album_art(current_song.file.as_str())?;
                         log::debug!(elapsed:? = start.elapsed(), size = album_art.as_ref().map(|v|v.len()); "Found album art");
                         self.album_art.set_image(album_art)?;
-                        return Ok(KeyHandleResultInternal::RenderRequested);
+
+                        context.render()?;
+                        return Ok(KeyHandleResultInternal::SkipRender);
                     }
                 }
 
@@ -119,15 +121,21 @@ impl Pane for AlbumArtPane {
             }
             UiEvent::Resized { columns, rows } => {
                 self.album_art.resize(*columns, *rows);
-                Ok(KeyHandleResultInternal::RenderRequested)
+
+                context.render()?;
+                Ok(KeyHandleResultInternal::SkipRender)
             }
             UiEvent::ModalOpened => {
                 self.album_art.hide(context.config.theme.background_color)?;
-                Ok(KeyHandleResultInternal::RenderRequested)
+
+                context.render()?;
+                Ok(KeyHandleResultInternal::SkipRender)
             }
             UiEvent::ModalClosed => {
                 self.album_art.show();
-                Ok(KeyHandleResultInternal::RenderRequested)
+
+                context.render()?;
+                Ok(KeyHandleResultInternal::SkipRender)
             }
             UiEvent::Exit => {
                 self.album_art.cleanup()?;

--- a/src/ui/panes/albums.rs
+++ b/src/ui/panes/albums.rs
@@ -76,26 +76,23 @@ impl Pane for AlbumsPane {
     }
 
     fn on_event(&mut self, event: &mut UiEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
-        match event {
-            crate::ui::UiEvent::Database => {
-                let result = client.list_tag(Tag::Album, None).context("Cannot list tags")?;
-                self.stack = DirStack::new(
-                    result
-                        .into_iter()
-                        .map(|v| DirOrSong::Dir {
-                            full_path: String::new(),
-                            name: v,
-                        })
-                        .collect::<Vec<_>>(),
-                );
-                let preview = self
-                    .prepare_preview(client, context.config)
-                    .context("Cannot prepare preview")?;
-                self.stack.set_preview(preview);
+        if let crate::ui::UiEvent::Database = event {
+            let result = client.list_tag(Tag::Album, None).context("Cannot list tags")?;
+            self.stack = DirStack::new(
+                result
+                    .into_iter()
+                    .map(|v| DirOrSong::Dir {
+                        full_path: String::new(),
+                        name: v,
+                    })
+                    .collect::<Vec<_>>(),
+            );
+            let preview = self
+                .prepare_preview(client, context.config)
+                .context("Cannot prepare preview")?;
+            self.stack.set_preview(preview);
 
-                status_warn!("The music database has been updated. The current tab has been reinitialized in the root directory to prevent inconsistent behaviours.");
-            }
-            _ => {}
+            status_warn!("The music database has been updated. The current tab has been reinitialized in the root directory to prevent inconsistent behaviours.");
         };
         Ok(())
     }

--- a/src/ui/panes/albums.rs
+++ b/src/ui/panes/albums.rs
@@ -7,6 +7,7 @@ use crate::{
         mpd_client::{Filter, MpdClient, Tag},
     },
     shared::{
+        key_event::KeyEvent,
         macros::{status_info, status_warn},
         mouse_event::MouseEvent,
     },
@@ -20,7 +21,6 @@ use crate::{
 
 use super::{browser::DirOrSong, Pane};
 use anyhow::{anyhow, Context, Result};
-use crossterm::event::KeyEvent;
 use itertools::Itertools;
 use ratatui::{
     prelude::Rect,
@@ -109,17 +109,10 @@ impl Pane for AlbumsPane {
         self.handle_mouse_action(event, client, context)
     }
 
-    fn handle_action(&mut self, event: KeyEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
-        let config = context.config;
-        if self.filter_input_mode {
-            self.handle_filter_input(event, client, config, context)?;
-        } else if let Some(action) = config.keybinds.navigation.get(&event.into()) {
-            self.handle_common_action(*action, client, context)?;
-        } else if let Some(action) = config.keybinds.global.get(&event.into()) {
-            self.handle_global_action(*action, client, context)?;
-        } else {
-            // TODO the event should bubble up
-        }
+    fn handle_action(&mut self, event: &mut KeyEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
+        self.handle_filter_input(event, client, context)?;
+        self.handle_common_action(event, client, context)?;
+        self.handle_global_action(event, client, context)?;
         Ok(())
     }
 }

--- a/src/ui/panes/artists.rs
+++ b/src/ui/panes/artists.rs
@@ -139,28 +139,25 @@ impl Pane for ArtistsPane {
     }
 
     fn on_event(&mut self, event: &mut UiEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
-        match event {
-            crate::ui::UiEvent::Database => {
-                let result = client
-                    .list_tag(self.artist_tag(), None)
-                    .context("Cannot list artists")?;
-                self.stack = DirStack::new(
-                    result
-                        .into_iter()
-                        .map(|v| DirOrSong::Dir {
-                            full_path: String::new(),
-                            name: v,
-                        })
-                        .collect::<Vec<_>>(),
-                );
-                let preview = self
-                    .prepare_preview(client, context.config)
-                    .context("Cannot prepare preview")?;
-                self.stack.set_preview(preview);
+        if let crate::ui::UiEvent::Database = event {
+            let result = client
+                .list_tag(self.artist_tag(), None)
+                .context("Cannot list artists")?;
+            self.stack = DirStack::new(
+                result
+                    .into_iter()
+                    .map(|v| DirOrSong::Dir {
+                        full_path: String::new(),
+                        name: v,
+                    })
+                    .collect::<Vec<_>>(),
+            );
+            let preview = self
+                .prepare_preview(client, context.config)
+                .context("Cannot prepare preview")?;
+            self.stack.set_preview(preview);
 
-                status_warn!("The music database has been updated. The current tab has been reinitialized in the root directory to prevent inconsistent behaviours.");
-            }
-            _ => {}
+            status_warn!("The music database has been updated. The current tab has been reinitialized in the root directory to prevent inconsistent behaviours.");
         };
         Ok(())
     }

--- a/src/ui/panes/artists.rs
+++ b/src/ui/panes/artists.rs
@@ -7,6 +7,7 @@ use crate::{
         mpd_client::{Filter, MpdClient, Tag},
     },
     shared::{
+        key_event::KeyEvent,
         macros::{status_info, status_warn},
         mouse_event::MouseEvent,
     },
@@ -20,7 +21,6 @@ use crate::{
 
 use super::{browser::DirOrSong, Pane};
 use anyhow::{anyhow, Context, Result};
-use crossterm::event::KeyEvent;
 use itertools::Itertools;
 use ratatui::{
     prelude::Rect,
@@ -174,18 +174,10 @@ impl Pane for ArtistsPane {
         self.handle_mouse_action(event, client, context)
     }
 
-    fn handle_action(&mut self, event: KeyEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
-        let config = context.config;
-        if self.filter_input_mode {
-            self.handle_filter_input(event, client, config, context)?;
-        } else if let Some(_action) = config.keybinds.artists.get(&event.into()) {
-        } else if let Some(action) = config.keybinds.navigation.get(&event.into()) {
-            self.handle_common_action(*action, client, context)?;
-        } else if let Some(action) = config.keybinds.global.get(&event.into()) {
-            self.handle_global_action(*action, client, context)?;
-        } else {
-            // TODO the event should bubble up
-        }
+    fn handle_action(&mut self, event: &mut KeyEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
+        self.handle_filter_input(event, client, context)?;
+        self.handle_common_action(event, client, context)?;
+        self.handle_global_action(event, client, context)?;
         Ok(())
     }
 }

--- a/src/ui/panes/directories.rs
+++ b/src/ui/panes/directories.rs
@@ -71,21 +71,18 @@ impl Pane for DirectoriesPane {
     }
 
     fn on_event(&mut self, event: &mut UiEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
-        match event {
-            crate::ui::UiEvent::Database => {
-                self.stack = DirStack::new(
-                    client
-                        .lsinfo(None)?
-                        .into_iter()
-                        .map(Into::<DirOrSong>::into)
-                        .collect::<Vec<_>>(),
-                );
-                let preview = self.prepare_preview(client, context.config)?;
-                self.stack.set_preview(preview);
+        if let crate::ui::UiEvent::Database = event {
+            self.stack = DirStack::new(
+                client
+                    .lsinfo(None)?
+                    .into_iter()
+                    .map(Into::<DirOrSong>::into)
+                    .collect::<Vec<_>>(),
+            );
+            let preview = self.prepare_preview(client, context.config)?;
+            self.stack.set_preview(preview);
 
-                status_warn!("The music database has been updated. The current tab has been reinitialized in the root directory to prevent inconsistent behaviours.");
-            }
-            _ => {}
+            status_warn!("The music database has been updated. The current tab has been reinitialized in the root directory to prevent inconsistent behaviours.");
         };
         Ok(())
     }

--- a/src/ui/panes/directories.rs
+++ b/src/ui/panes/directories.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use crossterm::event::KeyEvent;
 use itertools::Itertools;
 use ratatui::{
     prelude::Rect,
@@ -15,6 +14,7 @@ use crate::{
         mpd_client::{Filter, FilterKind, MpdClient, Tag},
     },
     shared::{
+        key_event::KeyEvent,
         macros::{status_info, status_warn},
         mouse_event::MouseEvent,
     },
@@ -99,17 +99,10 @@ impl Pane for DirectoriesPane {
         self.handle_mouse_action(event, client, context)
     }
 
-    fn handle_action(&mut self, event: KeyEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
-        let config = context.config;
-        if self.filter_input_mode {
-            self.handle_filter_input(event, client, config, context)?;
-        } else if let Some(action) = config.keybinds.navigation.get(&event.into()) {
-            self.handle_common_action(*action, client, context)?;
-        } else if let Some(action) = config.keybinds.global.get(&event.into()) {
-            self.handle_global_action(*action, client, context)?;
-        } else {
-            // TODO the event should bubble up
-        }
+    fn handle_action(&mut self, event: &mut KeyEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
+        self.handle_filter_input(event, client, context)?;
+        self.handle_common_action(event, client, context)?;
+        self.handle_global_action(event, client, context)?;
         Ok(())
     }
 }

--- a/src/ui/panes/logs.rs
+++ b/src/ui/panes/logs.rs
@@ -121,7 +121,6 @@ impl Pane for LogsPane {
     ) -> Result<()> {
         let config = context.config;
         if let Some(action) = event.as_logs_action(context) {
-            event.stop_propagation();
             match action {
                 LogsActions::Clear => {
                     self.logs.clear();
@@ -130,7 +129,6 @@ impl Pane for LogsPane {
                 }
             }
         } else if let Some(action) = event.as_common_action(context) {
-            event.stop_propagation();
             match action {
                 CommonAction::DownHalf => {
                     self.scrolling_state.next_half_viewport(context.config.scrolloff);

--- a/src/ui/panes/logs.rs
+++ b/src/ui/panes/logs.rs
@@ -77,17 +77,17 @@ impl Pane for LogsPane {
         &mut self,
         event: &mut UiEvent,
         _client: &mut impl MpdClient,
-        _context: &AppContext,
+        context: &AppContext,
     ) -> Result<KeyHandleResultInternal> {
         if let UiEvent::LogAdded(msg) = event {
             self.logs.push_back(std::mem::take(msg));
             if self.logs.len() > 1000 {
                 self.logs.pop_front();
             }
-            Ok(KeyHandleResultInternal::RenderRequested)
-        } else {
-            Ok(KeyHandleResultInternal::SkipRender)
+
+            context.render()?;
         }
+        Ok(KeyHandleResultInternal::SkipRender)
     }
 
     fn handle_mouse_event(
@@ -103,11 +103,15 @@ impl Pane for LogsPane {
         match event.kind {
             MouseEventKind::ScrollUp => {
                 self.scrolling_state.prev(context.config.scrolloff, false);
-                Ok(KeyHandleResultInternal::RenderRequested)
+
+                context.render()?;
+                Ok(KeyHandleResultInternal::SkipRender)
             }
             MouseEventKind::ScrollDown => {
                 self.scrolling_state.next(context.config.scrolloff, false);
-                Ok(KeyHandleResultInternal::RenderRequested)
+
+                context.render()?;
+                Ok(KeyHandleResultInternal::SkipRender)
             }
             _ => Ok(KeyHandleResultInternal::SkipRender),
         }
@@ -124,36 +128,50 @@ impl Pane for LogsPane {
             match action {
                 LogsActions::Clear => {
                     self.logs.clear();
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
             }
         } else if let Some(action) = config.keybinds.navigation.get(&event.into()) {
             match action {
                 CommonAction::DownHalf => {
                     self.scrolling_state.next_half_viewport(context.config.scrolloff);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::UpHalf => {
                     self.scrolling_state.prev_half_viewport(context.config.scrolloff);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Up => {
                     self.scrolling_state
                         .prev(context.config.scrolloff, config.wrap_navigation);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Down => {
                     self.scrolling_state
                         .next(context.config.scrolloff, config.wrap_navigation);
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Bottom => {
                     self.scrolling_state.last();
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Top => {
                     self.scrolling_state.first();
-                    Ok(KeyHandleResultInternal::RenderRequested)
+
+                    context.render()?;
+                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Right => Ok(KeyHandleResultInternal::SkipRender),
                 CommonAction::Left => Ok(KeyHandleResultInternal::SkipRender),

--- a/src/ui/panes/logs.rs
+++ b/src/ui/panes/logs.rs
@@ -14,7 +14,7 @@ use crate::{
     context::AppContext,
     mpd::mpd_client::MpdClient,
     shared::mouse_event::{MouseEvent, MouseEventKind},
-    ui::{dirstack::DirState, KeyHandleResultInternal, UiEvent},
+    ui::{dirstack::DirState, UiEvent},
 };
 
 use super::Pane;
@@ -73,12 +73,7 @@ impl Pane for LogsPane {
         Ok(())
     }
 
-    fn on_event(
-        &mut self,
-        event: &mut UiEvent,
-        _client: &mut impl MpdClient,
-        context: &AppContext,
-    ) -> Result<KeyHandleResultInternal> {
+    fn on_event(&mut self, event: &mut UiEvent, _client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
         if let UiEvent::LogAdded(msg) = event {
             self.logs.push_back(std::mem::take(msg));
             if self.logs.len() > 1000 {
@@ -87,7 +82,8 @@ impl Pane for LogsPane {
 
             context.render()?;
         }
-        Ok(KeyHandleResultInternal::SkipRender)
+
+        Ok(())
     }
 
     fn handle_mouse_event(
@@ -95,9 +91,9 @@ impl Pane for LogsPane {
         event: MouseEvent,
         _client: &mut impl MpdClient,
         context: &mut AppContext,
-    ) -> Result<KeyHandleResultInternal> {
+    ) -> Result<()> {
         if !self.logs_area.contains(event.into()) {
-            return Ok(KeyHandleResultInternal::SkipRender);
+            return Ok(());
         }
 
         match event.kind {
@@ -105,24 +101,19 @@ impl Pane for LogsPane {
                 self.scrolling_state.prev(context.config.scrolloff, false);
 
                 context.render()?;
-                Ok(KeyHandleResultInternal::SkipRender)
             }
             MouseEventKind::ScrollDown => {
                 self.scrolling_state.next(context.config.scrolloff, false);
 
                 context.render()?;
-                Ok(KeyHandleResultInternal::SkipRender)
             }
-            _ => Ok(KeyHandleResultInternal::SkipRender),
-        }
+            _ => {}
+        };
+
+        Ok(())
     }
 
-    fn handle_action(
-        &mut self,
-        event: KeyEvent,
-        _client: &mut impl MpdClient,
-        context: &AppContext,
-    ) -> Result<KeyHandleResultInternal> {
+    fn handle_action(&mut self, event: KeyEvent, _client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
         let config = context.config;
         if let Some(action) = config.keybinds.logs.get(&event.into()) {
             match action {
@@ -130,7 +121,6 @@ impl Pane for LogsPane {
                     self.logs.clear();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
             }
         } else if let Some(action) = config.keybinds.navigation.get(&event.into()) {
@@ -139,62 +129,56 @@ impl Pane for LogsPane {
                     self.scrolling_state.next_half_viewport(context.config.scrolloff);
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::UpHalf => {
                     self.scrolling_state.prev_half_viewport(context.config.scrolloff);
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Up => {
                     self.scrolling_state
                         .prev(context.config.scrolloff, config.wrap_navigation);
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Down => {
                     self.scrolling_state
                         .next(context.config.scrolloff, config.wrap_navigation);
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Bottom => {
                     self.scrolling_state.last();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
                 CommonAction::Top => {
                     self.scrolling_state.first();
 
                     context.render()?;
-                    Ok(KeyHandleResultInternal::SkipRender)
                 }
-                CommonAction::Right => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Left => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::EnterSearch => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::NextResult => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PreviousResult => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Add => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Select => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Delete => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Rename => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::MoveUp => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::MoveDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Close => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::Confirm => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::FocusInput => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::AddAll => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneDown => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneUp => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneRight => Ok(KeyHandleResultInternal::SkipRender),
-                CommonAction::PaneLeft => Ok(KeyHandleResultInternal::SkipRender),
+                CommonAction::Right => {}
+                CommonAction::Left => {}
+                CommonAction::EnterSearch => {}
+                CommonAction::NextResult => {}
+                CommonAction::PreviousResult => {}
+                CommonAction::Add => {}
+                CommonAction::Select => {}
+                CommonAction::Delete => {}
+                CommonAction::Rename => {}
+                CommonAction::MoveUp => {}
+                CommonAction::MoveDown => {}
+                CommonAction::Close => {}
+                CommonAction::Confirm => {}
+                CommonAction::FocusInput => {}
+                CommonAction::AddAll => {}
+                CommonAction::PaneDown => {}
+                CommonAction::PaneUp => {}
+                CommonAction::PaneRight => {}
+                CommonAction::PaneLeft => {}
             }
-        } else {
-            Ok(KeyHandleResultInternal::KeyNotHandled)
         }
+
+        Ok(())
     }
 }

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     shared::{ext::duration::DurationExt, mouse_event::MouseEvent},
 };
 
-use super::{widgets::volume::Volume, KeyHandleResultInternal, UiEvent};
+use super::{widgets::volume::Volume, UiEvent};
 
 pub mod album_art;
 pub mod albums;
@@ -106,7 +106,6 @@ impl PaneContainer {
     }
 }
 
-type KeyResult = Result<KeyHandleResultInternal>;
 #[allow(unused_variables)]
 pub(super) trait Pane {
     fn render(&mut self, frame: &mut Frame, area: Rect, context: &AppContext) -> Result<()>;
@@ -125,19 +124,19 @@ pub(super) trait Pane {
     }
 
     /// Used to keep the current state but refresh data
-    fn on_event(&mut self, event: &mut UiEvent, client: &mut impl MpdClient, context: &AppContext) -> KeyResult {
-        Ok(KeyHandleResultInternal::SkipRender)
+    fn on_event(&mut self, event: &mut UiEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
+        Ok(())
     }
 
-    fn handle_action(&mut self, event: KeyEvent, client: &mut impl MpdClient, context: &AppContext) -> KeyResult;
+    fn handle_action(&mut self, event: KeyEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()>;
 
     fn handle_mouse_event(
         &mut self,
         event: MouseEvent,
         client: &mut impl MpdClient,
         context: &mut AppContext,
-    ) -> KeyResult {
-        Ok(KeyHandleResultInternal::KeyNotHandled)
+    ) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -4,7 +4,6 @@ use album_art::AlbumArtPane;
 use albums::AlbumsPane;
 use anyhow::Result;
 use artists::{ArtistsPane, ArtistsPaneMode};
-use crossterm::event::KeyEvent;
 use directories::DirectoriesPane;
 use either::Either;
 #[cfg(debug_assertions)]
@@ -31,7 +30,7 @@ use crate::{
         commands::{status::OnOffOneshot, volume::Bound, Song, Status},
         mpd_client::MpdClient,
     },
-    shared::{ext::duration::DurationExt, mouse_event::MouseEvent},
+    shared::{ext::duration::DurationExt, key_event::KeyEvent, mouse_event::MouseEvent},
 };
 
 use super::{widgets::volume::Volume, UiEvent};
@@ -128,7 +127,7 @@ pub(super) trait Pane {
         Ok(())
     }
 
-    fn handle_action(&mut self, event: KeyEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()>;
+    fn handle_action(&mut self, event: &mut KeyEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()>;
 
     fn handle_mouse_event(
         &mut self,

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, Context, Result};
-use crossterm::event::KeyEvent;
 use itertools::Itertools;
 use ratatui::{
     prelude::Rect,
@@ -15,6 +14,7 @@ use crate::{
         mpd_client::{Filter, MpdClient, SingleOrRange, Tag},
     },
     shared::{
+        key_event::KeyEvent,
         macros::{modal, status_error, status_info},
         mouse_event::MouseEvent,
     },
@@ -164,17 +164,10 @@ impl Pane for PlaylistsPane {
         self.handle_mouse_action(event, client, context)
     }
 
-    fn handle_action(&mut self, event: KeyEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
-        let config = context.config;
-        if self.filter_input_mode {
-            self.handle_filter_input(event, client, config, context)?;
-        } else if let Some(action) = config.keybinds.navigation.get(&event.into()) {
-            self.handle_common_action(*action, client, context)?;
-        } else if let Some(action) = config.keybinds.global.get(&event.into()) {
-            self.handle_global_action(*action, client, context)?;
-        } else {
-            // TODO the event should bubble up
-        }
+    fn handle_action(&mut self, event: &mut KeyEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
+        self.handle_filter_input(event, client, context)?;
+        self.handle_common_action(event, client, context)?;
+        self.handle_global_action(event, client, context)?;
         Ok(())
     }
 }

--- a/src/ui/panes/playlists/tests.rs
+++ b/src/ui/panes/playlists/tests.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::unwrap_used)]
 
+use crossterm::event::{KeyEvent, KeyModifiers};
 use rstest::{fixture, rstest};
 
 use crate::context::AppContext;
@@ -8,7 +9,6 @@ use crate::tests::fixtures::mpd_client::{client, TestMpdClient};
 use crate::ui::browser::BrowserPane;
 use crate::ui::UiEvent;
 
-use crate::ui::panes::CommonAction;
 use crate::ui::panes::{browser::DirOrSong, playlists::PlaylistsPane, Pane};
 
 mod on_idle_event {
@@ -294,8 +294,9 @@ fn screen_in_playlist_0(mut client: TestMpdClient, app_context: AppContext) -> P
     let mut screen = PlaylistsPane::new(&app_context);
     screen.before_show(&mut client, &app_context).unwrap();
     screen.stack.current_mut().select_idx(0, 0);
+    let right = KeyEvent::new(crossterm::event::KeyCode::Char('l'), KeyModifiers::NONE);
     screen
-        .handle_common_action(CommonAction::Right, &mut client, &app_context)
+        .handle_common_action(&mut right.into(), &mut client, &app_context)
         .unwrap();
     screen
 }
@@ -305,8 +306,9 @@ fn screen_in_playlist_2(mut client: TestMpdClient, app_context: AppContext) -> P
     let mut screen = PlaylistsPane::new(&app_context);
     screen.before_show(&mut client, &app_context).unwrap();
     screen.stack.current_mut().select_idx(2, 0);
+    let right = KeyEvent::new(crossterm::event::KeyCode::Char('l'), KeyModifiers::NONE);
     screen
-        .handle_common_action(CommonAction::Right, &mut client, &app_context)
+        .handle_common_action(&mut right.into(), &mut client, &app_context)
         .unwrap();
     screen
 }
@@ -316,8 +318,9 @@ fn screen_in_playlist_4(mut client: TestMpdClient, app_context: AppContext) -> P
     let mut screen = PlaylistsPane::new(&app_context);
     screen.before_show(&mut client, &app_context).unwrap();
     screen.stack.current_mut().select_idx(2, 0);
+    let right = KeyEvent::new(crossterm::event::KeyCode::Char('l'), KeyModifiers::NONE);
     screen
-        .handle_common_action(CommonAction::Right, &mut client, &app_context)
+        .handle_common_action(&mut right.into(), &mut client, &app_context)
         .unwrap();
     screen
 }

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -179,22 +179,19 @@ impl Pane for QueuePane {
     }
 
     fn on_event(&mut self, event: &mut UiEvent, _client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
-        match event {
-            UiEvent::Player => {
-                if let Some((idx, _)) = context
-                    .queue
-                    .iter()
-                    .enumerate()
-                    .find(|(_, v)| Some(v.id) == context.status.songid)
-                {
-                    if context.config.select_current_song_on_change {
-                        self.scrolling_state.select(Some(idx), context.config.scrolloff);
-                    }
-
-                    context.render()?;
+        if let UiEvent::Player = event {
+            if let Some((idx, _)) = context
+                .queue
+                .iter()
+                .enumerate()
+                .find(|(_, v)| Some(v.id) == context.status.songid)
+            {
+                if context.config.select_current_song_on_change {
+                    self.scrolling_state.select(Some(idx), context.config.scrolloff);
                 }
+
+                context.render()?;
             }
-            _ => {}
         };
 
         Ok(())

--- a/src/ui/panes/search.rs
+++ b/src/ui/panes/search.rs
@@ -496,15 +496,12 @@ impl Pane for SearchPane {
     }
 
     fn on_event(&mut self, event: &mut UiEvent, client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
-        match event {
-            crate::ui::UiEvent::Database => {
-                self.songs_dir = Dir::default();
-                self.preview = self.prepare_preview(client, context.config)?;
-                self.phase = Phase::Search;
+        if let crate::ui::UiEvent::Database = event {
+            self.songs_dir = Dir::default();
+            self.preview = self.prepare_preview(client, context.config)?;
+            self.phase = Phase::Search;
 
-                status_warn!("The music database has been updated. The current tab has been reinitialized in the root directory to prevent inconsistent behaviours.");
-            }
-            _ => {}
+            status_warn!("The music database has been updated. The current tab has been reinitialized in the root directory to prevent inconsistent behaviours.");
         }
 
         Ok(())

--- a/src/ui/tab_screen.rs
+++ b/src/ui/tab_screen.rs
@@ -152,7 +152,6 @@ impl TabScreen {
                         .0,
                 );
                 context.render()?;
-                event.stop_propagation();
             }
             Some(CommonAction::PaneDown) => {
                 self.focused = Some(
@@ -174,7 +173,6 @@ impl TabScreen {
                         .0,
                 );
                 context.render()?;
-                event.stop_propagation();
             }
             Some(CommonAction::PaneRight) => {
                 self.focused = Some(
@@ -196,7 +194,6 @@ impl TabScreen {
                         .0,
                 );
                 context.render()?;
-                event.stop_propagation();
             }
             Some(CommonAction::PaneLeft) => {
                 self.focused = Some(
@@ -218,9 +215,9 @@ impl TabScreen {
                         .0,
                 );
                 context.render()?;
-                event.stop_propagation();
             }
             Some(_) | None => {
+                event.abandon();
                 let pane = panes.get_mut(focused.pane);
                 screen_call!(pane, handle_action(event, client, context))?;
             }

--- a/src/ui/tab_screen.rs
+++ b/src/ui/tab_screen.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use anyhow::Result;
-use crossterm::event::KeyEvent;
 use ratatui::{
     layout::{Constraint, Layout, Rect},
     widgets::Block,
@@ -18,6 +17,7 @@ use crate::{
     shared::{
         geometry::Point,
         id::Id,
+        key_event::KeyEvent,
         mouse_event::{MouseEvent, MouseEventKind},
     },
 };
@@ -27,7 +27,7 @@ use super::{Pane as _, PaneContainer, Panes};
 #[derive(Debug)]
 pub struct TabScreen {
     focused: Option<Pane>, // can focused ever be none?
-    panes: &'static crate::config::tabs::PaneOrSplitWithPosition,
+    pub panes: &'static crate::config::tabs::PaneOrSplitWithPosition,
     pane_areas: HashMap<Id, Rect>,
 }
 
@@ -123,7 +123,7 @@ impl TabScreen {
     pub(in crate::ui) fn handle_action(
         &mut self,
         panes: &mut PaneContainer,
-        event: KeyEvent,
+        event: &mut KeyEvent,
         client: &mut impl MpdClient,
         context: &AppContext,
     ) -> Result<()> {
@@ -131,7 +131,7 @@ impl TabScreen {
             return Ok(());
         };
 
-        match context.config.keybinds.navigation.get(&event.into()) {
+        match event.as_common_action(context) {
             Some(CommonAction::PaneUp) => {
                 self.focused = Some(
                     self.panes
@@ -152,6 +152,7 @@ impl TabScreen {
                         .0,
                 );
                 context.render()?;
+                event.stop_propagation();
             }
             Some(CommonAction::PaneDown) => {
                 self.focused = Some(
@@ -173,6 +174,7 @@ impl TabScreen {
                         .0,
                 );
                 context.render()?;
+                event.stop_propagation();
             }
             Some(CommonAction::PaneRight) => {
                 self.focused = Some(
@@ -194,6 +196,7 @@ impl TabScreen {
                         .0,
                 );
                 context.render()?;
+                event.stop_propagation();
             }
             Some(CommonAction::PaneLeft) => {
                 self.focused = Some(
@@ -215,6 +218,7 @@ impl TabScreen {
                         .0,
                 );
                 context.render()?;
+                event.stop_propagation();
             }
             Some(_) | None => {
                 let pane = panes.get_mut(focused.pane);

--- a/src/ui/tab_screen.rs
+++ b/src/ui/tab_screen.rs
@@ -152,7 +152,8 @@ impl TabScreen {
                         })
                         .0,
                 );
-                Ok(KeyHandleResultInternal::RenderRequested)
+                context.render()?;
+                Ok(KeyHandleResultInternal::SkipRender)
             }
             Some(CommonAction::PaneDown) => {
                 self.focused = Some(
@@ -173,7 +174,8 @@ impl TabScreen {
                         })
                         .0,
                 );
-                Ok(KeyHandleResultInternal::RenderRequested)
+                context.render()?;
+                Ok(KeyHandleResultInternal::SkipRender)
             }
             Some(CommonAction::PaneRight) => {
                 self.focused = Some(
@@ -194,7 +196,8 @@ impl TabScreen {
                         })
                         .0,
                 );
-                Ok(KeyHandleResultInternal::RenderRequested)
+                context.render()?;
+                Ok(KeyHandleResultInternal::SkipRender)
             }
             Some(CommonAction::PaneLeft) => {
                 self.focused = Some(
@@ -215,7 +218,8 @@ impl TabScreen {
                         })
                         .0,
                 );
-                Ok(KeyHandleResultInternal::RenderRequested)
+                context.render()?;
+                Ok(KeyHandleResultInternal::SkipRender)
             }
             Some(_) | None => {
                 let pane = panes.get_mut(focused.pane);
@@ -231,7 +235,7 @@ impl TabScreen {
         client: &mut impl MpdClient,
         context: &mut AppContext,
     ) -> Result<KeyHandleResultInternal> {
-        let mut result = KeyHandleResultInternal::KeyNotHandled;
+        let result = KeyHandleResultInternal::KeyNotHandled;
         if matches!(event.kind, MouseEventKind::LeftClick) {
             let Some(pane) = self
                 .pane_areas
@@ -246,7 +250,7 @@ impl TabScreen {
                 return Ok(KeyHandleResultInternal::KeyNotHandled);
             };
             self.focused = Some(pane);
-            result = KeyHandleResultInternal::RenderRequested;
+            context.render()?;
         }
 
         let Some(focused) = self.focused else {
@@ -255,8 +259,6 @@ impl TabScreen {
 
         let pane = panes.get_mut(focused.pane);
         match screen_call!(pane, handle_mouse_event(event, client, context))? {
-            KeyHandleResultInternal::Modal(modal) => Ok(KeyHandleResultInternal::Modal(modal)),
-            KeyHandleResultInternal::RenderRequested => Ok(KeyHandleResultInternal::RenderRequested),
             KeyHandleResultInternal::FullRenderRequested => Ok(KeyHandleResultInternal::FullRenderRequested),
             _ => Ok(result),
         }


### PR DESCRIPTION
This completely removes internal key handler's result in order simplify the determination of whether render is wanted and event propagation.