### PR TITLE
feat: schedule precise render fiming for lyrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Improved navigation between Pane splits by including recency bias
 - CLI now parses only the required part of the config
 - Status messages will now disappar automatically even when idle
+- Lyrics should now sync better because they are now scheduled precisely instead of periodically
 
 ### Fixed
 

--- a/src/core/scheduler/mod.rs
+++ b/src/core/scheduler/mod.rs
@@ -112,7 +112,7 @@ impl<T: Clone + Send + 'static + std::fmt::Debug> Scheduler<T> {
     /// Schedules a job to run after the specified duration.
     /// A job must guarantee that it will not block the scheduler.
     pub(crate) fn schedule(
-        &mut self,
+        &self,
         timeout: Duration,
         callback: impl FnOnce(&T) -> Result<()> + Send + 'static,
     ) {
@@ -132,7 +132,7 @@ impl<T: Clone + Send + 'static + std::fmt::Debug> Scheduler<T> {
     /// not guarantee that the job will not run at least once more.
     #[must_use = "When the return value is dropped the job is cancelled"]
     pub(crate) fn repeated(
-        &mut self,
+        &self,
         interval: Duration,
         callback: impl FnMut(&T) -> Result<()> + Send + 'static,
     ) -> TaskGuard<T> {

--- a/src/shared/mpd_query.rs
+++ b/src/shared/mpd_query.rs
@@ -5,14 +5,22 @@ use bon::Builder;
 use crossbeam::channel::Sender;
 use ratatui::widgets::ListItem;
 
+use super::events::AppEvent;
 use crate::{
     config::tabs::PaneType,
     mpd::{
         client::Client,
         commands::{Decoder, Output, Song, Status, Volume},
+        mpd_client::MpdClient,
     },
+    shared::{events::ClientRequest, macros::try_skip},
     ui::panes::browser::DirOrSong,
 };
+
+pub const EXTERNAL_COMMAND: &str = "external_command";
+pub const GLOBAL_STATUS_UPDATE: &str = "global_status_update";
+pub const GLOBAL_VOLUME_UPDATE: &str = "global_volume_update";
+pub const GLOBAL_QUEUE_UPDATE: &str = "global_queue_update";
 
 #[derive(derive_more::Debug, Builder)]
 pub(crate) struct MpdQuery {
@@ -67,4 +75,19 @@ pub(crate) enum MpdQueryResult {
     Decoders(Vec<Decoder>),
     ExternalCommand(&'static [&'static str], Vec<Song>),
     Any(Box<dyn Any + Send + Sync>),
+}
+
+// Is used as a scheduled function and thus needs the -> Result<()>
+#[allow(clippy::unnecessary_wraps)]
+pub fn run_status_update((_, client_tx): &(Sender<AppEvent>, Sender<ClientRequest>)) -> Result<()> {
+    try_skip!(
+        client_tx.send(ClientRequest::Query(MpdQuery {
+            id: GLOBAL_STATUS_UPDATE,
+            target: None,
+            replace_id: Some("status"),
+            callback: Box::new(move |client| Ok(MpdQueryResult::Status(client.get_status()?))),
+        })),
+        "Failed to send status update query"
+    );
+    Ok(())
 }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -11,11 +11,11 @@ use crate::{
     MpdQueryResult,
     config::keys::{CommonAction, GlobalAction},
     context::AppContext,
-    core::event_loop::EXTERNAL_COMMAND,
     mpd::{client::Client, commands::Song},
     shared::{
         key_event::KeyEvent,
         mouse_event::{MouseEvent, MouseEventKind},
+        mpd_query::EXTERNAL_COMMAND,
     },
 };
 


### PR DESCRIPTION
With the newly introduced scheduler, it is now possible to trigger lyrics update precisely when they are supposed to be displayed. Previously they were refreshed periodically with interval set by `status_update_interval_ms` only which could result in small delays between lrc line switching.