### PR TITLE
fix: adjust scrollbar position in browser panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to this project will be documented in this file.
 - Unchecked panic inside the volume widget when volume exceeds certain value
 - Several things that should have happened on song change were happening on every `Player` event, ie. seeking
 - Improved handling of errors while reading MPD's response
+- Adjust scrollbar position in browser panes when `track` symbol is empty
 
 ### Deprecated
 

--- a/src/ui/widgets/browser.rs
+++ b/src/ui/widgets/browser.rs
@@ -52,9 +52,11 @@ where
 
     #[allow(clippy::unwrap_used)]
     fn render(self, area: ratatui::prelude::Rect, buf: &mut ratatui::prelude::Buffer, state: &mut Self::State) {
+        let scrollbar_track = self.config.theme.scrollbar.symbols[0];
+
         let scrollbar_margin = Margin {
             vertical: 0,
-            horizontal: 0,
+            horizontal: scrollbar_track.is_empty().into(),
         };
         let previous = state.previous().to_list_items(self.config);
         let current = state.current().to_list_items(self.config);


### PR DESCRIPTION
In browser panes, the scrollbar position overlaps the pane separator.
This fits nicely with defaults symbols.

However, for a more minimalist approach with empty symbols, eg.
`scrollbar: (symbols: ["", "│", "", ""])`, the scrollbar becomes
invisible or bearly visible depending on the chosen character.

Assume that if the `track` symbol is empty, we expect the scrollbar
to be visible but not overlap with the pane separator.

Solution: Shift the horizontal position to the left.

This ensures the scrollbar remains visible and properly positioned
in all cases, matching the queue appareance.
