### PR TITLE
fix: lsinfo not supporting playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Styling not being applied to Bitrate and Crossfade props
 - Refactored and greatly simplified image backends
 - Potential infinite loop in lyrics indexing
+- `lsinfo` parsing playlist entries incorrectly
 
 ## [0.7.0] - 2024-12-24
 

--- a/src/mpd/commands/lsinfo.rs
+++ b/src/mpd/commands/lsinfo.rs
@@ -41,7 +41,6 @@ impl FromMpd for Dir {
                 self.full_path = value;
             }
             "last-modified" => self.last_modified = value,
-            "playlist" => {} // ignore, deprecated
             _ => return Ok(LineHandled::No { value }),
         }
         Ok(LineHandled::Yes)
@@ -90,7 +89,7 @@ mod tests {
     use super::{FromMpd, LsInfo};
 
     #[test]
-    fn lsinfoplaylist() {
+    fn can_parse_playlist_entry() {
         let input = r"playlist: autechre.m3u
 Last-Modified: 2024-10-30T00:04:26Z
 directory: .cue

--- a/src/mpd/commands/lsinfo.rs
+++ b/src/mpd/commands/lsinfo.rs
@@ -6,12 +6,13 @@ use anyhow::Context;
 use derive_more::{AsMut, AsRef, Into, IntoIterator};
 
 #[derive(Debug, Default, IntoIterator, AsRef, AsMut, Into)]
-pub struct LsInfo(pub Vec<FileOrDir>);
+pub struct LsInfo(pub Vec<LsInfoEntry>);
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum FileOrDir {
+pub enum LsInfoEntry {
     Dir(Dir),
     File(Song),
+    Playlist(Playlist),
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -21,6 +22,11 @@ pub struct Dir {
     /// this is the full path from mpd root
     pub full_path: String,
     pub last_modified: String,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Playlist {
+    name: String,
 }
 
 impl FromMpd for Dir {
@@ -42,13 +48,26 @@ impl FromMpd for Dir {
     }
 }
 
+impl FromMpd for Playlist {
+    fn next_internal(&mut self, key: &str, value: String) -> Result<LineHandled, MpdError> {
+        match key {
+            "playlist" => self.name = value,
+            _ => return Ok(LineHandled::No { value }),
+        }
+        Ok(LineHandled::Yes)
+    }
+}
+
 impl FromMpd for LsInfo {
     fn next_internal(&mut self, key: &str, value: String) -> Result<LineHandled, MpdError> {
         if key == "file" {
-            self.0.push(FileOrDir::File(Song::default()));
+            self.0.push(LsInfoEntry::File(Song::default()));
         }
         if key == "directory" {
-            self.0.push(FileOrDir::Dir(Dir::default()));
+            self.0.push(LsInfoEntry::Dir(Dir::default()));
+        }
+        if key == "playlist" {
+            self.0.push(LsInfoEntry::Playlist(Playlist::default()));
         }
 
         match self.0.last_mut().context(anyhow!(
@@ -56,8 +75,80 @@ impl FromMpd for LsInfo {
             key,
             value
         ))? {
-            FileOrDir::Dir(dir) => dir.next_internal(key, value),
-            FileOrDir::File(song) => song.next_internal(key, value),
+            LsInfoEntry::Dir(dir) => dir.next_internal(key, value),
+            LsInfoEntry::File(song) => song.next_internal(key, value),
+            LsInfoEntry::Playlist(playlist) => playlist.next_internal(key, value),
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use crate::mpd::commands::lsinfo::{Dir, LsInfoEntry, Playlist};
+
+    use super::{FromMpd, LsInfo};
+
+    #[test]
+    fn lsinfoplaylist() {
+        let input = r"playlist: autechre.m3u
+Last-Modified: 2024-10-30T00:04:26Z
+directory: .cue
+Last-Modified: 2024-11-02T02:55:40Z
+directory: .win
+Last-Modified: 2024-09-15T19:39:47Z
+directory: flac
+Last-Modified: 2024-12-23T00:11:38Z
+directory: wav
+Last-Modified: 2024-08-12T03:03:40Z";
+
+        let mut result = LsInfo::default();
+        for line in input.lines() {
+            let (key, value) = line.split_once(": ").unwrap();
+            result
+                .next_internal(key.to_lowercase().as_str(), value.to_owned())
+                .unwrap();
+        }
+
+        let result = result.0;
+        assert_eq!(result.len(), 5);
+        assert_eq!(
+            result[0],
+            LsInfoEntry::Playlist(Playlist {
+                name: "autechre.m3u".to_owned(),
+            })
+        );
+        assert_eq!(
+            result[1],
+            LsInfoEntry::Dir(Dir {
+                path: ".cue".to_owned(),
+                full_path: ".cue".to_owned(),
+                last_modified: "2024-11-02T02:55:40Z".to_owned()
+            })
+        );
+        assert_eq!(
+            result[2],
+            LsInfoEntry::Dir(Dir {
+                path: ".win".to_owned(),
+                full_path: ".win".to_owned(),
+                last_modified: "2024-09-15T19:39:47Z".to_owned()
+            })
+        );
+        assert_eq!(
+            result[3],
+            LsInfoEntry::Dir(Dir {
+                path: "flac".to_owned(),
+                full_path: "flac".to_owned(),
+                last_modified: "2024-12-23T00:11:38Z".to_owned()
+            })
+        );
+        assert_eq!(
+            result[4],
+            LsInfoEntry::Dir(Dir {
+                path: "wav".to_owned(),
+                full_path: "wav".to_owned(),
+                last_modified: "2024-08-12T03:03:40Z".to_owned()
+            })
+        );
     }
 }

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -160,7 +160,7 @@ pub(crate) mod browser {
 
     use crate::{
         config::theme::SymbolsConfig,
-        mpd::commands::{lsinfo::FileOrDir, Song},
+        mpd::commands::{lsinfo::LsInfoEntry, Song},
     };
 
     impl Song {
@@ -296,13 +296,14 @@ pub(crate) mod browser {
         }
     }
 
-    impl From<FileOrDir> for DirOrSong {
-        fn from(value: FileOrDir) -> Self {
+    impl From<LsInfoEntry> for Option<DirOrSong> {
+        fn from(value: LsInfoEntry) -> Self {
             match value {
-                FileOrDir::Dir(crate::mpd::commands::lsinfo::Dir { path, full_path, .. }) => {
-                    DirOrSong::Dir { name: path, full_path }
+                LsInfoEntry::Dir(crate::mpd::commands::lsinfo::Dir { path, full_path, .. }) => {
+                    Some(DirOrSong::Dir { name: path, full_path })
                 }
-                FileOrDir::File(song) => DirOrSong::Song(song),
+                LsInfoEntry::File(song) => Some(DirOrSong::Song(song)),
+                LsInfoEntry::Playlist(_) => None,
             }
         }
     }


### PR DESCRIPTION
This properly supports the `playlist` entry in `lsinfo` MPD protocol command. The `playlist` as a key was ignored untill now because that behaviour is deprecated by mpd. The ignore was however done incorrectly and could result in incorrect parsing of MPD's response and sometimes even fail altogether.
