### PR TITLE
[WIP] feat: time synced lyrics pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Mouse support for modal popups
 - List available decoder plugins from MPD via `ShowDecoders` action or `rmpc decoders`
 - Ability to add and instantly play song under cursor. Bound to `Confirm` action
+- A new `Lyrics` pane used to display synchronized lyrics.
 
 ### Changed
 

--- a/docs/src/content/docs/configuration/index.mdx
+++ b/docs/src/content/docs/configuration/index.mdx
@@ -56,6 +56,12 @@ Provide MPD with password upon connecting. Set to `None` or omit completely if y
 
 Directory for rmpc's cache files. Used for files downloaded for youtube and might be used for more in the future.
 
+### lyrics_dir
+
+<ConfigValue name="lyrics_dir" type="string" optional />
+
+Directory where rmpc should search for `lrc` files. Please see the [lyrics page](/rmpc/configuration/lyrics) for more information.
+
 ### theme
 
 <ConfigValue optional name="theme" type="string" />

--- a/docs/src/content/docs/configuration/lyrics.mdx
+++ b/docs/src/content/docs/configuration/lyrics.mdx
@@ -8,7 +8,8 @@ sidebar:
 ## Lyrics
 
 Rmpc supports displaying [synchronized lyrics](<https://en.wikipedia.org/wiki/LRC_(file_format)>) in the `Lyrics` pane.
-Other lyrics formats are not supported. The `lyrics_dir` must be configured for the resolution to work.
+Other lyrics formats are not supported. The `lyrics_dir` must be configured for the resolution to work. All `lrc` files
+must be on the client side.
 
 ### Lrc file resolution
 

--- a/docs/src/content/docs/configuration/lyrics.mdx
+++ b/docs/src/content/docs/configuration/lyrics.mdx
@@ -1,0 +1,35 @@
+---
+title: Lyrics
+description: Configuration of lyrics for rmpc
+sidebar:
+    order: 90
+---
+
+## Lyrics
+
+Rmpc supports displaying [synchronized lyrics](<https://en.wikipedia.org/wiki/LRC_(file_format)>) in the `Lyrics` pane.
+Other lyrics formats are not supported. The `lyrics_dir` must be configured for the resolution to work.
+
+### Lrc file resolution
+
+Lrc files are resolved by rmpc via two methods(in order):
+
+-   By indexing all the `.lrc` files in the `lyrics_dir`
+-   Same path as the song file, except with the `.lrc` file extension
+
+#### Lyrics index
+
+Rmpc will create an index of all `.lrc` files in your `lyrics_dir` on startup. Lrc files can contain metadata about
+the song which they belong to. These metadata can include artist(ar), title(ti) and album(al) as well as length.
+`Artist`, `title` and `album` have to exactly(case sensitive) match in song's and lrc's metadata for the song to match.
+If the lrc file contains `length`, it is matched to song's length plus or minus 2 seconds.
+
+#### Same path as the song file
+
+Following examples assume that your MPD's music directory is set to `/home/user/Music`.
+
+1. If your `lyrics_dir` is set to the same path as MPD's music directory
+   `/home/user/Music/artist/album/song.flac` will try to resolve `/home/user/Music/artist/album/song.lrc`
+
+2. If your `lyrics_dir` is set to a different path, ie. `/home/user/.lyrics`
+   `/home/user/Music/artist/album/song.flac` will try to resolve `/home/user/.lyrics/artist/album/song.lrc`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use itertools::Itertools;
-use std::io::Write;
+use std::{io::Write, path::PathBuf};
 
 use crate::{
     config::{cli::Command, Config},
@@ -9,7 +9,7 @@ use crate::{
         commands::{volume::Bound, IdleEvent},
         mpd_client::{Filter, MpdClient, Tag},
     },
-    shared::macros::status_error,
+    shared::{lrc::LrcIndex, macros::status_error},
     WorkRequest,
 };
 use anyhow::bail;
@@ -18,7 +18,7 @@ impl Command {
     pub fn execute<F, C>(
         self,
         client: &mut C,
-        _config: &'static Config,
+        config: &'static Config,
         mut request_work: F,
     ) -> Result<(), anyhow::Error>
     where
@@ -44,6 +44,15 @@ impl Command {
                         }
                     }
                 }
+            }
+            Command::LyricsIndex => {
+                let Some(dir) = config.lyrics_dir else {
+                    bail!("Lyrics dir is not configured");
+                };
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&LrcIndex::index(&PathBuf::from(dir))?)?
+                );
             }
             Command::Play { position: None } => client.play()?,
             Command::Play { position: Some(pos) } => client.play_pos(pos)?,

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -30,6 +30,8 @@ pub enum Command {
         #[arg(short, long, default_value = "false")]
         current: bool,
     },
