### PR TITLE
fix: recreate read stream on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - Scrolloff issues in Playlists pane after rename/move
 - Few typos in UI and internal messages
 - Click to select and rendering issues in SongInfo and Decoder modals
+- Read stream not being emptied after encountering error while reading MPD's response
 
 ### Deprecated
 

--- a/src/mpd/client.rs
+++ b/src/mpd/client.rs
@@ -212,6 +212,12 @@ impl<'name> Client<'name> {
     pub fn send<'cmd>(&mut self, command: &'cmd str) -> Result<ProtoClient<'cmd, '_, Self>, MpdError> {
         ProtoClient::new(command, self)
     }
+
+    fn clear_read_buf(&mut self) -> Result<()> {
+        log::trace!("Reinitialized read buffer");
+        self.rx = BufReader::new(self.stream.try_clone()?);
+        Ok(())
+    }
 }
 
 impl<'name> SocketClient for Client<'name> {
@@ -225,5 +231,9 @@ impl<'name> SocketClient for Client<'name> {
 
     fn read(&mut self) -> &mut impl BufRead {
         &mut self.rx
+    }
+
+    fn clear_read_buf(&mut self) -> Result<()> {
+        self.clear_read_buf()
     }
 }


### PR DESCRIPTION
Fixes issue where read buffer was not completely emptied after encountering error while reading MPD's response which resulted in spectacular borkedness of basically everything