### PR TITLE
feat: add confirmation modal for playlist deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Disabled album arts for songs over http(s). Can be brought back by changing `album_art.disabled_protocols`
 - Improves the usability and clarity of the queue deletion confirmation modal
 - `width_percent` config option in `song_table_format`. Replaced by `width`.
+- Deletion of a playlist now requires user confirmation
 
 ### Fixed
 

--- a/src/ui/modals/confirm_playlist_delete.rs
+++ b/src/ui/modals/confirm_playlist_delete.rs
@@ -1,0 +1,185 @@
+use anyhow::Result;
+use ratatui::{
+    layout::Alignment,
+    prelude::{Constraint, Layout},
+    style::Style,
+    symbols::{self, border},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+    Frame,
+};
+
+use crate::{
+    config::keys::{CommonAction, GlobalAction},
+    context::AppContext,
+    mpd::{client::Client, mpd_client::MpdClient},
+    shared::{
+        key_event::KeyEvent,
+        macros::pop_modal,
+        mouse_event::{MouseEvent, MouseEventKind},
+    },
+    ui::{
+        status_info,
+        widgets::button::{Button, ButtonGroup, ButtonGroupState},
+    },
+};
+
+use super::RectExt;
+
+use super::Modal;
+
+const BUTTON_GROUP_SYMBOLS: symbols::border::Set = symbols::border::Set {
+    top_right: symbols::line::NORMAL.vertical_left,
+    top_left: symbols::line::NORMAL.vertical_right,
+    ..symbols::border::ROUNDED
+};
+
+#[derive(Debug)]
+pub struct ConfirmPlaylistDeleteModal<'a> {
+    playlist: String,
+    button_group_state: ButtonGroupState,
+    button_group: ButtonGroup<'a>,
+}
+
+impl ConfirmPlaylistDeleteModal<'_> {
+    pub fn new(playlist: String, context: &AppContext) -> Self {
+        let mut button_group_state = ButtonGroupState::default();
+        let buttons = vec![Button::default().label("Delete"), Button::default().label("Cancel")];
+        button_group_state.set_button_count(buttons.len());
+        let button_group = ButtonGroup::default()
+            .active_style(context.config.theme.current_item_style)
+            .inactive_style(context.config.as_text_style())
+            .buttons(buttons)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_set(BUTTON_GROUP_SYMBOLS)
+                    .border_style(context.config.as_border_style()),
+            );
+
+        Self {
+            playlist,
+            button_group_state,
+            button_group,
+        }
+    }
+}
+
+impl Modal for ConfirmPlaylistDeleteModal<'_> {
+    fn render(&mut self, frame: &mut Frame, app: &mut AppContext) -> Result<()> {
+        let popup_area = frame.area().centered_exact(45, 6);
+        frame.render_widget(Clear, popup_area);
+
+        if let Some(bg_color) = app.config.theme.modal_background_color {
+            frame.render_widget(Block::default().style(Style::default().bg(bg_color)), popup_area);
+        }
+
+        let block = Block::default()
+            .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
+            .border_set(border::ROUNDED)
+            .border_style(app.config.as_border_style())
+            .title_alignment(ratatui::prelude::Alignment::Center);
+
+        let paragraph = Paragraph::new("Are you sure you want to delete this playlist? This action cannot be undone.")
+            .style(app.config.as_text_style())
+            .wrap(Wrap { trim: true })
+            .block(block.clone())
+            .alignment(Alignment::Center);
+
+        let [content_area, buttons_area] =
+            *Layout::vertical([Constraint::Min(3), Constraint::Length(3)]).split(popup_area)
+        else {
+            return Ok(());
+        };
+
+        frame.render_widget(paragraph, content_area);
+        frame.render_stateful_widget(&mut self.button_group, buttons_area, &mut self.button_group_state);
+        Ok(())
+    }
+
+    fn handle_key(&mut self, key: &mut KeyEvent, client: &mut Client<'_>, context: &mut AppContext) -> Result<()> {
+        if let Some(action) = key.as_common_action(context) {
+            match action {
+                CommonAction::Right => {
+                    self.button_group_state.next();
+                    context.render()?;
+                }
+                CommonAction::Left => {
+                    self.button_group_state.prev();
+                    context.render()?;
+                }
+                CommonAction::Close => {
+                    self.button_group_state = ButtonGroupState::default();
+                    pop_modal!(context);
+                }
+                CommonAction::Confirm => {
+                    if self.button_group_state.selected == 0 {
+                        client.delete_playlist(&self.playlist)?;
+                        status_info!("Playlist '{}' deleted", &self.playlist);
+                        context.render()?;
+                    }
+                    self.button_group_state = ButtonGroupState::default();
+                    pop_modal!(context);
+                }
+                _ => {}
+            }
+        } else if let Some(action) = key.as_global_action(context) {
+            match action {
+                GlobalAction::NextTab => {
+                    self.button_group_state.next();
+                    context.render()?;
+                }
+                GlobalAction::PreviousTab => {
+                    self.button_group_state.prev();
+                    context.render()?;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    fn handle_mouse_event(
+        &mut self,
+        event: MouseEvent,
+        client: &mut Client<'_>,
+        context: &mut AppContext,
+    ) -> Result<()> {
+        match event.kind {
+            MouseEventKind::LeftClick => {
+                if let Some(idx) = self.button_group.get_button_idx_at(event.into()) {
+                    self.button_group_state.select(idx);
+                    context.render()?;
+                }
+            }
+            MouseEventKind::DoubleClick => {
+                match self.button_group.get_button_idx_at(event.into()) {
+                    Some(0) => {
+                        client.delete_playlist(&self.playlist)?;
+                        status_info!("Playlist '{}' deleted", &self.playlist);
+                        pop_modal!(context);
+                    }
+                    Some(_) => {
+                        pop_modal!(context);
+                    }
+                    None => {}
+                };
+            }
+            MouseEventKind::MiddleClick => {}
+            MouseEventKind::RightClick => {}
+            MouseEventKind::ScrollUp => {
+                if self.button_group.get_button_idx_at(event.into()).is_some() {
+                    self.button_group_state.prev();
+                    context.render()?;
+                }
+            }
+            MouseEventKind::ScrollDown => {
+                if self.button_group.get_button_idx_at(event.into()).is_some() {
+                    self.button_group_state.next();
+                    context.render()?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/ui/modals/mod.rs
+++ b/src/ui/modals/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 
 pub mod add_to_playlist;
 pub mod confirm_modal;
+pub mod confirm_playlist_delete;
 pub mod confirm_queue_clear;
 pub mod decoders;
 pub mod keybinds;

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -22,7 +22,7 @@ use crate::{
     ui::{
         browser::{BrowserPane, MoveDirection},
         dirstack::{DirStack, DirStackItem},
-        modals::rename_playlist::RenamePlaylistModal,
+        modals::{confirm_playlist_delete::ConfirmPlaylistDeleteModal, rename_playlist::RenamePlaylistModal},
         widgets::browser::Browser,
         UiEvent,
     },
@@ -253,10 +253,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
     fn delete(&self, item: &DirOrSong, index: usize, client: &mut impl MpdClient, context: &AppContext) -> Result<()> {
         match item {
             DirOrSong::Dir { name: d, .. } => {
-                client.delete_playlist(d)?;
-                status_info!("Playlist '{d}' deleted");
-
-                context.render()?;
+                modal!(context, ConfirmPlaylistDeleteModal::new(d.clone(), context));
             }
             DirOrSong::Song(s) => {
                 let Some(DirOrSong::Dir { name: playlist, .. }) = self.stack.previous().selected() else {


### PR DESCRIPTION
Similar to the queue list deletion behavior, a playlist can contain a **lot** of songs; hence, the confirmation modal. 

This prevents users like me to fat-fingering this action and delete its beloved playlist ;)