### PR TITLE
feat: enhance queue deletion confirm modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Refactor and split utils module
 - Set binary limit to 5MB
 - Disabled album arts for songs over http(s). Can be brought back by changing `album_art.disabled_protocols`
+- Improves the usability and clarity of the queue deletion confirmation modal
 
 ### Fixed
 


### PR DESCRIPTION
This change improves the usability and clarity of the queue deletion confirmation modal.

- Renamed buttons from "Save" and "Cancel" to "Confirm" and "Cancel" for clarity
- Added support for TAB to cycle through 'Confirm' and 'Cancel' buttons
- Changed the Up and Down key for the Left and Right instead
- Updated the confirmation text to include a warning about the action being irreversible
- Removed unnecessary title for a cleaner UI