+    /// Index the lyrics dir and display result, meant only for debugging purposes
+    LyricsIndex,
     /// Scan MPD's music directory for updates.
     Update {
         /// If supplied, MPD will update only the provided directory/file. If not specified, everything is updated.

--- a/src/config/tabs.rs
+++ b/src/config/tabs.rs
@@ -39,6 +39,7 @@ enum PaneTypeFile {
     Playlists,
     Search,
     AlbumArt,
+    Lyrics,
 }
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, PartialOrd, Ord)]
@@ -53,11 +54,12 @@ pub enum PaneType {
     Playlists,
     Search,
     AlbumArt,
+    Lyrics,
 }
 
 impl PaneTypeFile {
     pub fn is_focusable(self) -> bool {
-        !matches!(self, PaneTypeFile::AlbumArt)
+        !matches!(self, PaneTypeFile::AlbumArt | PaneTypeFile::Lyrics)
     }
 }
 
@@ -74,6 +76,7 @@ impl From<&PaneTypeFile> for PaneType {
             PaneTypeFile::Playlists => PaneType::Playlists,
             PaneTypeFile::Search => PaneType::Search,
             PaneTypeFile::AlbumArt => PaneType::AlbumArt,
+            PaneTypeFile::Lyrics => PaneType::Lyrics,
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,7 +7,7 @@ use crate::{
         commands::{Song, Status},
         mpd_client::MpdClient,
     },
-    shared::macros::status_warn,
+    shared::{lrc::LrcIndex, macros::status_warn},
     AppEvent, WorkRequest,
 };
 use anyhow::Result;
