### PR TITLE
feat: album art alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Support for repeating lyrics in lrc
+- `vertical_align` and `horizontal_align` to album art config, supports kitty, sixel and iterm2
 
 ### Changed
 
-- Album art with kitty image protocol is no longer centered and is in line with the other image backends
+- Increased default album art `max_size_px` to `(1200, 1200)`.
 
 ### Fixed
 

--- a/docs/src/content/docs/next/assets/example_config.ron
+++ b/docs/src/content/docs/next/assets/example_config.ron
@@ -15,7 +15,7 @@
     select_current_song_on_change: false,
     album_art: (
         method: Auto,
-        max_size_px: (width: 600, height: 600),
+        max_size_px: (width: 1200, height: 1200),
         disabled_protocols: ["http://", "https://"],
         vertical_align: Center,
         horizontal_align: Center,

--- a/docs/src/content/docs/next/assets/example_config.ron
+++ b/docs/src/content/docs/next/assets/example_config.ron
@@ -17,6 +17,8 @@
         method: Auto,
         max_size_px: (width: 600, height: 600),
         disabled_protocols: ["http://", "https://"],
+        vertical_align: Center,
+        horizontal_align: Center,
     ),
     keybinds: (
         global: {

--- a/docs/src/content/docs/next/configuration/album-art.mdx
+++ b/docs/src/content/docs/next/configuration/album-art.mdx
@@ -46,9 +46,10 @@ Defaults to `Auto` which tries to use Kitty first and then Ueberzug if Kitty is 
 <ConfigValue name="max_size_px" type="other" customText="(<width>, <height>)" />
 
 Sets limit for the album art size. If the album art is larger than this, it will be resized to fit the limit.
-You should not set this option unless needed because preferred image methods will figure out the correct size
-themselves. This is needed only for terminals that do not report their size correctly. Default is `(600, 600)`.
-`(0, 0)` means no practical limit. Ueberzug method is not influenced by this setting.
+
+You can set this to `(0, 0)` (no limit) if you use terminal emulator which properly reports its size and rmpc will figure
+out the maximum size itself. This is needed only for terminals which do not report their size correctly.
+Default is `(1200, 1200)`. Ueberzug backend is not influenced by this setting.
 
 ### disabled_protocols
 
@@ -61,13 +62,13 @@ to enable all protocols. Defaults to `["http://", "https://]`
 
 <ConfigValue name="vertical_align" type={["Top", "Center", "Bottom"]} />
 
-Where to align album art vertically.
+Where to align album art vertically. Not supported by ueberzugpp backend.
 
 ### horizontal_align
 
 <ConfigValue name="horizontal_align" type={["Left", "Center", "Right"]} />
 
-Where to align album art horizontally.
+Where to align album art horizontally. Not supported by ueberzugpp backend.
 
 ## Backends
 
@@ -82,7 +83,7 @@ Cons:
 
 ### Ueberzugpp
 
-Requires [ueberzugpp](https://github.com/jstkdng/ueberzugpp). Art is aligned to the top of the window and not centered.
+Requires [ueberzugpp](https://github.com/jstkdng/ueberzugpp). Art is aligned to the top of and its position cannot be changed.
 
 Pros:
 

--- a/docs/src/content/docs/next/configuration/album-art.mdx
+++ b/docs/src/content/docs/next/configuration/album-art.mdx
@@ -57,6 +57,18 @@ themselves. This is needed only for terminals that do not report their size corr
 Album art will NOT be fetched and displayed for songs with path starting with any of the given protocols. Set to empty array
 to enable all protocols. Defaults to `["http://", "https://]`
 
+### vertical_align
+
+<ConfigValue name="vertical_align" type={["Top", "Center", "Bottom"]} />
+
+Where to align album art vertically.
+
+### horizontal_align
+
+<ConfigValue name="horizontal_align" type={["Left", "Center", "Right"]} />
+
+Where to align album art horizontally.
+
 ## Backends
 
 ### Kitty

--- a/docs/src/pages/changelog.astro
+++ b/docs/src/pages/changelog.astro
@@ -3,7 +3,7 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import { Content, getHeadings } from "../../../CHANGELOG.md";
 ---
 
-<StarlightPage frontmatter={{ title: "" }} hasSidebar={false} sidebar={[]} headings={getHeadings()}>
+<StarlightPage frontmatter={{ title: "Changelog" }} hasSidebar={false} sidebar={[]} headings={getHeadings()}>
     <div class="container">
         <Content />
     </div>

--- a/src/config/album_art.rs
+++ b/src/config/album_art.rs
@@ -1,0 +1,121 @@
+use serde::{Deserialize, Serialize};
+use strum::Display;
+
+use super::Size;
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct AlbumArtConfigFile {
+    #[serde(default)]
+    pub method: ImageMethodFile,
+    #[serde(default)]
+    pub max_size_px: Size,
+    #[serde(default = "super::defaults::disabled_album_art_protos")]
+    pub disabled_protocols: Vec<String>,
+    #[serde(default)]
+    pub vertical_align: VerticalAlignFile,
+    #[serde(default)]
+    pub horizontal_align: HorizontalAlignFile,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct AlbumArtConfig {
+    pub method: ImageMethod,
+    pub max_size_px: Size,
+    pub disabled_protocols: Vec<&'static str>,
+    pub vertical_align: VerticalAlign,
+    pub horizontal_align: HorizontalAlign,
+}
+
+#[derive(Default, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum HorizontalAlignFile {
+    Left,
+    #[default]
+    Center,
+    Right,
+}
+#[derive(Default, Display, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HorizontalAlign {
+    Left,
+    #[default]
+    Center,
+    Right,
+}
+
+#[derive(Default, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum VerticalAlignFile {
+    Top,
+    #[default]
+    Center,
+    Bottom,
+}
+#[derive(Default, Display, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerticalAlign {
+    Top,
+    #[default]
+    Center,
+    Bottom,
+}
+
+#[derive(Default, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum ImageMethodFile {
+    Kitty,
+    UeberzugWayland,
+    UeberzugX11,
+    Iterm2,
+    Sixel,
+    None,
+    #[default]
+    Auto,
+}
+
+#[derive(Default, Display, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImageMethod {
+    Kitty,
+    UeberzugWayland,
+    UeberzugX11,
+    Iterm2,
+    Sixel,
+    None,
+    #[default]
+    Unsupported,
+}
+
+impl From<AlbumArtConfigFile> for AlbumArtConfig {
+    fn from(value: AlbumArtConfigFile) -> Self {
+        let size = value.max_size_px;
+        AlbumArtConfig {
+            method: ImageMethod::default(),
+            max_size_px: Size {
+                width: if size.width == 0 { u16::MAX } else { size.width },
+                height: if size.height == 0 { u16::MAX } else { size.height },
+            },
+            disabled_protocols: value
+                .disabled_protocols
+                .into_iter()
+                .map(|proto| proto.leak() as &'static _)
+                .collect(),
+            vertical_align: value.vertical_align.into(),
+            horizontal_align: value.horizontal_align.into(),
+        }
+    }
+}
+
+impl From<VerticalAlignFile> for VerticalAlign {
+    fn from(value: VerticalAlignFile) -> Self {
+        match value {
+            VerticalAlignFile::Top => VerticalAlign::Top,
+            VerticalAlignFile::Center => VerticalAlign::Center,
+            VerticalAlignFile::Bottom => VerticalAlign::Bottom,
+        }
+    }
+}
+
+impl From<HorizontalAlignFile> for HorizontalAlign {
+    fn from(value: HorizontalAlignFile) -> Self {
+        match value {
+            HorizontalAlignFile::Left => HorizontalAlign::Left,
+            HorizontalAlignFile::Center => HorizontalAlign::Center,
+            HorizontalAlignFile::Right => HorizontalAlign::Right,
+        }
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -110,8 +110,8 @@ pub struct Size {
 impl Default for Size {
     fn default() -> Self {
         Self {
-            width: 600,
-            height: 600,
+            width: 1200,
+            height: 1200,
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,7 @@
 use std::{cell::Cell, collections::HashSet, path::PathBuf};
 
 use crate::{
-    config::{tabs::PaneType, Config, ImageMethod, Leak},
+    config::{album_art::ImageMethod, tabs::PaneType, Config, Leak},
     mpd::{
         client::Client,
         commands::{Song, State, Status},

--- a/src/shared/image.rs
+++ b/src/shared/image.rs
@@ -3,12 +3,12 @@ use std::io::Cursor;
 
 use anyhow::Context;
 use anyhow::Result;
-use crossterm::terminal::WindowSize;
 use image::codecs::gif::GifDecoder;
 use image::codecs::jpeg::JpegEncoder;
 use image::AnimationDecoder;
 use image::DynamicImage;
 use image::ImageDecoder;
+use ratatui::layout::Rect;
 use rustix::path::Arg;
 
 use crate::config::Size;
@@ -183,57 +183,102 @@ pub fn read_size_csi() -> Result<Option<(u16, u16)>> {
     Ok(None)
 }
 
-pub fn get_image_area_size_px(area_width_col: u16, area_height_col: u16, max_size_px: Size) -> Result<(u16, u16)> {
-    let size = crossterm::terminal::window_size().context("Unable to query terminal size")?;
-
-    // TODO: Figure out how to execute and read CSI sequences without it messing up crossterm
-
-    // if size.width == 0 || size.height == 0 {
-    //     if let Ok(Some((width, height))) = read_size_csi() {
-    //         size.width = width;
-    //         size.height = height;
-    //     }
-    // }
-
-    // TODO calc correct max size
-
-    let (w, h) = clamp_image_size(&size, area_width_col, area_height_col, max_size_px);
-
-    log::debug!(w, h, size:?; "Resolved terminal size");
-    Ok((w, h))
+#[derive(Debug, Clone, Copy)]
+pub struct AlignedArea {
+    pub area: Rect,
+    pub size_px: Size,
 }
 
-pub fn resize_image(image_data: &[u8], width_px: u16, hegiht_px: u16) -> Result<DynamicImage> {
-    Ok(image::ImageReader::new(Cursor::new(image_data))
+/// Returns a new aligned area contained by [`available_area`] with aspect ratio provided by [`image_size`].
+/// Constrains area by [`max_size_px`].
+/// Returns the input [`available_area`] and [`max_size_px`] if terminal's size cannot be determined properly.
+/// Also returns resulting area size in pixels.
+#[allow(clippy::cast_lossless, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+pub fn create_aligned_area(available_area: Rect, image_size: (u32, u32), max_size_px: Size) -> AlignedArea {
+    let Ok(window_size) = crossterm::terminal::window_size() else {
+        log::warn!(available_area:?, max_size_px:?; "Failed to query terminal size");
+        return AlignedArea {
+            area: available_area,
+            size_px: max_size_px,
+        };
+    };
+
+    if window_size.width == 0 || window_size.height == 0 {
+        log::warn!(available_area:?, max_size_px:?; "Terminal returned invalid size");
+        return AlignedArea {
+            area: available_area,
+            size_px: max_size_px,
+        };
+    };
+
+    let available_width = available_area.width as f64;
+    let available_height = available_area.height as f64;
+    let cell_width = window_size.width as f64 / window_size.columns as f64;
+    let cell_height = window_size.height as f64 / window_size.rows as f64;
+
+    let image_aspect_ratio = image_size.0 as f64 / image_size.1 as f64;
+    let cell_aspect_ratio = cell_width / cell_height;
+    let available_area_aspect_ratio = available_width / available_height * cell_aspect_ratio;
+
+    let (mut new_width, mut new_height) = if available_area_aspect_ratio < image_aspect_ratio {
+        let new_width = available_area.width;
+        let new_height = (available_width / image_aspect_ratio * cell_aspect_ratio).ceil() as u16;
+
+        (new_width, new_height)
+    } else {
+        let new_width = (available_height * image_aspect_ratio / cell_aspect_ratio).ceil() as u16;
+        let new_height = available_area.height;
+
+        (new_width, new_height)
+    };
+
+    if new_width > available_area.width {
+        new_width = available_area.width;
+    }
+    if new_height > available_area.height {
+        new_height = available_area.height;
+    }
+
+    let result = AlignedArea {
+        area: Rect::new(
+            available_area.x + (available_area.width.saturating_sub(new_width)) / 2,
+            available_area.y + (available_area.height.saturating_sub(new_height)) / 2,
+            new_width,
+            new_height,
+        ),
+        size_px: Size {
+            width: ((new_width as f64 * cell_width) as u16).min(max_size_px.width),
+            height: ((new_height as f64 * cell_height) as u16).min(max_size_px.height),
+        },
+    };
+
+    log::debug!(result:?, available_area:?, cell_width, cell_height, image_size:?, max_size_px:?; "Aligned area");
+
+    result
+}
+
+pub fn resize_image(image_data: &[u8], availabe_area: Rect, max_size_px: Size) -> Result<(DynamicImage, AlignedArea)> {
+    let image = image::ImageReader::new(Cursor::new(image_data))
         .with_guessed_format()
         .context("Unable to guess image format")?
         .decode()
-        .context("Unable to decode image")?
-        .resize(
-            u32::from(width_px),
-            u32::from(hegiht_px),
-            image::imageops::FilterType::Lanczos3,
-        ))
+        .context("Unable to decode image")?;
+
+    let result_area = create_aligned_area(availabe_area, (image.width(), image.height()), max_size_px);
+
+    let result = image.resize(
+        result_area.size_px.width.into(),
+        result_area.size_px.height.into(),
+        image::imageops::FilterType::Lanczos3,
+    );
+
+    Ok((result, result_area))
 }
 
 pub fn jpg_encode(img: &DynamicImage) -> Result<Vec<u8>> {
     let mut jpg = Vec::new();
     JpegEncoder::new(&mut jpg).encode_image(img)?;
     Ok(jpg)
-}
-
-fn clamp_image_size(size: &WindowSize, area_width_col: u16, area_height_col: u16, max_size_px: Size) -> (u16, u16) {
-    if size.width == 0 || size.height == 0 {
-        return (max_size_px.width, max_size_px.height);
-    }
-
-    let cell_width = size.width / size.columns;
-    let cell_height = size.height / size.rows;
-
-    let w = cell_width * area_width_col;
-    let h = cell_height * area_height_col;
-
-    (w.min(max_size_px.width), h.min(max_size_px.height))
 }
 
 pub struct GifData<'frames> {
@@ -255,32 +300,5 @@ pub fn get_gif_frames(data: &[u8]) -> Result<Option<GifData<'_>>> {
         }))
     } else {
         Ok(None)
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crossterm::terminal::WindowSize;
-    use test_case::test_case;
-
-    use crate::config::Size;
-
-    use super::clamp_image_size;
-
-    #[test_case(&WindowSize { width: 0, height: 0, columns: 10, rows: 10 }, 10, 10, Size { width: 500, height: 500 }, Size { width: 500, height: 500 }; "size not reported")]
-    #[test_case(&WindowSize { width: 500, height: 500, columns: 10, rows: 10 }, 50, 10, Size { width: 500, height: 500 }, Size { width: 500, height: 500 }; "wider area")]
-    #[test_case(&WindowSize { width: 500, height: 500, columns: 10, rows: 10 }, 10, 50, Size { width: 500, height: 500 }, Size { width: 500, height: 500 }; "taller area")]
-    #[test_case(&WindowSize { width: 500, height: 500, columns: 10, rows: 10 }, 10, 10, Size { width: 5000, height: 500 }, Size { width: 500, height: 500 }; "square area")]
-    fn uses_max_size_if_size_not_reported(
-        window: &WindowSize,
-        area_width: u16,
-        area_height: u16,
-        max_size: Size,
-        expected: Size,
-    ) {
-        let (w, h) = clamp_image_size(window, area_width, area_height, max_size);
-
-        assert_eq!(w, expected.width, "width not correct");
-        assert_eq!(h, expected.height, "height not correct");
     }
 }

--- a/src/shared/image.rs
+++ b/src/shared/image.rs
@@ -14,7 +14,6 @@ use rustix::path::Arg;
 use crate::config::album_art::HorizontalAlign;
 use crate::config::album_art::VerticalAlign;
 use crate::config::Size;
-use crate::shared::macros::status_info;
 
 use super::dependencies::UEBERZUGPP;
 

--- a/src/ui/image/facade.rs
+++ b/src/ui/image/facade.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use anyhow::Result;
 use ratatui::layout::Rect;
 
-use crate::config::{Config, ImageMethod};
+use crate::config::album_art::ImageMethod;
+use crate::config::Config;
 use crate::shared::image::ImageProtocol;
 
 use super::{iterm2::Iterm2, kitty::Kitty, Backend};
@@ -37,12 +38,14 @@ impl AlbumArtFacade {
     pub fn new(config: &Config) -> Self {
         let max_size = config.album_art.max_size_px;
         let bg_color = config.theme.background_color;
+        let valign = config.album_art.vertical_align;
+        let halign = config.album_art.horizontal_align;
         let proto = match config.album_art.method.into() {
-            ImageProtocol::Kitty => ImageState::Kitty(Kitty::new(max_size, bg_color)),
+            ImageProtocol::Kitty => ImageState::Kitty(Kitty::new(max_size, bg_color, halign, valign)),
             ImageProtocol::UeberzugWayland => ImageState::Ueberzug(Ueberzug::new(Layer::Wayland, max_size)),
             ImageProtocol::UeberzugX11 => ImageState::Ueberzug(Ueberzug::new(Layer::X11, max_size)),
-            ImageProtocol::Iterm2 => ImageState::Iterm2(Iterm2::new(max_size, bg_color)),
-            ImageProtocol::Sixel => ImageState::Sixel(Sixel::new(max_size, bg_color)),
+            ImageProtocol::Iterm2 => ImageState::Iterm2(Iterm2::new(max_size, bg_color, halign, valign)),
+            ImageProtocol::Sixel => ImageState::Sixel(Sixel::new(max_size, bg_color, halign, valign)),
             ImageProtocol::None => ImageState::None,
         };
         Self {

--- a/src/ui/image/facade.rs
+++ b/src/ui/image/facade.rs
@@ -57,19 +57,8 @@ impl AlbumArtFacade {
     }
 
     pub fn show_default(&mut self) -> Result<()> {
-        self.current_album_art = None;
-        IS_SHOWING.store(true, Ordering::Relaxed);
-
-        let data = Arc::clone(&self.default_album_art);
-        log::debug!(bytes = data.len(), area:? = self.last_size; "Displaying default image");
-
-        match &mut self.image_state {
-            ImageState::Kitty(kitty) => kitty.show(data, self.last_size),
-            ImageState::Ueberzug(ueberzug) => ueberzug.show(data, self.last_size),
-            ImageState::Iterm2(iterm2) => iterm2.show(data, self.last_size),
-            ImageState::Sixel(s) => s.show(data, self.last_size),
-            ImageState::None => Ok(()),
-        }
+        self.current_album_art = Some(Arc::clone(&self.default_album_art));
+        self.show_current()
     }
 
     pub fn show_current(&mut self) -> Result<()> {

--- a/src/ui/image/kitty.rs
+++ b/src/ui/image/kitty.rs
@@ -11,7 +11,7 @@ use std::{
     time::Instant,
 };
 
-use crate::shared::tmux::tmux_write;
+use crate::shared::{image::create_aligned_area, macros::try_cont, tmux::tmux_write};
 use base64::Engine;
 use flate2::Compression;
 use ratatui::prelude::{Color, Rect};
@@ -20,7 +20,7 @@ use crate::{
     config::Size,
     shared::{
         ext::mpsc::RecvLast,
-        image::{get_gif_frames, get_image_area_size_px, resize_image},
+        image::{get_gif_frames, resize_image},
         macros::status_error,
     },
 };
@@ -60,20 +60,19 @@ impl Kitty {
             .spawn(move || {
                 let mut pending_req: Option<(Arc<Vec<_>>, Rect)> = None;
                 loop {
-                    let Ok((vec, rect)) = pending_req.take().ok_or(()).or_else(|()| receiver.recv_last()) else {
+                    let Ok((vec, area)) = pending_req.take().ok_or(()).or_else(|()| receiver.recv_last()) else {
                         continue;
                     };
 
-                    let data =
-                        match create_data_to_transfer(&vec, rect.width, rect.height, Compression::new(6), max_size) {
-                            Ok(data) => data,
-                            Err(err) => {
-                                status_error!(err:?; "Failed to compress image data");
-                                continue;
-                            }
-                        };
+                    let data = match create_data_to_transfer(&vec, area, Compression::new(6), max_size) {
+                        Ok(data) => data,
+                        Err(err) => {
+                            status_error!(err:?; "Failed to compress image data");
+                            continue;
+                        }
+                    };
 
-                    let mut stdout = std::io::stdout().lock();
+                    let mut w = std::io::stdout().lock();
                     if !IS_SHOWING.load(Ordering::Relaxed) {
                         log::trace!("Not showing image because its not supposed to be displayed anymore");
                         continue;
@@ -85,26 +84,30 @@ impl Kitty {
                         continue;
                     };
 
-                    if let Err(err) = match data {
-                        Data::ImageData(data) => transfer_image_data(
-                            &mut stdout,
-                            &data.content,
-                            rect.width,
-                            rect.height,
-                            data.img_width,
-                            data.img_height,
-                        ),
-                        Data::AnimationData(data) => {
-                            transfer_animation_data(&mut stdout, data, rect.width, rect.height)
-                        }
-                    } {
-                        status_error!(err:?; "Failed to transfer image data");
-                        continue;
-                    }
+                    try_cont!(clear_area(&mut w, colors, area), "Failed to clear kitty image area");
+                    match data {
+                        Data::ImageData(data) => {
+                            try_cont!(
+                                transfer_image_data(&mut w, &data.content, data.img_width, data.img_height),
+                                "Failed to transfer image data"
+                            );
 
-                    if let Err(err) = create_unicode_placeholder_grid(&mut stdout, colors, rect) {
-                        status_error!(err:?; "Failed to create unicode placeholders");
-                        continue;
+                            try_cont!(
+                                create_unicode_placeholder_grid(&mut w, colors, data.aligned_area),
+                                "Failed to create unicode placeholders"
+                            );
+                        }
+                        Data::AnimationData(data) => {
+                            let aligned_area = data.aligned_area;
+                            try_cont!(
+                                transfer_animation_data(&mut w, data),
+                                "Failed to transfer animation data"
+                            );
+                            try_cont!(
+                                create_unicode_placeholder_grid(&mut w, colors, aligned_area),
+                                "Failed to create unicode placeholders"
+                            );
+                        }
                     }
                 }
             })
@@ -114,20 +117,14 @@ impl Kitty {
     }
 }
 
-fn create_data_to_transfer(
-    image_data: &[u8],
-    width: u16,
-    height: u16,
-    compression: Compression,
-    max_size: Size,
-) -> Result<Data> {
+fn create_data_to_transfer(image_data: &[u8], area: Rect, compression: Compression, max_size: Size) -> Result<Data> {
     let start_time = Instant::now();
     log::debug!(bytes = image_data.len(); "Compressing image data");
-    let (w, h) = get_image_area_size_px(width, height, max_size)?;
 
     if let Some(data) = get_gif_frames(image_data)? {
         let frames = data.frames;
         let (width, height) = data.dimensions;
+
         let frames: Vec<AnimationFrame> = frames
             .map_ok(|frame| {
                 let delay = frame.delay().numer_denom_ms();
@@ -138,15 +135,17 @@ fn create_data_to_transfer(
                 }
             })
             .try_collect()?;
+        let aligned_area = create_aligned_area(area, (width, height), max_size).area;
 
         Ok(Data::AnimationData(AnimationData {
             frames,
             is_compressed: false,
             img_width: width,
             img_height: height,
+            aligned_area,
         }))
     } else {
-        let image = resize_image(image_data, w, h)?;
+        let (image, aligned_area) = resize_image(image_data, area, max_size)?;
 
         let mut e = flate2::write::ZlibEncoder::new(Vec::new(), compression);
         e.write_all(image.to_rgba8().as_raw())
@@ -160,6 +159,7 @@ fn create_data_to_transfer(
         log::debug!(input_bytes = image_data.len(), compressed_bytes = content.len(), duration:? = start_time.elapsed(); "Image data compression finished");
         Ok(Data::ImageData(ImageData {
             content,
+            aligned_area: aligned_area.area,
             img_width: image.width(),
             img_height: image.height(),
         }))
@@ -191,16 +191,17 @@ fn create_unicode_placeholder_grid(w: &mut impl Write, colors: Colors, area: Rec
     Ok(())
 }
 
-fn transfer_animation_data(w: &mut impl Write, data: AnimationData, cols: u16, rows: u16) -> Result<()> {
+fn transfer_animation_data(w: &mut impl Write, data: AnimationData) -> Result<()> {
     let start_time = Instant::now();
     let AnimationData {
         frames,
         is_compressed,
         img_width,
         img_height,
+        aligned_area,
     } = data;
 
-    log::debug!(frames = frames.len(), img_width, img_height, rows, cols; "Transferring animation data");
+    log::debug!(frames = frames.len(), img_width, img_height, aligned_area:?; "Transferring animation data");
 
     if frames.len() < 2 {
         log::warn!("Less than two frames, invalid animation data");
@@ -216,7 +217,9 @@ fn transfer_animation_data(w: &mut impl Write, data: AnimationData, cols: u16, r
     // Create image and transfer first frame
     tmux_write!(w,
         "\x1b_Gi=1,f=32,U=1,a=T,t=d,m={m},z={delay},q=2,s={img_width},v={img_height},c={cols},r={rows}{compression};{chunk}\x1b\\",
-         compression = if is_compressed { ",o=z" } else { ""} 
+         compression = if is_compressed { ",o=z" } else { ""},
+         cols = aligned_area.width,
+         rows = aligned_area.height
     )?;
 
     // Transfer the rest of the first frame if any
@@ -251,16 +254,9 @@ fn transfer_animation_data(w: &mut impl Write, data: AnimationData, cols: u16, r
     Ok(())
 }
 
-fn transfer_image_data(
-    w: &mut impl Write,
-    content: &str,
-    cols: u16,
-    rows: u16,
-    img_width: u32,
-    img_height: u32,
-) -> Result<()> {
+fn transfer_image_data(w: &mut impl Write, content: &str, img_width: u32, img_height: u32) -> Result<()> {
     let start_time = Instant::now();
-    log::debug!(bytes = content.len(), img_width, img_height, rows, cols; "Transferring compressed image data");
+    log::debug!(bytes = content.len(), img_width, img_height; "Transferring compressed image data");
     let mut iter = content.chars().peekable();
 
     let first: String = iter.by_ref().take(4096).collect();
@@ -288,6 +284,7 @@ struct ImageData {
     content: String,
     img_width: u32,
     img_height: u32,
+    aligned_area: Rect,
 }
 
 struct AnimationFrame {
@@ -300,6 +297,7 @@ struct AnimationData {
     is_compressed: bool,
     img_width: u32,
     img_height: u32,
+    aligned_area: Rect,
 }
 
 const DELIM: &str = "\u{10EEEE}";

--- a/src/ui/image/sixel.rs
+++ b/src/ui/image/sixel.rs
@@ -20,7 +20,7 @@ use crate::{
     config::Size,
     shared::{
         ext::mpsc::RecvLast,
-        image::{get_image_area_size_px, resize_image},
+        image::resize_image,
         macros::{status_error, try_cont},
     },
     tmux,
@@ -70,7 +70,7 @@ impl Sixel {
                         continue;
                     };
 
-                    let buf = try_cont!(encode(area.width, area.height, &data, max_size), "Failed to encode");
+                    let (buf, resized_area) = try_cont!(encode(&data, area, max_size), "Failed to encode");
 
                     let mut w = std::io::stdout().lock();
                     if !IS_SHOWING.load(Ordering::Relaxed) {
@@ -85,7 +85,7 @@ impl Sixel {
                     };
 
                     try_cont!(clear_area(&mut w, colors, area), "Failed to clear sixel image area");
-                    try_cont!(display(&mut w, &buf, area), "Failed to display sixel image");
+                    try_cont!(display(&mut w, &buf, resized_area), "Failed to display sixel image");
                 }
             })
             .expect("sixel thread to be spawned");
@@ -105,17 +105,10 @@ fn display(w: &mut impl Write, data: &[u8], area: Rect) -> Result<()> {
     Ok(())
 }
 
-fn encode(width: u16, height: u16, data: &[u8], max_size: Size) -> Result<Vec<u8>> {
+fn encode(data: &[u8], area: Rect, max_size: Size) -> Result<(Vec<u8>, Rect)> {
     let start = Instant::now();
 
-    let (iwidth, iheight) = match get_image_area_size_px(width, height, max_size) {
-        Ok(v) => v,
-        Err(err) => {
-            bail!("Failed to get image size, err: {}", err);
-        }
-    };
-
-    let image = match resize_image(data, iwidth, iheight) {
+    let (image, resized_area) = match resize_image(data, area, max_size) {
         Ok(v) => v,
         Err(err) => {
             bail!("Failed to resize image, err: {}", err);
@@ -185,7 +178,7 @@ fn encode(width: u16, height: u16, data: &[u8], max_size: Size) -> Result<Vec<u8
     }
 
     log::debug!(bytes = buf.len(), image_bytes = image.len(), elapsed:? = start.elapsed(); "encoded data");
-    Ok(buf)
+    Ok((buf, resized_area.area))
 }
 
 fn put_color<W: Write>(buf: &mut W, byte: u8, color: usize, repeat: u16) -> Result<(), std::io::Error> {

--- a/src/ui/panes/album_art.rs
+++ b/src/ui/panes/album_art.rs
@@ -137,8 +137,8 @@ mod tests {
 
     use super::AlbumArtPane;
 
+    use crate::config::album_art::ImageMethod;
     use crate::config::Config;
-    use crate::config::ImageMethod;
     use crate::config::Leak;
     use crate::mpd::commands::Song;
     use crate::mpd::commands::State;


### PR DESCRIPTION
This will allow us to align album art in its provided area if it does not fill it completely. Till now kitty was centered and others were rendered in the top left column.

Some work left to do, kitty, iterm2 and sixel ~~are now aligned to center,~~ can configure vertical and horizontal alignment separately, ueberzug is untouched still.