### PR TITLE
fix: album art showing when its not supposed to

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -605,19 +605,24 @@ impl<'ui> Ui<'ui> {
         data: MpdQueryResult,
         context: &mut AppContext,
     ) -> Result<()> {
+        let contains_pane = |p| {
+            self.tabs
+                .get(&self.active_tab)
+                .is_some_and(|tab| tab.panes.panes_iter().any(|pane| pane.pane == p))
+        };
         match pane {
             Some(pane) => match self.panes.get_mut(pane) {
                 #[cfg(debug_assertions)]
-                Panes::Logs(p) => p.on_query_finished(id, data, context),
-                Panes::Queue(p) => p.on_query_finished(id, data, context),
-                Panes::Directories(p) => p.on_query_finished(id, data, context),
-                Panes::Albums(p) => p.on_query_finished(id, data, context),
-                Panes::Artists(p) => p.on_query_finished(id, data, context),
-                Panes::Playlists(p) => p.on_query_finished(id, data, context),
-                Panes::Search(p) => p.on_query_finished(id, data, context),
-                Panes::AlbumArtists(p) => p.on_query_finished(id, data, context),
-                Panes::AlbumArt(p) => p.on_query_finished(id, data, context),
-                Panes::Lyrics(p) => p.on_query_finished(id, data, context),
+                Panes::Logs(p) => p.on_query_finished(id, data, contains_pane(PaneType::Logs), context),
+                Panes::Queue(p) => p.on_query_finished(id, data, contains_pane(PaneType::Queue), context),
+                Panes::Directories(p) => p.on_query_finished(id, data, contains_pane(PaneType::Directories), context),
+                Panes::Albums(p) => p.on_query_finished(id, data, contains_pane(PaneType::Albums), context),
+                Panes::Artists(p) => p.on_query_finished(id, data, contains_pane(PaneType::Artists), context),
+                Panes::Playlists(p) => p.on_query_finished(id, data, contains_pane(PaneType::Playlists), context),
+                Panes::Search(p) => p.on_query_finished(id, data, contains_pane(PaneType::Search), context),
+                Panes::AlbumArtists(p) => p.on_query_finished(id, data, contains_pane(PaneType::AlbumArtists), context),
+                Panes::AlbumArt(p) => p.on_query_finished(id, data, contains_pane(PaneType::AlbumArt), context),
+                Panes::Lyrics(p) => p.on_query_finished(id, data, contains_pane(PaneType::Lyrics), context),
             }?,
             None => match (id, data) {
                 (OPEN_OUTPUTS_MODAL, MpdQueryResult::Outputs(outputs)) => {

--- a/src/ui/panes/album_art.rs
+++ b/src/ui/panes/album_art.rs
@@ -89,7 +89,16 @@ impl Pane for AlbumArtPane {
         Ok(())
     }
 
-    fn on_query_finished(&mut self, id: &'static str, data: MpdQueryResult, _context: &AppContext) -> Result<()> {
+    fn on_query_finished(
+        &mut self,
+        id: &'static str,
+        data: MpdQueryResult,
+        is_visible: bool,
+        _context: &AppContext,
+    ) -> Result<()> {
+        if !is_visible {
+            return Ok(());
+        }
         match (id, data) {
             (ALBUM_ART, MpdQueryResult::AlbumArt(Some(data))) => {
                 self.album_art.show(data)?;
@@ -109,11 +118,11 @@ impl Pane for AlbumArtPane {
                     self.album_art.show_default()?;
                 }
             }
-            UiEvent::ModalOpened => {
+            UiEvent::ModalOpened if is_visible => {
                 self.album_art.hide()?;
                 context.render()?;
             }
-            UiEvent::ModalClosed => {
+            UiEvent::ModalClosed if is_visible => {
                 self.album_art.show_current()?;
                 context.render()?;
             }

--- a/src/ui/panes/albums.rs
+++ b/src/ui/panes/albums.rs
@@ -155,7 +155,13 @@ impl Pane for AlbumsPane {
         Ok(())
     }
 
-    fn on_query_finished(&mut self, id: &'static str, data: MpdQueryResult, context: &AppContext) -> Result<()> {
+    fn on_query_finished(
+        &mut self,
+        id: &'static str,
+        data: MpdQueryResult,
+        _is_visible: bool,
+        context: &AppContext,
+    ) -> Result<()> {
         match (id, data) {
             (PREVIEW, MpdQueryResult::Preview { data, origin_path }) => {
                 if let Some(origin_path) = origin_path {

--- a/src/ui/panes/artists.rs
+++ b/src/ui/panes/artists.rs
@@ -280,7 +280,13 @@ impl Pane for ArtistsPane {
         Ok(())
     }
 
-    fn on_query_finished(&mut self, id: &'static str, data: MpdQueryResult, context: &AppContext) -> Result<()> {
+    fn on_query_finished(
+        &mut self,
+        id: &'static str,
+        data: MpdQueryResult,
+        _is_visible: bool,
+        context: &AppContext,
+    ) -> Result<()> {
         match (id, data) {
             (PREVIEW, MpdQueryResult::SongsList { data, origin_path }) => {
                 let Some(artist) = origin_path.and_then(|mut v| v.first_mut().map(std::mem::take)) else {

--- a/src/ui/panes/directories.rs
+++ b/src/ui/panes/directories.rs
@@ -173,7 +173,13 @@ impl Pane for DirectoriesPane {
         Ok(())
     }
 
-    fn on_query_finished(&mut self, id: &'static str, data: MpdQueryResult, context: &AppContext) -> Result<()> {
+    fn on_query_finished(
+        &mut self,
+        id: &'static str,
+        data: MpdQueryResult,
+        _is_visible: bool,
+        context: &AppContext,
+    ) -> Result<()> {
         match (id, data) {
             (PREVIEW, MpdQueryResult::Preview { data, origin_path }) => {
                 if let Some(origin_path) = origin_path {

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -136,7 +136,13 @@ pub(super) trait Pane {
         Ok(())
     }
 
-    fn on_query_finished(&mut self, id: &'static str, data: MpdQueryResult, context: &AppContext) -> Result<()> {
+    fn on_query_finished(
+        &mut self,
+        id: &'static str,
+        data: MpdQueryResult,
+        is_visible: bool,
+        context: &AppContext,
+    ) -> Result<()> {
         Ok(())
     }
 

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -189,7 +189,13 @@ impl Pane for PlaylistsPane {
         Ok(())
     }
 
-    fn on_query_finished(&mut self, id: &'static str, mpd_command: MpdQueryResult, context: &AppContext) -> Result<()> {
+    fn on_query_finished(
+        &mut self,
+        id: &'static str,
+        mpd_command: MpdQueryResult,
+        _is_visible: bool,
+        context: &AppContext,
+    ) -> Result<()> {
         match (id, mpd_command) {
             (PREVIEW, MpdQueryResult::Preview { data, origin_path }) => {
                 if let Some(origin_path) = origin_path {

--- a/src/ui/panes/playlists/tests.rs
+++ b/src/ui/panes/playlists/tests.rs
@@ -32,6 +32,7 @@ mod on_idle_event {
                         data: vec![dir("pl1"), dir("pl2"), dir("pl3"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -46,6 +47,7 @@ mod on_idle_event {
                         data: vec![dir("pl2"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -65,6 +67,7 @@ mod on_idle_event {
                         data: vec![dir("pl1"), dir("pl2"), dir("pl3"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -77,6 +80,7 @@ mod on_idle_event {
                         data: vec![dir("pl1"), dir("pl2"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -96,6 +100,7 @@ mod on_idle_event {
                         data: vec![dir("pl1"), dir("pl2"), dir("pl3"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -108,6 +113,7 @@ mod on_idle_event {
                         data: vec![dir("pl1"), dir("pl2")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -127,6 +133,7 @@ mod on_idle_event {
                         data: vec![dir("pl1"), dir("pl2"), dir("pl3"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -138,6 +145,7 @@ mod on_idle_event {
                         data: vec![dir("pl3"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -171,6 +179,7 @@ mod on_idle_event {
                         data: vec![dir("pl1"), dir("pl2"), dir("pl3"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -183,6 +192,7 @@ mod on_idle_event {
                         data: initial_songs.clone(),
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -212,6 +222,7 @@ mod on_idle_event {
                         data: vec![dir("pl2"), dir("pl3"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -238,6 +249,7 @@ mod on_idle_event {
                         data: vec![dir("pl1"), dir("pl2"), dir("pl3"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -250,6 +262,7 @@ mod on_idle_event {
                         data: initial_songs.clone(),
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -279,6 +292,7 @@ mod on_idle_event {
                         data: vec![dir("pl1"), dir("pl2"), dir("pl3"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -306,6 +320,7 @@ mod on_idle_event {
                         data: vec![dir("pl1"), dir("pl2"), dir("pl3"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -318,6 +333,7 @@ mod on_idle_event {
                         data: initial_songs.clone(),
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -347,6 +363,7 @@ mod on_idle_event {
                         data: vec![dir("pl1"), dir("pl2"), dir("pl3"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -373,6 +390,7 @@ mod on_idle_event {
                         data: vec![dir("pl1"), dir("pl2"), dir("pl3"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -385,6 +403,7 @@ mod on_idle_event {
                         data: initial_songs.clone(),
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -414,6 +433,7 @@ mod on_idle_event {
                         data: vec![dir("pl1"), dir("pl2"), dir("pl3"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -441,6 +461,7 @@ mod on_idle_event {
                         data: initial_playlists,
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -453,6 +474,7 @@ mod on_idle_event {
                         data: initial_songs.clone(),
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();
@@ -482,6 +504,7 @@ mod on_idle_event {
                         data: vec![dir("pl1"), dir("pl2"), dir("pl4")],
                         origin_path: None,
                     },
+                    true,
                     &app_context,
                 )
                 .unwrap();

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -321,7 +321,13 @@ impl Pane for QueuePane {
         Ok(())
     }
 
-    fn on_query_finished(&mut self, id: &'static str, data: MpdQueryResult, context: &AppContext) -> Result<()> {
+    fn on_query_finished(
+        &mut self,
+        id: &'static str,
+        data: MpdQueryResult,
+        _is_visible: bool,
+        context: &AppContext,
+    ) -> Result<()> {
         match (id, data) {
             (ADD_TO_PLAYLIST, MpdQueryResult::AddToPlaylist { playlists, song_file }) => {
                 modal!(

--- a/src/ui/panes/search.rs
+++ b/src/ui/panes/search.rs
@@ -587,7 +587,13 @@ impl Pane for SearchPane {
         Ok(())
     }
 
-    fn on_query_finished(&mut self, id: &'static str, data: MpdQueryResult, context: &AppContext) -> Result<()> {
+    fn on_query_finished(
+        &mut self,
+        id: &'static str,
+        data: MpdQueryResult,
+        _is_visible: bool,
+        context: &AppContext,
+    ) -> Result<()> {
         match (id, data) {
             (PREVIEW, MpdQueryResult::Preview { data, origin_path }) => {
                 let Some(selected) = self.songs_dir.selected().map(|s| [s.as_path()]) else {


### PR DESCRIPTION
fixes album art showing after closing modal on a tab which does not containt an album art also fixes album art showing on other tab if user switches tabs before the image download finishes

fixes https://github.com/mierak/rmpc/issues/206