### PR TITLE
refactor: image protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Album art with kitty image protocol is no longer centered and is in line with the other image backends
+
 ### Fixed
 
 - `ToggleConsume` and `ToggleSingle` causing playback to stop
 - Styling not being applied to Bitrate and Crossfade props
+- Refactored and greatly simplified image backends
 
 ## [0.7.0] - 2024-12-24
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -72,7 +72,7 @@ impl AppContext {
         }
 
         self.needs_render.replace(true);
-        self.app_event_sender.send(AppEvent::RequestRender(false))
+        self.app_event_sender.send(AppEvent::RequestRender)
     }
 
     pub fn finish_frame(&self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,10 +195,7 @@ fn main() -> Result<()> {
                     "Failed to request lyrics indexing"
                 );
             }
-            try_ret!(
-                event_tx.send(AppEvent::RequestRender(false)),
-                "Failed to render first frame"
-            );
+            try_ret!(event_tx.send(AppEvent::RequestRender), "Failed to render first frame");
 
             let mut client = try_ret!(
                 Client::init(config.address, config.password, "command"),

--- a/src/shared/events.rs
+++ b/src/shared/events.rs
@@ -48,7 +48,7 @@ pub(crate) enum AppEvent {
     Status(String, Level),
     Log(Vec<u8>),
     IdleEvent(IdleEvent),
-    RequestRender(bool),
+    RequestRender,
     Resized { columns: u16, rows: u16 },
     WorkDone(Result<WorkDone>),
     UiEvent(UiAppEvent),

--- a/src/shared/ext.rs
+++ b/src/shared/ext.rs
@@ -41,15 +41,18 @@ pub mod duration {
     }
 }
 
+#[allow(unused)]
 pub mod mpsc {
+    use crossbeam::channel::{Receiver, RecvError, TryRecvError};
+
     pub trait RecvLast<T> {
-        fn recv_last(&self) -> Result<T, std::sync::mpsc::RecvError>;
-        fn try_recv_last(&self) -> Result<T, std::sync::mpsc::TryRecvError>;
+        fn recv_last(&self) -> Result<T, RecvError>;
+        fn try_recv_last(&self) -> Result<T, TryRecvError>;
     }
 
-    impl<T> RecvLast<T> for std::sync::mpsc::Receiver<T> {
+    impl<T> RecvLast<T> for Receiver<T> {
         /// recv the last message in the channel and drop all the other ones
-        fn recv_last(&self) -> Result<T, std::sync::mpsc::RecvError> {
+        fn recv_last(&self) -> Result<T, RecvError> {
             self.recv().map(|data| {
                 let mut result = data;
                 while let Ok(newer_data) = self.try_recv() {
@@ -60,7 +63,7 @@ pub mod mpsc {
         }
 
         /// recv the last message in the channel in a non-blocking manner and drop all the other ones
-        fn try_recv_last(&self) -> Result<T, std::sync::mpsc::TryRecvError> {
+        fn try_recv_last(&self) -> Result<T, TryRecvError> {
             self.try_recv().map(|data| {
                 let mut result = data;
                 while let Ok(newer_data) = self.try_recv() {

--- a/src/shared/macros.rs
+++ b/src/shared/macros.rs
@@ -82,8 +82,16 @@ macro_rules! pop_modal {
     }};
 }
 
+macro_rules! csi_move {
+    ( $buf:ident, $x:expr, $y:expr ) => {
+        write!($buf, "\x1b[{};{}H", $y + 1, $x + 1)
+    };
+}
+
 pub(crate) use modal;
 pub(crate) use pop_modal;
+
+pub(crate) use csi_move;
 
 pub(crate) use status_error;
 pub(crate) use status_info;

--- a/src/ui/image/facade.rs
+++ b/src/ui/image/facade.rs
@@ -118,16 +118,6 @@ impl AlbumArtFacade {
         Ok(())
     }
 
-    pub fn resize(&mut self) {
-        match &mut self.image_state {
-            ImageState::Kitty(state) => state.resize(),
-            ImageState::Ueberzug(ueberzug) => ueberzug.resize(),
-            ImageState::Iterm2(iterm2) => iterm2.resize(),
-            ImageState::Sixel(s) => s.resize(),
-            ImageState::None => {}
-        }
-    }
-
     pub fn cleanup(&mut self) -> Result<()> {
         let state = std::mem::take(&mut self.image_state);
         IS_SHOWING.store(false, Ordering::Relaxed);
@@ -141,12 +131,7 @@ impl AlbumArtFacade {
     }
 
     pub fn set_size(&mut self, area: Rect) {
-        if self.last_size == area {
-            self.last_size = area;
-        } else {
-            self.last_size = area;
-            self.resize();
-        }
+        self.last_size = area;
     }
 }
 

--- a/src/ui/image/facade.rs
+++ b/src/ui/image/facade.rs
@@ -55,11 +55,11 @@ impl AlbumArtFacade {
 
     pub fn show_default(&mut self) -> Result<()> {
         self.current_album_art = None;
-
-        let data = Arc::clone(&self.default_album_art);
         IS_SHOWING.store(true, Ordering::Relaxed);
 
+        let data = Arc::clone(&self.default_album_art);
         log::debug!(bytes = data.len(), area:? = self.last_size; "Displaying default image");
+
         match &mut self.image_state {
             ImageState::Kitty(kitty) => kitty.show(data, self.last_size),
             ImageState::Ueberzug(ueberzug) => ueberzug.show(data, self.last_size),
@@ -75,10 +75,11 @@ impl AlbumArtFacade {
             return Ok(());
         };
 
-        let data = Arc::clone(current_album_art);
         IS_SHOWING.store(true, Ordering::Relaxed);
 
+        let data = Arc::clone(current_album_art);
         log::debug!(bytes = data.len(), area:? = self.last_size; "Displaying current image again",);
+
         match &mut self.image_state {
             ImageState::Kitty(kitty) => kitty.show(data, self.last_size),
             ImageState::Ueberzug(ueberzug) => ueberzug.show(data, self.last_size),
@@ -89,9 +90,7 @@ impl AlbumArtFacade {
     }
 
     pub fn show(&mut self, data: Vec<u8>) -> Result<()> {
-        if IS_SHOWING.swap(true, Ordering::Relaxed) {
-            return Ok(());
-        }
+        IS_SHOWING.store(true, Ordering::Relaxed);
 
         log::debug!(bytes = data.len(), area:? = self.last_size; "New image received",);
         let data = Arc::new(data);

--- a/src/ui/image/iterm2.rs
+++ b/src/ui/image/iterm2.rs
@@ -1,19 +1,17 @@
 use anyhow::{bail, Result};
 use base64::Engine;
+use crossbeam::channel::{unbounded, Sender};
 use crossterm::{
     cursor::{MoveTo, RestorePosition, SavePosition},
     queue,
-    style::{Colors, SetColors},
+    style::Colors,
 };
 use std::{
     io::Write,
-    sync::{
-        mpsc::{channel, Receiver, Sender},
-        Arc,
-    },
+    sync::{atomic::Ordering, Arc},
 };
 
-use ratatui::{buffer::Buffer, layout::Rect, style::Color};
+use ratatui::{layout::Rect, style::Color};
 
 use crate::{
     config::Size,
@@ -21,11 +19,12 @@ use crate::{
         ext::mpsc::RecvLast,
         image::{get_gif_frames, get_image_area_size_px, jpg_encode, resize_image},
         macros::try_cont,
+        tmux::tmux_write,
     },
-    tmux,
+    ui::image::{clear_area, facade::IS_SHOWING},
 };
 
-use super::ImageProto;
+use super::Backend;
 
 #[derive(Debug)]
 struct EncodedData {
@@ -33,243 +32,125 @@ struct EncodedData {
     size: usize,
     width: u32,
     height: u32,
-    id: u64,
 }
 
 #[derive(Debug)]
 struct DataToEncode {
-    width: u16,
-    height: u16,
-    wants_full_render: bool,
+    area: Rect,
     data: Arc<Vec<u8>>,
-    request_id: u64,
 }
 
 #[derive(Debug)]
 pub struct Iterm2 {
-    image_data_to_encode: Arc<Vec<u8>>,
-    encoded_data: Option<EncodedData>,
-    default_art: Arc<Vec<u8>>,
     sender: Sender<DataToEncode>,
-    encoded_data_receiver: Receiver<EncodedData>,
-    state: State,
-    last_id: u64,
+    colors: Colors,
 }
 
-#[derive(Debug)]
-enum State {
-    Initial,
-    Resize,
-    Rerender,
-    Encoding,
-    Showing,
-    Encoded,
-}
-
-impl ImageProto for Iterm2 {
-    fn render(
-        &mut self,
-        _buf: &mut Buffer,
-        Rect {
-            x: _,
-            y: _,
-            width,
-            height,
-        }: Rect,
-    ) -> Result<()> {
-        match self.state {
-            State::Initial => {
-                self.sender.send(DataToEncode {
-                    width,
-                    height,
-                    wants_full_render: false,
-                    data: Arc::clone(&self.image_data_to_encode),
-                    request_id: self.last_id,
-                })?;
-                self.state = State::Encoding;
-            }
-            State::Resize => {
-                self.sender.send(DataToEncode {
-                    width,
-                    height,
-                    wants_full_render: true,
-                    data: Arc::clone(&self.image_data_to_encode),
-                    request_id: self.last_id,
-                })?;
-                self.state = State::Encoding;
-            }
-            _ => {
-                if let Ok(data) = self.encoded_data_receiver.try_recv_last() {
-                    self.encoded_data = Some(data);
-                    self.state = State::Encoded;
-                }
-            }
-        }
-        Ok(())
+impl Backend for Iterm2 {
+    fn hide(&mut self, size: Rect) -> Result<()> {
+        clear_area(&mut std::io::stdout().lock(), self.colors, size)
     }
 
-    fn post_render(
-        &mut self,
-        _buf: &mut Buffer,
-        bg_color: Option<Color>,
-        Rect { x, y, width, height }: Rect,
-    ) -> Result<()> {
-        if !matches!(self.state, State::Encoded | State::Rerender) {
-            return Ok(());
-        }
-
-        if let Some(data) = &self.encoded_data {
-            self.clear_area(bg_color, Rect { x, y, width, height })?;
-
-            let EncodedData {
-                content,
-                size,
-                width,
-                height,
-                id,
-            } = data;
-
-            if *id != self.last_id {
-                return Ok(());
-            }
-
-            let mut stdout = std::io::stdout();
-            queue!(stdout, SavePosition)?;
-            queue!(stdout, MoveTo(x, y))?;
-
-            if tmux::is_inside_tmux() {
-                write!(stdout, "{}", &format!("\x1bPtmux;\x1b\x1b]1337;File=inline=1;size={size};width={width}px;height={height}px;preserveAspectRatio=1;doNotMoveCursor=1:{content}\x07\x1b\\"))?;
-            } else {
-                write!(stdout, "{}", &format!("\x1b]1337;File=inline=1;size={size};width={width}px;height={height}px;preserveAspectRatio=1;doNotMoveCursor=1:{content}\x07"))?;
-            }
-            queue!(stdout, RestorePosition)?;
-
-            self.state = State::Showing;
-        };
-        Ok(())
+    fn show(&mut self, data: Arc<Vec<u8>>, area: Rect) -> Result<()> {
+        Ok(self.sender.send(DataToEncode { area, data })?)
     }
 
-    fn hide(&mut self, bg_color: Option<Color>, size: Rect) -> Result<()> {
-        self.clear_area(bg_color, size)?;
-        Ok(())
-    }
-
-    fn show(&mut self) {
-        if self.encoded_data.is_some() {
-            self.state = State::Rerender;
-        } else {
-            self.state = State::Initial;
-        }
-    }
-
-    fn resize(&mut self) {
-        self.state = State::Resize;
-    }
-
-    fn set_data(&mut self, data: Option<Vec<u8>>) -> Result<()> {
-        self.last_id += 1;
-        if let Some(data) = data {
-            self.image_data_to_encode = Arc::new(data);
-        } else {
-            self.image_data_to_encode = Arc::clone(&self.default_art);
-        }
-
-        self.state = State::Initial;
-        self.encoded_data = None;
-        Ok(())
-    }
+    fn resize(&mut self) {}
 }
 
 impl Iterm2 {
-    pub fn new(default_art: &[u8], max_size: Size, request_render: impl Fn(bool) + Send + 'static) -> Self {
-        let (sender, receiver) = channel::<DataToEncode>();
-        let (encoded_tx, encoded_rx) = channel::<EncodedData>();
+    pub fn new(max_size: Size, bg_color: Option<Color>) -> Self {
+        let (sender, receiver) = unbounded::<DataToEncode>();
+        let colors = Colors {
+            background: bg_color.map(Into::into),
+            foreground: None,
+        };
 
         std::thread::Builder::new()
             .name("iterm2".to_string())
-            .spawn(move || loop {
-                if let Ok(DataToEncode {
-                    width,
-                    height,
-                    wants_full_render,
-                    data,
-                    request_id,
-                }) = receiver.recv_last()
-                {
+            .spawn(move || {
+                let mut pending_req = None;
+                loop {
+                    let Ok(DataToEncode { area, data }) =
+                        pending_req.take().ok_or(()).or_else(|()| receiver.recv_last())
+                    else {
+                        continue;
+                    };
+
                     let encoded = try_cont!(
-                        Iterm2::encode(width, height, &data, max_size, request_id),
+                        encode(area.width, area.height, &data, max_size),
                         "Failed to encode data"
                     );
-                    try_cont!(encoded_tx.send(encoded), "Failed to send encoded data");
 
-                    request_render(wants_full_render);
+                    let mut w = std::io::stdout().lock();
+                    if !IS_SHOWING.load(Ordering::Relaxed) {
+                        log::trace!("Not showing image because its not supposed to be displayed anymore");
+                        continue;
+                    }
+
+                    if let Ok(msg) = receiver.try_recv_last() {
+                        pending_req = Some(msg);
+                        log::trace!("Skipping image because another one is waiting in the queue");
+                        continue;
+                    };
+
+                    try_cont!(clear_area(&mut w, colors, area), "Failed to clear iterm2 image area");
+                    try_cont!(display(&mut w, encoded, area), "Failed to display iterm2 image");
                 }
             })
             .expect("iterm2 thread to be spawned");
-        let default_art = Arc::new(default_art.to_vec());
 
-        Self {
-            image_data_to_encode: Arc::clone(&default_art),
-            default_art,
-            encoded_data: None,
-            sender,
-            encoded_data_receiver: encoded_rx,
-            state: State::Initial,
-            last_id: 0,
-        }
+        Self { sender, colors }
     }
+}
 
-    fn encode(width: u16, height: u16, data: &[u8], max_size_px: Size, id: u64) -> Result<EncodedData> {
-        let start = std::time::Instant::now();
-        let (iwidth, iheight) = match get_image_area_size_px(width, height, max_size_px) {
+fn display(w: &mut impl Write, data: EncodedData, area: Rect) -> Result<()> {
+    let EncodedData {
+        content,
+        size,
+        width,
+        height,
+    } = data;
+
+    queue!(w, SavePosition)?;
+    queue!(w, MoveTo(area.x, area.y))?;
+
+    tmux_write!(w, "\x1b]1337;File=inline=1;size={size};width={width}px;height={height}px;preserveAspectRatio=1;doNotMoveCursor=1:{content}\x07")?;
+    queue!(w, RestorePosition)?;
+
+    Ok(())
+}
+
+fn encode(width: u16, height: u16, data: &[u8], max_size_px: Size) -> Result<EncodedData> {
+    let start = std::time::Instant::now();
+    let (iwidth, iheight) = match get_image_area_size_px(width, height, max_size_px) {
+        Ok(v) => v,
+        Err(err) => {
+            bail!("Failed to get image size, err: {}", err);
+        }
+    };
+
+    let (len, data) = if get_gif_frames(data)?.is_some() {
+        log::debug!("encoding animated gif");
+        (data.len(), base64::engine::general_purpose::STANDARD.encode(data))
+    } else {
+        let image = match resize_image(data, iwidth, iheight) {
             Ok(v) => v,
             Err(err) => {
-                bail!("Failed to get image size, err: {}", err);
+                bail!("Failed to resize image, err: {}", err);
             }
         };
-
-        let (len, data) = if get_gif_frames(data)?.is_some() {
-            log::debug!("encoding animated gif");
-            (data.len(), base64::engine::general_purpose::STANDARD.encode(data))
-        } else {
-            let image = match resize_image(data, iwidth, iheight) {
-                Ok(v) => v,
-                Err(err) => {
-                    bail!("Failed to resize image, err: {}", err);
-                }
-            };
-            let Ok(jpg) = jpg_encode(&image) else {
-                bail!("Failed to encode image as jpg")
-            };
-            (jpg.len(), base64::engine::general_purpose::STANDARD.encode(&jpg))
+        let Ok(jpg) = jpg_encode(&image) else {
+            bail!("Failed to encode image as jpg")
         };
+        (jpg.len(), base64::engine::general_purpose::STANDARD.encode(&jpg))
+    };
 
-        log::debug!(id, compressed_bytes = data.len(), image_bytes = len, elapsed:? = start.elapsed(); "encoded data");
-        Ok(EncodedData {
-            content: data,
-            size: len,
-            width: u32::from(iwidth),
-            height: u32::from(iheight),
-            id,
-        })
-    }
-
-    fn clear_area(&self, bg_color: Option<Color>, Rect { x, y, width, height }: Rect) -> Result<()> {
-        let mut stdout = std::io::stdout();
-        queue!(stdout, SavePosition)?;
-
-        let set_color = SetColors(Colors {
-            background: bg_color.map(|c| c.into()),
-            foreground: None,
-        });
-        for y in y..y + height {
-            for x in x..x + width {
-                queue!(stdout, MoveTo(x, y))?;
-                queue!(stdout, set_color)?;
-                write!(stdout, " ")?;
-            }
-        }
-        queue!(stdout, RestorePosition)?;
-        Ok(())
-    }
+    log::debug!(compressed_bytes = data.len(), image_bytes = len, elapsed:? = start.elapsed(); "encoded data");
+    Ok(EncodedData {
+        content: data,
+        size: len,
+        width: u32::from(iwidth),
+        height: u32::from(iheight),
+    })
 }

--- a/src/ui/image/iterm2.rs
+++ b/src/ui/image/iterm2.rs
@@ -54,8 +54,6 @@ impl Backend for Iterm2 {
     fn show(&mut self, data: Arc<Vec<u8>>, area: Rect) -> Result<()> {
         Ok(self.sender.send(DataToEncode { area, data })?)
     }
-
-    fn resize(&mut self) {}
 }
 
 impl Iterm2 {

--- a/src/ui/image/kitty.rs
+++ b/src/ui/image/kitty.rs
@@ -42,8 +42,6 @@ impl Backend for Kitty {
         Ok(self.sender.send((data, area))?)
     }
 
-    fn resize(&mut self) {}
-
     fn cleanup(self: Box<Self>, area: Rect) -> Result<()> {
         clear_area(&mut std::io::stdout().lock(), self.colors, area)
     }

--- a/src/ui/image/kitty.rs
+++ b/src/ui/image/kitty.rs
@@ -1,17 +1,20 @@
 use anyhow::{Context, Result};
+use crossbeam::channel::{unbounded, Sender};
+use crossterm::{
+    execute,
+    style::{Colors, SetColors},
+};
 use itertools::Itertools;
 use std::{
     io::Write,
-    sync::{
-        mpsc::{channel, Receiver, Sender},
-        Arc,
-    },
+    sync::{atomic::Ordering, Arc},
     time::Instant,
 };
 
+use crate::shared::tmux::tmux_write;
 use base64::Engine;
 use flate2::Compression;
-use ratatui::prelude::{Buffer, Rect};
+use ratatui::prelude::{Color, Rect};
 
 use crate::{
     config::Size,
@@ -20,127 +23,96 @@ use crate::{
         image::{get_gif_frames, get_image_area_size_px, resize_image},
         macros::status_error,
     },
-    tmux,
 };
 
-use super::ImageProto;
+use super::{csi_move, facade::IS_SHOWING, Backend};
 
 #[derive(Debug)]
-pub struct KittyImageState {
-    idx: u32,
-    image: Arc<Vec<u8>>,
-    default_art: Arc<Vec<u8>>,
-    needs_transfer: bool,
-    transfer_request_channel: Sender<(Arc<Vec<u8>>, u16, u16)>,
-    compression_finished_receiver: Receiver<Data>,
+pub struct Kitty {
+    sender: Sender<(Arc<Vec<u8>>, Rect)>,
+    colors: Colors,
 }
 
-impl ImageProto for KittyImageState {
-    fn render(&mut self, buf: &mut Buffer, rect: Rect) -> Result<()> {
-        let state = self;
-        let height = rect.height;
-        let width = rect.width;
-
-        if state.needs_transfer {
-            state.needs_transfer = false;
-
-            let delete_all_images = "\x1b_Ga=D\x1b\\";
-            if tmux::is_inside_tmux() {
-                tmux::wrap_print(delete_all_images);
-            } else {
-                print!("{delete_all_images}");
-            }
-
-            if let Err(err) = state
-                .transfer_request_channel
-                .send((Arc::clone(&state.image), width, height))
-            {
-                status_error!(err:?; "Failed to compress image data");
-            }
-        }
-
-        if let Ok(data) = state.compression_finished_receiver.try_recv() {
-            state.idx = state.idx.wrapping_add(1);
-            match data {
-                Data::ImageData(data) => {
-                    transfer_image_data(&data.content, width, height, data.img_width, data.img_height, state);
-                }
-                Data::AnimationData(data) => transfer_animation_data(data, width, height, state),
-            }
-        }
-
-        create_unicode_placeholder_grid(state, buf, rect);
-        Ok(())
+impl Backend for Kitty {
+    fn hide(&mut self, area: Rect) -> Result<()> {
+        clear_area(&mut std::io::stdout().lock(), self.colors, area)
     }
 
-    fn post_render(&mut self, _: &mut Buffer, _: Option<ratatui::prelude::Color>, _: Rect) -> Result<()> {
-        Ok(())
+    fn show(&mut self, data: Arc<Vec<u8>>, area: Rect) -> Result<()> {
+        Ok(self.sender.send((data, area))?)
     }
 
-    fn hide(&mut self, _: Option<ratatui::prelude::Color>, _: Rect) -> Result<()> {
-        Ok(())
-    }
+    fn resize(&mut self) {}
 
-    fn show(&mut self) {
-        self.needs_transfer = true;
-    }
-
-    fn resize(&mut self) {
-        self.needs_transfer = true;
-    }
-
-    fn set_data(&mut self, data: Option<Vec<u8>>) -> Result<()> {
-        if let Some(data) = data {
-            self.image = Arc::new(data);
-        } else {
-            self.image = Arc::clone(&self.default_art);
-        }
-        log::debug!(bytes = self.image.len(); "New image received",);
-        self.needs_transfer = true;
-
-        Ok(())
+    fn cleanup(self: Box<Self>, area: Rect) -> Result<()> {
+        clear_area(&mut std::io::stdout().lock(), self.colors, area)
     }
 }
 
-impl KittyImageState {
-    pub fn new(default_art: &'static [u8], max_size: Size, request_render: impl Fn(bool) + Send + 'static) -> Self {
-        let compression_request_channel = channel::<(Arc<Vec<_>>, u16, u16)>();
-        let rx = compression_request_channel.1;
-
-        let image_data_to_transfer_channel = channel::<Data>();
-        let data_sender = image_data_to_transfer_channel.0;
+impl Kitty {
+    pub fn new(max_size: Size, bg_color: Option<Color>) -> Self {
+        let (sender, receiver) = unbounded::<(Arc<Vec<_>>, Rect)>();
+        let colors = Colors {
+            background: bg_color.map(Into::into),
+            foreground: None,
+        };
 
         std::thread::Builder::new()
             .name("kitty".to_string())
             .spawn(move || {
-                while let Ok((vec, width, height)) = rx.recv_last() {
-                    let data = match create_data_to_transfer(&vec, width, height, Compression::new(6), max_size) {
-                        Ok(data) => data,
-                        Err(err) => {
-                            status_error!(err:?; "Failed to compress image data");
-                            continue;
-                        }
+                let mut pending_req: Option<(Arc<Vec<_>>, Rect)> = None;
+                loop {
+                    let Ok((vec, rect)) = pending_req.take().ok_or(()).or_else(|()| receiver.recv_last()) else {
+                        continue;
                     };
 
-                    if let Err(err) = data_sender.send(data) {
-                        status_error!(err:?; "Failed to send compressed image data");
+                    let data =
+                        match create_data_to_transfer(&vec, rect.width, rect.height, Compression::new(6), max_size) {
+                            Ok(data) => data,
+                            Err(err) => {
+                                status_error!(err:?; "Failed to compress image data");
+                                continue;
+                            }
+                        };
+
+                    let mut stdout = std::io::stdout().lock();
+                    if !IS_SHOWING.load(Ordering::Relaxed) {
+                        log::trace!("Not showing image because its not supposed to be displayed anymore");
                         continue;
                     }
 
-                    request_render(false);
+                    if let Ok(msg) = receiver.try_recv_last() {
+                        pending_req = Some(msg);
+                        log::trace!("Skipping image because another one is waiting in the queue");
+                        continue;
+                    };
+
+                    if let Err(err) = match data {
+                        Data::ImageData(data) => transfer_image_data(
+                            &mut stdout,
+                            &data.content,
+                            rect.width,
+                            rect.height,
+                            data.img_width,
+                            data.img_height,
+                        ),
+                        Data::AnimationData(data) => {
+                            transfer_animation_data(&mut stdout, data, rect.width, rect.height)
+                        }
+                    } {
+                        status_error!(err:?; "Failed to transfer image data");
+                        continue;
+                    }
+
+                    if let Err(err) = create_unicode_placeholder_grid(&mut stdout, colors, rect) {
+                        status_error!(err:?; "Failed to create unicode placeholders");
+                        continue;
+                    }
                 }
             })
             .expect("Kitty thread to be spawned");
 
-        let default_art = Arc::new(default_art.to_vec());
-        Self {
-            idx: 0,
-            needs_transfer: true,
-            image: Arc::clone(&default_art),
-            transfer_request_channel: compression_request_channel.0,
-            compression_finished_receiver: image_data_to_transfer_channel.1,
-            default_art,
-        }
+        Self { sender, colors }
     }
 }
 
@@ -196,30 +168,32 @@ fn create_data_to_transfer(
     }
 }
 
-fn create_unicode_placeholder_grid(state: &KittyImageState, buf: &mut Buffer, area: Rect) {
-    (0..area.height).for_each(|y| {
-        let mut res = format!("\x1b[38;5;{}m", state.idx);
-
-        (0..area.width).for_each(|x| {
-            res.push_str(&format!(
-                "{DELIM}{row}{col}",
-                row = GRID[y as usize],
-                col = GRID[x as usize],
-            ));
-
-            if x > 0 {
-                buf.cell_mut((area.left() + x, area.top() + y))
-                    .map(|cell| cell.set_skip(true));
-            }
-        });
-
-        res.push_str("\x1b[39m\n");
-        buf.cell_mut((area.left(), area.top() + y))
-            .map(|cell| cell.set_symbol(&res));
-    });
+fn clear_area(w: &mut impl Write, colors: Colors, area: Rect) -> Result<()> {
+    super::clear_area(w, colors, area)?;
+    tmux_write!(w, "\x1b_Ga=d,d=A,q=2\x1b\\")?;
+    Ok(())
 }
 
-fn transfer_animation_data(data: AnimationData, cols: u16, rows: u16, state: &mut KittyImageState) {
+fn create_unicode_placeholder_grid(w: &mut impl Write, colors: Colors, area: Rect) -> Result<()> {
+    let mut buf = Vec::with_capacity(area.width as usize * area.height as usize * 2);
+    execute!(buf, SetColors(colors))?;
+    for y in 0..area.height {
+        csi_move!(buf, area.left(), area.top() + y)?;
+        write!(buf, "\x1b[38;5;1m")?;
+
+        for x in 0..area.width {
+            write!(buf, "{DELIM}{row}{col}", row = GRID[y as usize], col = GRID[x as usize])?;
+        }
+
+        write!(buf, "\x1b[39m")?;
+    }
+    w.write_all(&buf)?;
+    w.flush()?;
+
+    Ok(())
+}
+
+fn transfer_animation_data(w: &mut impl Write, data: AnimationData, cols: u16, rows: u16) -> Result<()> {
     let start_time = Instant::now();
     let AnimationData {
         frames,
@@ -232,7 +206,7 @@ fn transfer_animation_data(data: AnimationData, cols: u16, rows: u16, state: &mu
 
     if frames.len() < 2 {
         log::warn!("Less than two frames, invalid animation data");
-        return;
+        return Ok(());
     }
 
     let mut first_frame_iter = frames[0].content.chars().peekable();
@@ -242,17 +216,16 @@ fn transfer_animation_data(data: AnimationData, cols: u16, rows: u16, state: &mu
     let delay = frames[0].delay;
 
     // Create image and transfer first frame
-    let create_img = &format!(
-        "\x1b_Gi={},f=32,U=1,a=T,t=d,m={m},z={delay},q=2,s={img_width},v={img_height},c={cols},r={rows}{compression};{chunk}\x1b\\",
-        state.idx, compression = if is_compressed { ",o=z" } else { ""} 
-    );
-    tmux::wrap_print_if_needed(create_img);
+    tmux_write!(w,
+        "\x1b_Gi=1,f=32,U=1,a=T,t=d,m={m},z={delay},q=2,s={img_width},v={img_height},c={cols},r={rows}{compression};{chunk}\x1b\\",
+         compression = if is_compressed { ",o=z" } else { ""} 
+    )?;
 
     // Transfer the rest of the first frame if any
     while first_frame_iter.peek().is_some() {
         let chunk: String = first_frame_iter.by_ref().take(4096).collect();
         let m = i32::from(first_frame_iter.peek().is_some());
-        tmux::wrap_print_if_needed(&format!("\x1b_Gi={},m={m};{chunk}\x1b\\", state.idx));
+        tmux_write!(w, "\x1b_Gi=1,m={m};{chunk}\x1b\\")?;
     }
 
     // Transfer rest of the frames, skip first because it was already transferred
@@ -260,53 +233,52 @@ fn transfer_animation_data(data: AnimationData, cols: u16, rows: u16, state: &mu
         let mut frame_iter = content.chars().peekable();
         let chunk: String = frame_iter.by_ref().take(4096).collect();
 
-        let next_frame = &format!(
-            "\x1b_Gi={},a=f,t=d,m={m},z={delay},q=2,s={img_width},v={img_height}{compression};{chunk}\x1b\\",
-            state.idx,
+        tmux_write!(
+            w,
+            "\x1b_Gi=1,a=f,t=d,m={m},z={delay},q=2,s={img_width},v={img_height}{compression};{chunk}\x1b\\",
             compression = if is_compressed { ",o=z" } else { "" }
-        );
+        )?;
 
-        tmux::wrap_print_if_needed(next_frame);
         while frame_iter.peek().is_some() {
             let chunk: String = frame_iter.by_ref().take(4096).collect();
             let m = i32::from(frame_iter.peek().is_some());
-            tmux::wrap_print_if_needed(&format!("\x1b_Ga=f,i={},m={m};{chunk}\x1b\\", state.idx));
+            tmux_write!(w, "\x1b_Ga=f,i=1,m={m};{chunk}\x1b\\")?;
         }
     }
 
     // Run the animation
-    tmux::wrap_print_if_needed(&format!("\x1b_Ga=a,i={},s=3\x1b\\", state.idx));
+    tmux_write!(w, "\x1b_Ga=a,i=1,s=3\x1b\\")?;
     log::debug!(duration:? = start_time.elapsed(); "Transfer finished");
+
+    Ok(())
 }
 
 fn transfer_image_data(
+    w: &mut impl Write,
     content: &str,
     cols: u16,
     rows: u16,
     img_width: u32,
     img_height: u32,
-    state: &mut KittyImageState,
-) {
+) -> Result<()> {
     let start_time = Instant::now();
     log::debug!(bytes = content.len(), img_width, img_height, rows, cols; "Transferring compressed image data");
     let mut iter = content.chars().peekable();
 
     let first: String = iter.by_ref().take(4096).collect();
-    let delete_all_images = "\x1b_Ga=D\x1b\\";
-    let virtual_image_placement = &format!(
-        "\x1b_Gi={},f=32,U=1,t=d,a=T,m=1,q=2,o=z,s={},v={},c={},r={};{}\x1b\\",
-        state.idx, img_width, img_height, cols, rows, first
-    );
-
-    tmux::wrap_print_if_needed(delete_all_images);
-    tmux::wrap_print_if_needed(virtual_image_placement);
+    tmux_write!(
+        w,
+        "\x1b_Gi=1,f=32,U=1,t=d,a=T,m=1,q=2,o=z,s={img_width},v={img_height};{first}\x1b\\"
+    )?;
 
     while iter.peek().is_some() {
         let chunk: String = iter.by_ref().take(4096).collect();
         let m = i32::from(iter.peek().is_some());
-        tmux::wrap_print_if_needed(&format!("\x1b_Gm={m};{chunk}\x1b\\"));
+        tmux_write!(w, "\x1b_Gm={m};{chunk}\x1b\\")?;
     }
     log::debug!(duration:? = start_time.elapsed(); "Transfer finished");
+
+    Ok(())
 }
 
 enum Data {

--- a/src/ui/image/mod.rs
+++ b/src/ui/image/mod.rs
@@ -1,5 +1,14 @@
+use std::{io::Write, sync::Arc};
+
 use anyhow::Result;
-use ratatui::{buffer::Buffer, layout::Rect, style::Color};
+use crossterm::{
+    cursor::{RestorePosition, SavePosition},
+    queue,
+    style::{Colors, SetColors},
+};
+use ratatui::layout::Rect;
+
+use crate::shared::macros::csi_move;
 
 pub mod facade;
 pub mod iterm2;
@@ -7,14 +16,31 @@ pub mod kitty;
 pub mod sixel;
 pub mod ueberzug;
 
-pub trait ImageProto {
-    fn render(&mut self, buf: &mut Buffer, rect: Rect) -> Result<()>;
-    fn post_render(&mut self, buf: &mut Buffer, bg_color: Option<Color>, rect: Rect) -> Result<()>;
-    fn hide(&mut self, bg_color: Option<Color>, size: Rect) -> Result<()>;
-    fn show(&mut self);
+#[allow(unused)]
+pub trait Backend {
+    fn hide(&mut self, size: Rect) -> Result<()>;
+    fn show(&mut self, data: Arc<Vec<u8>>, area: Rect) -> Result<()>;
     fn resize(&mut self);
-    fn set_data(&mut self, data: Option<Vec<u8>>) -> Result<()>;
-    fn cleanup(self: Box<Self>) -> Result<()> {
+    fn cleanup(self: Box<Self>, rect: Rect) -> Result<()> {
         Ok(())
     }
+}
+
+pub fn clear_area(w: &mut impl Write, colors: Colors, area: Rect) -> Result<()> {
+    queue!(w, SetColors(colors))?;
+    queue!(w, SavePosition)?;
+    let capacity: usize = 2usize * area.width as usize * area.height as usize;
+    let mut buf = Vec::with_capacity(capacity);
+    for y in area.top()..area.bottom() {
+        csi_move!(buf, area.x, y)?;
+        for _ in 0..area.width {
+            write!(buf, " ")?;
+        }
+    }
+
+    w.write_all(&buf)?;
+    w.flush()?;
+    queue!(w, RestorePosition)?;
+
+    Ok(())
 }

--- a/src/ui/image/mod.rs
+++ b/src/ui/image/mod.rs
@@ -20,7 +20,6 @@ pub mod ueberzug;
 pub trait Backend {
     fn hide(&mut self, size: Rect) -> Result<()>;
     fn show(&mut self, data: Arc<Vec<u8>>, area: Rect) -> Result<()>;
-    fn resize(&mut self);
     fn cleanup(self: Box<Self>, rect: Rect) -> Result<()> {
         Ok(())
     }

--- a/src/ui/image/sixel.rs
+++ b/src/ui/image/sixel.rs
@@ -49,8 +49,6 @@ impl Backend for Sixel {
     fn show(&mut self, data: Arc<Vec<u8>>, area: Rect) -> Result<()> {
         Ok(self.sender.send(DataToEncode { area, data })?)
     }
-
-    fn resize(&mut self) {}
 }
 
 impl Sixel {

--- a/src/ui/image/sixel.rs
+++ b/src/ui/image/sixel.rs
@@ -129,9 +129,14 @@ fn encode(width: u16, height: u16, data: &[u8], max_size: Size) -> Result<Vec<u8
     let mut buf = Vec::new();
 
     if tmux {
-        write!(buf, "\x1bPtmux;\x1b\x1bP0;7q\"1;1;{};{}", image.width(), image.height())?;
+        write!(
+            buf,
+            "\x1bPtmux;\x1b\x1bP0;1;7q\"1;1;{};{}",
+            image.width(),
+            image.height()
+        )?;
     } else {
-        write!(buf, "\x1bP0;7q\"1;1;{};{}", image.width(), image.height())?;
+        write!(buf, "\x1bP0;1;7q\"1;1;{};{}", image.width(), image.height())?;
     }
 
     let image = image.to_rgba8();

--- a/src/ui/image/sixel.rs
+++ b/src/ui/image/sixel.rs
@@ -1,221 +1,113 @@
 use std::{
     io::Write,
     ops::AddAssign,
-    sync::{
-        mpsc::{channel, Receiver, Sender},
-        Arc,
-    },
+    sync::{atomic::Ordering, Arc},
     time::Instant,
 };
 
 use anyhow::{bail, Result};
 use color_quant::NeuQuant;
+use crossbeam::channel::{unbounded, Sender};
 use crossterm::{
     cursor::{MoveTo, RestorePosition, SavePosition},
     queue,
-    style::{Colors, SetColors},
+    style::Colors,
 };
 use image::Rgba;
-use ratatui::{buffer::Buffer, layout::Rect, style::Color};
+use ratatui::{layout::Rect, style::Color};
 
 use crate::{
     config::Size,
     shared::{
         ext::mpsc::RecvLast,
         image::{get_image_area_size_px, resize_image},
-        macros::{status_error, try_cont, try_skip},
+        macros::{status_error, try_cont},
     },
     tmux,
+    ui::image::facade::IS_SHOWING,
 };
 
-use super::ImageProto;
-
-#[derive(Debug)]
-enum State {
-    Initial,
-    Resize,
-    Rerender,
-    Encoding,
-    Showing,
-    Encoded,
-}
+use super::{clear_area, Backend};
 
 #[derive(Debug)]
 pub struct Sixel {
-    default_art: Arc<Vec<u8>>,
-    image_data_to_encode: Arc<Vec<u8>>,
-    encoded_data: Option<EncodedData>,
     sender: Sender<DataToEncode>,
-    encoded_data_receiver: Receiver<EncodedData>,
-    state: State,
-    last_id: u64,
+    colors: Colors,
 }
 
 #[derive(Debug)]
 struct DataToEncode {
-    width: u16,
-    height: u16,
-    wants_full_render: bool,
+    area: Rect,
     data: Arc<Vec<u8>>,
-    request_id: u64,
 }
 
-#[derive(Debug)]
-struct EncodedData {
-    data: Vec<u8>,
-    id: u64,
-}
-
-impl ImageProto for Sixel {
-    fn render(&mut self, _buf: &mut Buffer, Rect { width, height, .. }: Rect) -> anyhow::Result<()> {
-        match self.state {
-            State::Initial => {
-                self.sender.send(DataToEncode {
-                    width,
-                    height,
-                    wants_full_render: false,
-                    data: Arc::clone(&self.image_data_to_encode),
-                    request_id: self.last_id,
-                })?;
-                self.state = State::Encoding;
-            }
-            State::Resize => {
-                self.sender.send(DataToEncode {
-                    width,
-                    height,
-                    wants_full_render: true,
-                    data: Arc::clone(&self.image_data_to_encode),
-                    request_id: self.last_id,
-                })?;
-                self.state = State::Encoding;
-            }
-            _ => {
-                if let Ok(data) = self.encoded_data_receiver.try_recv_last() {
-                    self.encoded_data = Some(data);
-                    self.state = State::Encoded;
-                }
-            }
-        }
-        Ok(())
+impl Backend for Sixel {
+    fn hide(&mut self, size: Rect) -> anyhow::Result<()> {
+        clear_area(&mut std::io::stdout().lock(), self.colors, size)
     }
 
-    fn post_render(
-        &mut self,
-        _buf: &mut ratatui::prelude::Buffer,
-        bg_color: Option<ratatui::prelude::Color>,
-        rect @ Rect { x, y, .. }: Rect,
-    ) -> anyhow::Result<()> {
-        if !matches!(self.state, State::Encoded | State::Rerender) {
-            return Ok(());
-        }
-
-        if let Some(EncodedData { data, id }) = &self.encoded_data {
-            if *id != self.last_id {
-                return Ok(());
-            }
-            log::debug!(bytes = data.len(); "transmitting data");
-            self.clear_area(bg_color, rect)?;
-            let mut stdout = std::io::stdout();
-            queue!(stdout, SavePosition)?;
-            queue!(stdout, MoveTo(x, y))?;
-            stdout.write_all(data)?;
-            stdout.flush()?;
-            queue!(stdout, RestorePosition)?;
-            self.state = State::Showing;
-        }
-
-        Ok(())
+    fn show(&mut self, data: Arc<Vec<u8>>, area: Rect) -> Result<()> {
+        Ok(self.sender.send(DataToEncode { area, data })?)
     }
 
-    fn hide(&mut self, bg_color: Option<Color>, size: Rect) -> anyhow::Result<()> {
-        self.clear_area(bg_color, size)?;
-        Ok(())
-    }
-
-    fn show(&mut self) {
-        if self.encoded_data.is_some() {
-            self.state = State::Rerender;
-        } else {
-            self.state = State::Initial;
-        }
-    }
-
-    fn resize(&mut self) {
-        self.state = State::Resize;
-    }
-
-    fn set_data(&mut self, data: Option<Vec<u8>>) -> anyhow::Result<()> {
-        self.last_id += 1;
-        if let Some(data) = data {
-            self.image_data_to_encode = Arc::new(data);
-        } else {
-            self.image_data_to_encode = Arc::clone(&self.default_art);
-        }
-
-        self.state = State::Initial;
-        self.encoded_data = None;
-        Ok(())
-    }
+    fn resize(&mut self) {}
 }
 
 impl Sixel {
-    pub fn new(default_art: &[u8], max_size: Size, request_render: impl Fn(bool) + Send + 'static) -> Self {
-        let (sender, receiver) = channel::<DataToEncode>();
-        let (encoded_tx, encoded_rx) = channel::<EncodedData>();
+    pub fn new(max_size: Size, bg_color: Option<Color>) -> Self {
+        let (sender, receiver) = unbounded::<DataToEncode>();
+        let colors = Colors {
+            background: bg_color.map(Into::into),
+            foreground: None,
+        };
 
         std::thread::Builder::new()
             .name("sixel".to_string())
-            .spawn(move || loop {
-                if let Ok(DataToEncode {
-                    width,
-                    height,
-                    wants_full_render,
-                    data,
-                    request_id,
-                }) = receiver.recv_last()
-                {
-                    let buf = try_cont!(encode(width, height, &data, max_size, request_id), "Failed to encode");
+            .spawn(move || {
+                let mut pending_req = None;
+                loop {
+                    let Ok(DataToEncode { area, data }) =
+                        pending_req.take().ok_or(()).or_else(|()| receiver.recv_last())
+                    else {
+                        continue;
+                    };
 
-                    try_skip!(encoded_tx.send(buf), "Failed to send encoded data");
+                    let buf = try_cont!(encode(area.width, area.height, &data, max_size), "Failed to encode");
 
-                    request_render(wants_full_render);
+                    let mut w = std::io::stdout().lock();
+                    if !IS_SHOWING.load(Ordering::Relaxed) {
+                        log::trace!("Not showing image because its not supposed to be displayed anymore");
+                        continue;
+                    }
+
+                    if let Ok(msg) = receiver.try_recv_last() {
+                        pending_req = Some(msg);
+                        log::trace!("Skipping image because another one is waiting in the queue");
+                        continue;
+                    };
+
+                    try_cont!(clear_area(&mut w, colors, area), "Failed to clear sixel image area");
+                    try_cont!(display(&mut w, &buf, area), "Failed to display sixel image");
                 }
             })
             .expect("sixel thread to be spawned");
-        let default_art = Arc::new(default_art.to_vec());
 
-        Self {
-            image_data_to_encode: Arc::clone(&default_art),
-            default_art,
-            encoded_data: None,
-            sender,
-            encoded_data_receiver: encoded_rx,
-            state: State::Initial,
-            last_id: 0,
-        }
-    }
-
-    fn clear_area(&self, bg_color: Option<Color>, Rect { x, y, width, height }: Rect) -> Result<()> {
-        let mut stdout = std::io::stdout();
-        queue!(stdout, SavePosition)?;
-
-        let set_color = SetColors(Colors {
-            background: bg_color.map(|c| c.into()),
-            foreground: None,
-        });
-        for y in y..y + height {
-            for x in x..x + width {
-                queue!(stdout, MoveTo(x, y))?;
-                queue!(stdout, set_color)?;
-                write!(stdout, " ")?;
-            }
-        }
-        queue!(stdout, RestorePosition)?;
-        Ok(())
+        Self { sender, colors }
     }
 }
 
-fn encode(width: u16, height: u16, data: &[u8], max_size: Size, id: u64) -> Result<EncodedData> {
+fn display(w: &mut impl Write, data: &[u8], area: Rect) -> Result<()> {
+    log::debug!(bytes = data.len(); "transmitting data");
+    queue!(w, SavePosition)?;
+    queue!(w, MoveTo(area.x, area.y))?;
+    w.write_all(data)?;
+    w.flush()?;
+    queue!(w, RestorePosition)?;
+
+    Ok(())
+}
+
+fn encode(width: u16, height: u16, data: &[u8], max_size: Size) -> Result<Vec<u8>> {
     let start = Instant::now();
 
     let (iwidth, iheight) = match get_image_area_size_px(width, height, max_size) {
@@ -289,8 +181,8 @@ fn encode(width: u16, height: u16, data: &[u8], max_size: Size, id: u64) -> Resu
         write!(buf, "\x1b\\")?;
     }
 
-    log::debug!(id, bytes = buf.len(), image_bytes = image.len(), elapsed:? = start.elapsed(); "encoded data");
-    Ok(EncodedData { data: buf, id })
+    log::debug!(bytes = buf.len(), image_bytes = image.len(), elapsed:? = start.elapsed(); "encoded data");
+    Ok(buf)
 }
 
 fn put_color<W: Write>(buf: &mut W, byte: u8, color: usize, repeat: u16) -> Result<(), std::io::Error> {
@@ -333,98 +225,3 @@ impl Iterator for U16Triples {
         Some([a * 100 / 255, b * 100 / 255, c * 100 / 255])
     }
 }
-
-// for y in (0..image.height() as usize).step_by(6) {
-//     if y + 6 >= image.height() as usize {
-//         break;
-//     }
-//     let mut visited_colors = [false; 256];
-//     let mut colors_to_visit: Vec<u8> = vec![
-//         color_data[y][0],
-//         color_data[y + 1][0],
-//         color_data[y + 2][0],
-//         color_data[y + 3][0],
-//         color_data[y + 4][0],
-//         color_data[y + 5][0],
-//     ]
-//     .into_iter()
-//     .sorted()
-//     .dedup()
-//     .collect();
-//
-//     while let Some(color_idx) = colors_to_visit.pop() {
-//         if visited_colors[color_idx as usize] {
-//             continue;
-//         }
-//         let mut prevchar = b'?' as char;
-//         let mut prevcolor = 0;
-//         let mut repeat = 0;
-//         for x in 0..image.width() as usize {
-//             let mut character: u8 = 63;
-//
-//             let a = color_data[y][x];
-//             let b = color_data[y + 1][x];
-//             let c = color_data[y + 2][x];
-//             let d = color_data[y + 3][x];
-//             let e = color_data[y + 4][x];
-//             let f = color_data[y + 5][x];
-//
-//             if a == color_idx {
-//                 character += 1;
-//             } else if !visited_colors[a as usize] {
-//                 colors_to_visit.push(a);
-//             }
-//             if b == color_idx {
-//                 character += 2;
-//             } else if !visited_colors[b as usize] {
-//                 colors_to_visit.push(b);
-//             }
-//             if c == color_idx {
-//                 character += 4;
-//             } else if !visited_colors[c as usize] {
-//                 colors_to_visit.push(c);
-//             }
-//             if d == color_idx {
-//                 character += 8;
-//             } else if !visited_colors[d as usize] {
-//                 colors_to_visit.push(d);
-//             }
-//             if e == color_idx {
-//                 character += 16;
-//             } else if !visited_colors[e as usize] {
-//                 colors_to_visit.push(e);
-//             }
-//             if f == color_idx {
-//                 character += 32;
-//             } else if !visited_colors[f as usize] {
-//                 colors_to_visit.push(f);
-//             }
-//
-//             let character = character as char;
-//             if (color_idx == prevcolor && prevchar == character) || repeat == 0 {
-//                 repeat += 1;
-//                 prevchar = character as char;
-//                 prevcolor = color_idx;
-//                 continue;
-//             }
-//             visited_colors[color_idx as usize] = true;
-//
-//             if repeat > 1 {
-//                 write!(buf, "#{color_idx}!{repeat}{character}")?;
-//             } else {
-//                 write!(buf, "#{color_idx}{character}")?;
-//             }
-//
-//             prevchar = character as char;
-//             prevcolor = color_idx;
-//             repeat = 1;
-//         }
-//         if repeat > 1 {
-//             write!(buf, "#{color_idx}!{repeat}{prevchar}")?;
-//         } else {
-//             write!(buf, "#{color_idx}{prevchar}")?;
-//         }
-//         buf.push(b'$');
-//     }
-//     buf.push(b'-');
-// }

--- a/src/ui/image/ueberzug.rs
+++ b/src/ui/image/ueberzug.rs
@@ -91,8 +91,6 @@ impl Backend for Ueberzug {
         Ok(self.sender.send(Action::Remove)?)
     }
 
-    fn resize(&mut self) {}
-
     fn cleanup(self: Box<Self>, _: Rect) -> Result<()> {
         self.sender.send(Action::Destroy)?;
         self.handle.join().expect("Ueberzug thread to end gracefully");

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -552,19 +552,22 @@ impl<'ui> Ui<'ui> {
     }
 
     pub fn on_event(&mut self, mut event: UiEvent, context: &mut AppContext) -> Result<()> {
+        let contains_pane = |p| {
+            self.tabs
+                .get(&self.active_tab)
+                .is_some_and(|tab| tab.panes.panes_iter().any(|pane| pane.pane == p))
+        };
+
         match event {
             UiEvent::Player => {}
             UiEvent::Database => {
                 status_warn!("The music database has been updated. Some parts of the UI may have been reinitialized to prevent inconsistent behaviours.");
             }
             UiEvent::StoredPlaylist => {}
-            UiEvent::LogAdded(_) => {
+            UiEvent::LogAdded(_) =>
+            {
                 #[cfg(debug_assertions)]
-                if self
-                    .tabs
-                    .get(&self.active_tab)
-                    .is_some_and(|tab| tab.panes.panes_iter().any(|pane| matches!(pane.pane, PaneType::Logs)))
-                {
+                if contains_pane(PaneType::Logs) {
                     context.render()?;
                 }
             }
@@ -579,16 +582,16 @@ impl<'ui> Ui<'ui> {
         for name in context.config.tabs.active_panes {
             match self.panes.get_mut(*name) {
                 #[cfg(debug_assertions)]
-                Panes::Logs(p) => p.on_event(&mut event, context),
-                Panes::Queue(p) => p.on_event(&mut event, context),
-                Panes::Directories(p) => p.on_event(&mut event, context),
-                Panes::Albums(p) => p.on_event(&mut event, context),
-                Panes::Artists(p) => p.on_event(&mut event, context),
-                Panes::Playlists(p) => p.on_event(&mut event, context),
-                Panes::Search(p) => p.on_event(&mut event, context),
-                Panes::AlbumArtists(p) => p.on_event(&mut event, context),
-                Panes::AlbumArt(p) => p.on_event(&mut event, context),
-                Panes::Lyrics(p) => p.on_event(&mut event, context),
+                Panes::Logs(p) => p.on_event(&mut event, contains_pane(PaneType::Logs), context),
+                Panes::Queue(p) => p.on_event(&mut event, contains_pane(PaneType::Queue), context),
+                Panes::Directories(p) => p.on_event(&mut event, contains_pane(PaneType::Directories), context),
+                Panes::Albums(p) => p.on_event(&mut event, contains_pane(PaneType::Albums), context),
+                Panes::Artists(p) => p.on_event(&mut event, contains_pane(PaneType::Artists), context),
+                Panes::Playlists(p) => p.on_event(&mut event, contains_pane(PaneType::Playlists), context),
+                Panes::Search(p) => p.on_event(&mut event, contains_pane(PaneType::Search), context),
+                Panes::AlbumArtists(p) => p.on_event(&mut event, contains_pane(PaneType::AlbumArtists), context),
+                Panes::AlbumArt(p) => p.on_event(&mut event, contains_pane(PaneType::AlbumArt), context),
+                Panes::Lyrics(p) => p.on_event(&mut event, contains_pane(PaneType::Lyrics), context),
             }?;
         }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -156,9 +156,6 @@ impl<'ui> Ui<'ui> {
 
         Ok(())
     }
-    pub fn post_render(&mut self, frame: &mut Frame, context: &mut AppContext) -> Result<()> {
-        screen_call!(self, post_render(frame, context))
-    }
 
     fn change_tab(&mut self, new_tab: TabName, context: &AppContext) -> Result<()> {
         screen_call!(self, on_hide(&context))?;
@@ -548,6 +545,12 @@ impl<'ui> Ui<'ui> {
         Ok(())
     }
 
+    pub fn resize(&mut self, area: Rect, context: &AppContext) -> Result<()> {
+        log::trace!(area:?; "Terminal was resized");
+        self.calc_areas(area, context)?;
+        screen_call!(self, resize(self.areas[Areas::Content], context))
+    }
+
     pub fn on_event(&mut self, mut event: UiEvent, context: &mut AppContext) -> Result<()> {
         match event {
             UiEvent::Player => {}
@@ -565,7 +568,6 @@ impl<'ui> Ui<'ui> {
                     context.render()?;
                 }
             }
-            UiEvent::Resized { .. } => {}
             UiEvent::ModalOpened => {}
             UiEvent::ModalClosed => {}
             UiEvent::Exit => {}
@@ -650,7 +652,6 @@ pub enum UiEvent {
     Database,
     StoredPlaylist,
     LogAdded(Vec<u8>),
-    Resized { columns: u16, rows: u16 },
     ModalOpened,
     ModalClosed,
     Exit,

--- a/src/ui/panes/album_art.rs
+++ b/src/ui/panes/album_art.rs
@@ -2,9 +2,9 @@ use crate::{
     config::tabs::PaneType,
     context::AppContext,
     mpd::mpd_client::MpdClient,
-    shared::{image::ImageProtocol, key_event::KeyEvent, macros::try_skip},
+    shared::{image::ImageProtocol, key_event::KeyEvent},
     ui::{image::facade::AlbumArtFacade, UiEvent},
-    AppEvent, MpdQueryResult,
+    MpdQueryResult,
 };
 use anyhow::Result;
 use ratatui::{layout::Rect, Frame};
@@ -14,28 +14,14 @@ use super::Pane;
 #[derive(Debug)]
 pub struct AlbumArtPane {
     album_art: AlbumArtFacade,
-    image_data: Option<Vec<u8>>,
 }
 
 const ALBUM_ART: &str = "album_art";
 
 impl AlbumArtPane {
     pub fn new(context: &AppContext) -> Self {
-        let sender = context.app_event_sender.clone();
-        let config = context.config;
         Self {
-            image_data: None,
-            album_art: AlbumArtFacade::new(
-                config.album_art.method.into(),
-                config.theme.default_album_art,
-                config.album_art.max_size_px,
-                move |full_render: bool| {
-                    try_skip!(
-                        sender.send(AppEvent::RequestRender(full_render)),
-                        "Failed to request render"
-                    );
-                },
-            ),
+            album_art: AlbumArtFacade::new(context.config),
         }
     }
 
@@ -74,44 +60,42 @@ impl AlbumArtPane {
 }
 
 impl Pane for AlbumArtPane {
-    fn render(&mut self, frame: &mut Frame, area: Rect, context: &AppContext) -> Result<()> {
+    fn render(&mut self, _frame: &mut Frame, area: Rect, _context: &AppContext) -> Result<()> {
         self.album_art.set_size(area);
-        if let Some(data) = self.image_data.take() {
-            self.album_art.set_image(Some(data))?;
-            self.album_art.show();
-            self.album_art.render(frame, context.config)?;
-        } else {
-            self.album_art.render(frame, context.config)?;
-        }
         Ok(())
     }
 
-    fn post_render(&mut self, frame: &mut ratatui::Frame, context: &AppContext) -> Result<()> {
-        self.album_art.post_render(frame, context.config)?;
-        Ok(())
+    fn calculate_areas(&mut self, area: Rect, _context: &AppContext) {
+        self.album_art.set_size(area);
     }
 
     fn handle_action(&mut self, _event: &mut KeyEvent, _context: &mut AppContext) -> Result<()> {
         Ok(())
     }
 
-    fn on_hide(&mut self, context: &AppContext) -> Result<()> {
-        self.album_art.hide(context.config.theme.background_color)?;
-        Ok(())
+    fn on_hide(&mut self, _context: &AppContext) -> Result<()> {
+        self.album_art.hide()
+    }
+
+    fn resize(&mut self, area: Rect, _context: &AppContext) -> Result<()> {
+        self.album_art.set_size(area);
+        self.album_art.show_current()
     }
 
     fn before_show(&mut self, context: &AppContext) -> Result<()> {
         if AlbumArtPane::fetch_album_art(context).is_none() {
-            self.album_art.set_image(None)?;
+            self.album_art.show_default()?;
         }
         Ok(())
     }
 
-    fn on_query_finished(&mut self, id: &'static str, data: MpdQueryResult, context: &AppContext) -> Result<()> {
+    fn on_query_finished(&mut self, id: &'static str, data: MpdQueryResult, _context: &AppContext) -> Result<()> {
         match (id, data) {
-            (ALBUM_ART, MpdQueryResult::AlbumArt(data)) => {
-                self.image_data = data;
-                context.render()?;
+            (ALBUM_ART, MpdQueryResult::AlbumArt(Some(data))) => {
+                self.album_art.show(data)?;
+            }
+            (ALBUM_ART, MpdQueryResult::AlbumArt(None)) => {
+                self.album_art.show_default()?;
             }
             _ => {}
         }
@@ -122,21 +106,16 @@ impl Pane for AlbumArtPane {
         match event {
             UiEvent::SongChanged | UiEvent::Reconnected => {
                 if AlbumArtPane::fetch_album_art(context).is_none() {
-                    self.album_art.set_image(None)?;
+                    self.album_art.show_default()?;
                 }
             }
-            UiEvent::Resized { columns, rows } => {
-                self.album_art.resize(*columns, *rows);
-
-                context.render()?;
-            }
             UiEvent::ModalOpened => {
-                self.album_art.hide(context.config.theme.background_color)?;
+                self.album_art.hide()?;
 
                 context.render()?;
             }
             UiEvent::ModalClosed => {
-                self.album_art.show();
+                self.album_art.show_current()?;
 
                 context.render()?;
             }

--- a/src/ui/panes/album_art.rs
+++ b/src/ui/panes/album_art.rs
@@ -102,21 +102,19 @@ impl Pane for AlbumArtPane {
         Ok(())
     }
 
-    fn on_event(&mut self, event: &mut UiEvent, context: &AppContext) -> Result<()> {
+    fn on_event(&mut self, event: &mut UiEvent, is_visible: bool, context: &AppContext) -> Result<()> {
         match event {
-            UiEvent::SongChanged | UiEvent::Reconnected => {
+            UiEvent::SongChanged | UiEvent::Reconnected if is_visible => {
                 if AlbumArtPane::fetch_album_art(context).is_none() {
                     self.album_art.show_default()?;
                 }
             }
             UiEvent::ModalOpened => {
                 self.album_art.hide()?;
-
                 context.render()?;
             }
             UiEvent::ModalClosed => {
                 self.album_art.show_current()?;
-
                 context.render()?;
             }
             UiEvent::Exit => {
@@ -227,7 +225,7 @@ mod tests {
         app_context.status.state = State::Play;
         let mut screen = AlbumArtPane::new(&app_context);
 
-        screen.on_event(&mut UiEvent::SongChanged, &app_context).unwrap();
+        screen.on_event(&mut UiEvent::SongChanged, true, &app_context).unwrap();
 
         if should_search {
             assert!(matches!(

--- a/src/ui/panes/albums.rs
+++ b/src/ui/panes/albums.rs
@@ -119,7 +119,7 @@ impl Pane for AlbumsPane {
         Ok(())
     }
 
-    fn on_event(&mut self, event: &mut UiEvent, context: &AppContext) -> Result<()> {
+    fn on_event(&mut self, event: &mut UiEvent, _is_visible: bool, context: &AppContext) -> Result<()> {
         match event {
             UiEvent::Database => {
                 context

--- a/src/ui/panes/artists.rs
+++ b/src/ui/panes/artists.rs
@@ -241,7 +241,7 @@ impl Pane for ArtistsPane {
         Ok(())
     }
 
-    fn on_event(&mut self, event: &mut UiEvent, context: &AppContext) -> Result<()> {
+    fn on_event(&mut self, event: &mut UiEvent, _is_visible: bool, context: &AppContext) -> Result<()> {
         match event {
             UiEvent::Database => {
                 let target = self.target_pane();

--- a/src/ui/panes/directories.rs
+++ b/src/ui/panes/directories.rs
@@ -131,7 +131,7 @@ impl Pane for DirectoriesPane {
         Ok(())
     }
 
-    fn on_event(&mut self, event: &mut UiEvent, context: &AppContext) -> Result<()> {
+    fn on_event(&mut self, event: &mut UiEvent, _is_visible: bool, context: &AppContext) -> Result<()> {
         match event {
             UiEvent::Database => {
                 context

--- a/src/ui/panes/logs.rs
+++ b/src/ui/panes/logs.rs
@@ -89,7 +89,7 @@ impl Pane for LogsPane {
         Ok(())
     }
 
-    fn on_event(&mut self, event: &mut UiEvent, context: &AppContext) -> Result<()> {
+    fn on_event(&mut self, event: &mut UiEvent, _is_visible: bool, context: &AppContext) -> Result<()> {
         if let UiEvent::LogAdded(msg) = event {
             self.logs.push_back(std::mem::take(msg));
             if self.logs.len() > 1000 {

--- a/src/ui/panes/lyrics.rs
+++ b/src/ui/panes/lyrics.rs
@@ -86,7 +86,7 @@ impl Pane for LyricsPane {
         Ok(())
     }
 
-    fn on_event(&mut self, event: &mut UiEvent, context: &AppContext) -> Result<()> {
+    fn on_event(&mut self, event: &mut UiEvent, _is_visible: bool, context: &AppContext) -> Result<()> {
         match event {
             UiEvent::SongChanged | UiEvent::Reconnected => match context.find_lrc() {
                 Ok(lrc) => {

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -126,7 +126,7 @@ pub(super) trait Pane {
     }
 
     /// Used to keep the current state but refresh data
-    fn on_event(&mut self, event: &mut UiEvent, context: &AppContext) -> Result<()> {
+    fn on_event(&mut self, event: &mut UiEvent, is_visible: bool, context: &AppContext) -> Result<()> {
         Ok(())
     }
 

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -114,9 +114,6 @@ impl PaneContainer {
 #[allow(unused_variables)]
 pub(super) trait Pane {
     fn render(&mut self, frame: &mut Frame, area: Rect, context: &AppContext) -> Result<()>;
-    fn post_render(&mut self, frame: &mut Frame, context: &AppContext) -> Result<()> {
-        Ok(())
-    }
 
     /// For any cleanup operations, ran when the screen hides
     fn on_hide(&mut self, context: &AppContext) -> Result<()> {
@@ -144,6 +141,10 @@ pub(super) trait Pane {
     }
 
     fn calculate_areas(&mut self, area: Rect, context: &AppContext) {}
+
+    fn resize(&mut self, area: Rect, context: &AppContext) -> Result<()> {
+        Ok(())
+    }
 }
 
 pub mod dirstack {}

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -136,7 +136,7 @@ impl Pane for PlaylistsPane {
         Ok(())
     }
 
-    fn on_event(&mut self, event: &mut UiEvent, context: &AppContext) -> Result<()> {
+    fn on_event(&mut self, event: &mut UiEvent, _is_visible: bool, context: &AppContext) -> Result<()> {
         let id = match event {
             UiEvent::Database => Some(INIT),
             UiEvent::StoredPlaylist => Some(REINIT),

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -250,7 +250,7 @@ impl Pane for QueuePane {
         Ok(())
     }
 
-    fn on_event(&mut self, event: &mut UiEvent, context: &AppContext) -> Result<()> {
+    fn on_event(&mut self, event: &mut UiEvent, _is_visible: bool, context: &AppContext) -> Result<()> {
         match event {
             UiEvent::SongChanged => {
                 if let Some((idx, _)) = context.find_current_song_in_queue() {

--- a/src/ui/panes/search.rs
+++ b/src/ui/panes/search.rs
@@ -568,7 +568,7 @@ impl Pane for SearchPane {
         Ok(())
     }
 
-    fn on_event(&mut self, event: &mut UiEvent, context: &AppContext) -> Result<()> {
+    fn on_event(&mut self, event: &mut UiEvent, _is_visible: bool, context: &AppContext) -> Result<()> {
         match event {
             UiEvent::Database => {
                 self.songs_dir = Dir::default();

--- a/src/ui/tab_screen.rs
+++ b/src/ui/tab_screen.rs
@@ -265,14 +265,6 @@ impl TabScreen {
         screen_call!(pane, handle_mouse_event(event, context))
     }
 
-    pub fn post_render(&mut self, panes: &mut PaneContainer, frame: &mut Frame, context: &AppContext) -> Result<()> {
-        for pane in self.panes.panes_iter() {
-            let screen = panes.get_mut(pane.pane);
-            screen_call!(screen, post_render(frame, context))?;
-        }
-        Ok(())
-    }
-
     pub fn on_hide(&mut self, panes: &mut PaneContainer, context: &AppContext) -> Result<()> {
         for pane in self.panes.panes_iter() {
             let screen = panes.get_mut(pane.pane);
@@ -285,6 +277,14 @@ impl TabScreen {
         self.for_each_pane(panes, self.panes, area, context, &mut |pane, rect, _, _| {
             screen_call!(pane, calculate_areas(rect, context));
             screen_call!(pane, before_show(context))?;
+            Ok(())
+        })
+    }
+
+    pub fn resize(&mut self, panes: &mut PaneContainer, area: Rect, context: &AppContext) -> Result<()> {
+        self.for_each_pane(panes, self.panes, area, context, &mut |pane, rect, _, _| {
+            screen_call!(pane, calculate_areas(rect, context));
+            screen_call!(pane, resize(rect, context))?;
             Ok(())
         })
     }

--- a/src/ui/widgets/browser.rs
+++ b/src/ui/widgets/browser.rs
@@ -50,7 +50,6 @@ where
 {
     type State = DirStack<T>;
 
-    #[allow(clippy::unwrap_used)]
     fn render(self, area: ratatui::prelude::Rect, buf: &mut ratatui::prelude::Buffer, state: &mut Self::State) {
         let scrollbar_margin = if self.config.theme.draw_borders {
             let scrollbar_track = self.config.theme.scrollbar.symbols[0];


### PR DESCRIPTION
This greatly simplifies and unifies the code around the different image protocol backends and gets it to a place where I am generally happy with it. I was able to remove a bunch of hacks and improper solutions while also allowing better handling of resize events, simplifying the program flow and other things.
One unfortunate side effect is that Kitty's image is no longer centered anymore and is instead rendered in the top left corner, but this at least brings it in line with the other backends and I plan to introduce image alignment config at some point this release anyway.

Anyway, this is not 100% ready yet but is almost there. Its mostly testing whether something is broken thats left, so if you stumble upon this before merge and feel like testing it out, feel free to do so, thanks!