### PR TITLE
fix(ui): skip album art for stream songs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,6 +1583,7 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "ratatui",
+ "regex",
  "ron",
  "rstest",
  "rustix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ sysinfo = "0.32.0"
 color_quant = "1.1.0"
 enum-map = "2.7.3"
 textwrap = "0.16.1"
+regex = "1.11.1"
 
 [build-dependencies]
 clap = { workspace = true }


### PR DESCRIPTION
When the song is a stream (eg. a webradio), the file URI is not a local path but an HTTP URL.

Depending on the computer you run rmpc, there's a lag displaying the Queue view because it needs to query mpd about the album art. And by providing an URL it fails everytime obviously.

When I say lag, the elapsed time may vary from 500ms to over 2s sometimes on a potatoe hardware (and feel instant on a brand new machine), here is one of the log entry of my beloved potatoe:

```
2024-11-01T17:59:27.762451247Z DEBUG src/ui/panes/album_art.rs:78 message="Searching for album art" file="https://icecast.radiofrance.fr/fiphiphop-hifi.aac"
2024-11-01T17:59:29.011874642Z WARN  src/mpd/proto_client.rs:160 message="Expected binary data but got 'OK'"
2024-11-01T17:59:29.011928583Z DEBUG src/mpd/mpd_client.rs:484 message="No album art found, falling back to placeholder image"
2024-11-01T17:59:29.011952774Z DEBUG src/ui/panes/album_art.rs:80 message="Found album art" elapsed="1.249503322s" size="None"
```

This PR fallback directly to the default cover if the song file looks like a protocol instead of a path.
I refactor the logic a bit since it was called twice. Seems cleaner to me.

This is probably not the best approach but it works. I chose to check if it looks like protocol but maybe only http?s is necessary. I did not dug that much. And I'm still very new to Rust so feel free to adapt or even close this PR if you have other idea on how to handle it.