@@ -20,6 +20,7 @@ pub struct AppContext {
     pub app_event_sender: Sender<AppEvent>,
     pub work_sender: Sender<WorkRequest>,
     pub needs_render: Cell<bool>,
+    pub lrc_index: LrcIndex,
 }
 
 impl AppContext {
@@ -43,6 +44,7 @@ impl AppContext {
         log::info!(config:? = config; "Resolved config");
 
         Ok(Self {
+            lrc_index: LrcIndex::default(),
             config: config.leak(),
             status,
             queue,

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,8 +327,9 @@ fn handle_work_request(request: WorkRequest, config: &Config) -> Result<WorkDone
             Ok(WorkDone::YoutubeDowloaded { file_path })
         }
         WorkRequest::IndexLyrics { lyrics_dir } => {
+            let start = std::time::Instant::now();
             let index = LrcIndex::index(&PathBuf::from(lyrics_dir))?;
-            log::info!(found_count = index.len(); "Indexed lrc files");
+            log::info!(found_count = index.len(), elapsed:? = start.elapsed(); "Indexed lrc files");
             Ok(WorkDone::LyricsIndexed { index })
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@
 use std::{
     io::{Read, Write},
     ops::Sub,
+    path::PathBuf,
     sync::mpsc::TryRecvError,
     time::Duration,
 };
@@ -33,7 +34,10 @@ use log::{error, info, trace, warn};
 use mpd::{client::Client, commands::idle::IdleEvent};
 use ratatui::{prelude::Backend, Terminal};
 use rustix::path::Arg;
-use shared::dependencies::{DEPENDENCIES, FFMPEG, FFPROBE, PYTHON3, PYTHON3MUTAGEN, UEBERZUGPP, YTDLP};
+use shared::{
+    dependencies::{DEPENDENCIES, FFMPEG, FFPROBE, PYTHON3, PYTHON3MUTAGEN, UEBERZUGPP, YTDLP},
+    lrc::LrcIndex,
+};
 use shared::{
     env::ENV,
     ext::{duration::DurationExt, error::ErrorExt},
@@ -67,11 +71,13 @@ mod ui;
 #[derive(Debug)]
 pub enum WorkRequest {
     DownloadYoutube { url: String },
+    IndexLyrics { lyrics_dir: &'static str },
 }
 
 #[derive(Debug)]
 pub enum WorkDone {
     YoutubeDowloaded { file_path: String },
+    LyricsIndexed { index: LrcIndex },
 }
 
 #[derive(Debug)]
@@ -198,6 +204,7 @@ fn main() -> Result<()> {
                             log::error!(path = file_path.as_str(), err = err.to_string().as_str(); "Failed to add already downloaded youtube video to queue");
                         }
                     },
+                    Ok(WorkDone::LyricsIndexed { .. }) => {}, // lrc indexing does not make sense in cli mode
                     Err(err) => {
                         log::error!(err = err.to_string().as_str(); "Failed to handle work request");
                     }
@@ -230,6 +237,12 @@ fn main() -> Result<()> {
                 }
             };
 
+            if let Some(lyrics_dir) = config.lyrics_dir {
+                try_ret!(
+                    worker_tx.send(WorkRequest::IndexLyrics { lyrics_dir }),
+                    "Failed to request lyrics indexing"
+                );
+            }
             try_ret!(tx.send(AppEvent::RequestRender(false)), "Failed to render first frame");
 
             let mut client = try_ret!(
@@ -312,6 +325,11 @@ fn handle_work_request(request: WorkRequest, config: &Config) -> Result<WorkDone
             let file_path = ytdlp.download(&url)?;
 
             Ok(WorkDone::YoutubeDowloaded { file_path })
+        }
+        WorkRequest::IndexLyrics { lyrics_dir } => {
+            let index = LrcIndex::index(&PathBuf::from(lyrics_dir))?;
+            log::info!(found_count = index.len(); "Indexed lrc files");
+            Ok(WorkDone::LyricsIndexed { index })
         }
     }
 }
@@ -439,6 +457,12 @@ fn main_task<B: Backend + std::io::Write>(
                                 status_error!(err:?; "Failed to add '{file_path}' to the queue");
                             }
                         };
+                    }
+                    WorkDone::LyricsIndexed { index } => {
+                        context.lrc_index = index;
+                        if let Err(err) = ui.on_event(UiEvent::LyricsIndexed, &mut context, &mut client) {
+                            error!(error:? = err; "UI failed to resize event");
+                        }
                     }
                 },
                 AppEvent::WorkDone(Err(err)) => {

--- a/src/shared/lrc.rs
+++ b/src/shared/lrc.rs
@@ -1,0 +1,120 @@
+use std::{collections::HashMap, str::FromStr, time::Duration};
+
+use anyhow::{bail, Context};
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct LrcLine {
+    pub time: Duration,
+    pub content: String,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct Lrc {
+    pub lines: Vec<LrcLine>,
+    pub metadata: HashMap<String, String>,
+}
+
+impl FromStr for Lrc {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut lines = Vec::new();
+        let mut metadata = HashMap::new();
+
+        for s in s.lines() {
+            if s.is_empty() {
+                continue;
+            }
+
+            let (meta_or_time, line) = s
+                .trim()
+                .strip_prefix('[')
+                .and_then(|s| s.split_once(']'))
+                .with_context(|| format!("Invalid lrc line format: '{s}'"))?;
+
+            match meta_or_time.chars().next() {
+                Some(c) if c.is_numeric() => {
+                    let (minutes, time_rest) = meta_or_time
+                        .split_once(':')
+                        .with_context(|| format!("Invalid lrc minutes format: '{meta_or_time}'"))?;
+                    let (seconds, hundreths) = time_rest
+                        .split_once('.')
+                        .or_else(|| time_rest.split_once(':'))
+                        .with_context(|| format!("Invalid lrc seconds and hundreths format: '{time_rest}'"))?;
+
+                    let mut milis = 0;
+                    milis += minutes.parse::<u64>()? * 60 * 1000;
+                    milis += seconds.parse::<u64>()? * 1000;
+                    milis += hundreths.parse::<u64>()? * 10;
+
+                    lines.push(LrcLine {
+                        time: Duration::from_millis(milis),
+                        content: line.to_owned(),
+                    });
+                }
+                Some(_) => {
+                    let (key, value) = meta_or_time
+                        .split_once(':')
+                        .with_context(|| format!("Invalid metadata line: '{meta_or_time}'"))?;
+                    metadata.insert(key.trim().to_string(), value.trim().to_string());
+                }
+                None => {
+                    bail!("Invalid lrc metadata/timestamp: '{meta_or_time}'");
+                }
+            }
+        }
+
+        Ok(Self { lines, metadata })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::{collections::HashMap, time::Duration};
+
+    use crate::shared::lrc::{Lrc, LrcLine};
+
+    #[test]
+    fn lrc() {
+        let input = r"[t1: asdf ]
+[t2:123]
+[length: 2:23]
+[offset: -15000]
+
+[00:01.86]line with dot before hundredths
+[00:04.73]line with colon before hundredths
+[00:11.24]
+[11:16.91]line with long time";
+
+        let result: Lrc = input.parse().unwrap();
+
+        assert_eq!(
+            result,
+            Lrc {
+                lines: vec![
+                    LrcLine {
+                        time: Duration::from_millis(1860),
+                        content: "line with dot before hundredths".to_string()
+                    },
+                    LrcLine {
+                        time: Duration::from_millis(4730),
+                        content: "line with colon before hundredths".to_string()
+                    },
+                    LrcLine {
+                        time: Duration::from_millis(11240),
+                        content: String::new()
+                    },
+                    LrcLine {
+                        time: Duration::from_millis(676_910),
+                        content: "line with long time".to_string()
+                    },
+                ],
+                metadata: [("t1", "asdf"), ("t2", "123"), ("length", "2:23"), ("offset", "-15000"),]
+                    .iter()
+                    .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                    .collect::<HashMap<_, _>>()
+            }
+        );
+    }
+}

--- a/src/shared/lrc/index.rs
+++ b/src/shared/lrc/index.rs
@@ -1,0 +1,135 @@
+use std::{io::BufRead, io::BufReader, path::PathBuf, time::Duration};
+
+use anyhow::{bail, Context, Result};
+use itertools::Itertools;
+use walkdir::WalkDir;
+
+use crate::mpd::commands::Song;
+
+use super::{parse_length, Lrc};
+#[derive(Debug, Eq, PartialEq, Default)]
+pub struct LrcIndex {
+    index: Vec<LrcIndexEntry>,
+}
+
+impl LrcIndex {
+    pub fn index(lyrics_dir: &PathBuf) -> anyhow::Result<Self> {
+        Ok(Self {
+            index: WalkDir::new(lyrics_dir)
+                .into_iter()
+                .filter_ok(|entry| entry.file_name().to_string_lossy().ends_with(".lrc"))
+                .map_ok(|entry| {
+                    LrcIndexEntry::read(
+                        BufReader::new(std::fs::File::open(entry.path())?),
+                        entry.path().to_path_buf(),
+                    )
+                })
+                .flatten()
+                .filter_map(|entry| entry.transpose())
+                .try_collect()?,
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.index.len()
+    }
+
+    pub fn find_lrc_for_song(&self, song: &Song) -> Result<Option<Lrc>> {
+        match (song.artist(), song.title(), song.album(), song.duration) {
+            (Some(artist), Some(title), Some(album), length) => self.find_lrc(artist, title, album, length),
+            _ => None,
+        }
+        .map_or(Ok(None), |lrc| Ok(Some(std::fs::read_to_string(&lrc.path)?.parse()?)))
+    }
+
+    fn find_lrc(&self, artist: &str, title: &str, album: &str, length: Option<Duration>) -> Option<&LrcIndexEntry> {
+        self.index.iter().find(|entry| {
+            log::debug!(entry:?; "searching entry");
+
+            let length_matches = match (entry.length, length) {
+                (Some(entry_length), Some(length)) => entry_length.abs_diff(length) < Duration::from_secs(3),
+                _ => true,
+            };
+
+            length_matches && entry.artist == artist && entry.title == title && entry.album == album
+        })
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct LrcIndexEntry {
+    pub path: PathBuf,
+    /// ti
+    pub title: String,
+    /// ar
+    pub artist: String,
+    /// al
+    pub album: String,
+    /// length
+    pub length: Option<Duration>,
+}
+
+impl LrcIndexEntry {
+    fn read(mut read: impl BufRead, path: PathBuf) -> Result<Option<Self>> {
+        let mut title = None;
+        let mut artist = None;
+        let mut album = None;
+        let mut length = None;
+
+        let mut buf = String::new();
+        while read.read_line(&mut buf).is_ok() {
+            if buf.trim().is_empty() || buf.starts_with('#') {
+                continue;
+            }
+
+            let (metadata, rest) = buf
+                .trim()
+                .strip_prefix('[')
+                .and_then(|s| s.split_once(']'))
+                .with_context(|| format!("Invalid lrc line format: '{buf}'"))?;
+            if !rest.is_empty() {
+                break;
+            }
+
+            match metadata.chars().next() {
+                Some(c) if c.is_numeric() => {
+                    break;
+                }
+                Some(_) => {
+                    let (key, value) = metadata
+                        .split_once(':')
+                        .with_context(|| format!("Invalid metadata line: '{metadata}'"))?;
+                    match key.trim() {
+                        "ti" => title = Some(value.trim().to_string()),
+                        "ar" => artist = Some(value.trim().to_string()),
+                        "al" => album = Some(value.trim().to_string()),
+                        "length" => length = Some(parse_length(value.trim())?),
+                        _ => {}
+                    }
+                }
+                None => {
+                    bail!("Invalid lrc metadata/timestamp: '{metadata}'");
+                }
+            }
+            buf.clear();
+        }
+
+        let Some(artist) = artist else {
+            return Ok(None);
+        };
+        let Some(album) = album else {
+            return Ok(None);
+        };
+        let Some(title) = title else {
+            return Ok(None);
+        };
+
+        Ok(Some(Self {
+            path,
+            title,
+            artist,
+            album,
+            length,
+        }))
+    }
+}

--- a/src/shared/lrc/index.rs
+++ b/src/shared/lrc/index.rs
@@ -2,12 +2,13 @@ use std::{io::BufRead, io::BufReader, path::PathBuf, time::Duration};
 
 use anyhow::{bail, Context, Result};
 use itertools::Itertools;
+use serde::Serialize;
 use walkdir::WalkDir;
 
 use crate::mpd::commands::Song;
 
 use super::{parse_length, Lrc};
-#[derive(Debug, Eq, PartialEq, Default)]
+#[derive(Debug, Eq, PartialEq, Default, Serialize)]
 pub struct LrcIndex {
     index: Vec<LrcIndexEntry>,
 }
@@ -56,7 +57,7 @@ impl LrcIndex {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash, Serialize)]
 pub struct LrcIndexEntry {
     pub path: PathBuf,
     /// ti

--- a/src/shared/lrc/mod.rs
+++ b/src/shared/lrc/mod.rs
@@ -1,0 +1,15 @@
+mod index;
+mod lyrics;
+
+use std::time::Duration;
+
+use anyhow::Context;
+pub use index::LrcIndex;
+pub use lyrics::Lrc;
+
+fn parse_length(input: &str) -> anyhow::Result<Duration> {
+    let (minutes, seconds) = input.split_once(':').context("Invalid lrc length format")?;
+    let minutes: u64 = minutes.parse().context("Invalid minutes format in lrc length")?;
+    let seconds: u64 = seconds.parse().context("Invalid seconds format in lrc length")?;
+    Ok(Duration::from_secs(minutes * 60 + seconds))
+}

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -6,6 +6,7 @@ pub mod id;
 pub mod image;
 pub mod key_event;
 pub mod logging;
+pub mod lrc;
 pub mod macros;
 pub mod mouse_event;
 pub mod percent;

--- a/src/tests/fixtures/mod.rs
+++ b/src/tests/fixtures/mod.rs
@@ -7,6 +7,7 @@ use crate::{
     config::{Config, ConfigFile, Leak},
     context::AppContext,
     mpd::commands::Status,
+    shared::lrc::LrcIndex,
 };
 
 pub mod mpd_client;
@@ -34,6 +35,7 @@ pub fn app_context() -> AppContext {
         work_sender: chan2.0,
         supported_commands: HashSet::new(),
         needs_render: Cell::new(false),
+        lrc_index: LrcIndex::default(),
     }
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -537,6 +537,7 @@ impl<'ui> Ui<'ui> {
                 Panes::Search(p) => p.on_event(&mut event, client, context),
                 Panes::AlbumArtists(p) => p.on_event(&mut event, client, context),
                 Panes::AlbumArt(p) => p.on_event(&mut event, client, context),
+                Panes::Lyrics(p) => p.on_event(&mut event, client, context),
             }?;
         }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -523,6 +523,7 @@ impl<'ui> Ui<'ui> {
             UiEvent::ModalOpened => {}
             UiEvent::ModalClosed => {}
             UiEvent::Exit => {}
+            UiEvent::LyricsIndexed => {}
         }
 
         for name in context.config.tabs.active_panes {
@@ -565,6 +566,7 @@ pub enum UiEvent {
     ModalOpened,
     ModalClosed,
     Exit,
+    LyricsIndexed,
 }
 
 impl TryFrom<IdleEvent> for UiEvent {

--- a/src/ui/panes/lyrics.rs
+++ b/src/ui/panes/lyrics.rs
@@ -1,0 +1,87 @@
+use anyhow::Result;
+use ratatui::{
+    layout::{Constraint, Layout, Rect},
+    style::Style,
+    text::Text,
+    Frame,
+};
+
+use crate::{
+    context::AppContext,
+    mpd::mpd_client::MpdClient,
+    shared::{key_event::KeyEvent, lrc::Lrc},
+    ui::UiEvent,
+};
+
+use super::Pane;
+
+#[derive(Debug)]
+pub struct LyricsPane {
+    current_lyrics: Option<Lrc>,
+}
+
+impl LyricsPane {
+    pub fn new(_context: &AppContext) -> Self {
+        Self { current_lyrics: None }
+    }
+}
+
+impl Pane for LyricsPane {
+    fn render(&mut self, frame: &mut Frame, area: Rect, context: &AppContext) -> Result<()> {
+        let Some(lrc) = &self.current_lyrics else { return Ok(()) };
+
+        let elapsed = context.status.elapsed;
+        let Some((current_line_idx, _)) = lrc
+            .lines
+            .iter()
+            .enumerate()
+            .min_by(|a, b| a.1.time.abs_diff(elapsed).cmp(&b.1.time.abs_diff(elapsed)))
+        else {
+            return Ok(());
+        };
+
+        let rows = area.height;
+        let areas = Layout::vertical((0..rows).map(|_| Constraint::Length(1))).split(area);
+        let middle_row = rows / 2;
+
+        for i in 0..rows {
+            let i = i as usize;
+            let Some(idx) = (current_line_idx + i).checked_sub(middle_row as usize) else {
+                continue;
+            };
+            let Some(line) = lrc.lines.get(idx) else {
+                continue;
+            };
+
+            let darken = (middle_row as usize).abs_diff(i) > 0;
+
+            let p = Text::from(line.content.clone())
+                .alignment(ratatui::layout::Alignment::Center)
+                .style(if darken {
+                    Style::default().fg(context.config.theme.text_color.unwrap_or_default())
+                } else {
+                    context.config.theme.highlighted_item_style
+                });
+
+            frame.render_widget(p, areas[i]);
+        }
+
+        Ok(())
+    }
+
+    fn on_event(&mut self, event: &mut UiEvent, _client: &mut impl MpdClient, _context: &AppContext) -> Result<()> {
+        if let UiEvent::Player = event {
+            // self.current_lyrics = load_lyrics_somehow();
+        }
+        Ok(())
+    }
+
+    fn handle_action(
+        &mut self,
+        _event: &mut KeyEvent,
+        _client: &mut impl MpdClient,
+        _context: &AppContext,
+    ) -> Result<()> {
+        Ok(())
+    }
+}

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -8,6 +8,7 @@ use directories::DirectoriesPane;
 use either::Either;
 #[cfg(debug_assertions)]
 use logs::LogsPane;
+use lyrics::LyricsPane;
 use playlists::PlaylistsPane;
 use queue::QueuePane;
 use ratatui::{
@@ -41,6 +42,7 @@ pub mod artists;
 pub mod directories;
 #[cfg(debug_assertions)]
 pub mod logs;
+pub mod lyrics;
 pub mod playlists;
 pub mod queue;
 pub mod search;
@@ -57,6 +59,7 @@ pub enum Panes<'a> {
     Playlists(&'a mut PlaylistsPane),
     Search(&'a mut SearchPane),
     AlbumArt(&'a mut AlbumArtPane),
+    Lyrics(&'a mut LyricsPane),
 }
 
 #[derive(Debug)]
@@ -71,6 +74,7 @@ pub struct PaneContainer {
     pub playlists: PlaylistsPane,
     pub search: SearchPane,
     pub album_art: AlbumArtPane,
+    pub lyrics: LyricsPane,
 }
 
 impl PaneContainer {
@@ -86,6 +90,7 @@ impl PaneContainer {
             playlists: PlaylistsPane::new(context),
             search: SearchPane::new(context),
             album_art: AlbumArtPane::new(context),
+            lyrics: LyricsPane::new(context),
         }
     }
 
@@ -101,6 +106,7 @@ impl PaneContainer {
             PaneType::Playlists => Panes::Playlists(&mut self.playlists),
             PaneType::Search => Panes::Search(&mut self.search),
             PaneType::AlbumArt => Panes::AlbumArt(&mut self.album_art),
+            PaneType::Lyrics => Panes::Lyrics(&mut self.lyrics),
         }
     }
 }

--- a/src/ui/tab_screen.rs
+++ b/src/ui/tab_screen.rs
@@ -63,6 +63,7 @@ macro_rules! screen_call {
             Panes::Playlists(s) => s.$fn($($param),+),
             Panes::Search(s) => s.$fn($($param),+),
             Panes::AlbumArt(s) => s.$fn($($param),+),
+            Panes::Lyrics(s) => s.$fn($($param),+),
         }
     }
 }


### PR DESCRIPTION
For now its just a simple unfocusable pane like `AlbumArt`

<details>
<summary>Quick preview</summary>

![image](https://github.com/user-attachments/assets/73edbd0d-c0e8-47fc-bddf-714e71f41da3)
</details>

- [x] Determine where we want to store lyrics and how to pair them with the current song
- [x] Load lyrics from file
- [x] Handling of lyrics offset from metadata as well
- [x] Maybe scan `lyrics_dir` and try to match by metadata
- [x] Docs, examples
- [x] ~~Maybe render more often? Currently render happens only on update interval which results in potential delay in switching of the active line~~ Dont think I am going to do that unless there absolutely is a need to. Decreasing update interval works.
