### PR TITLE
[WIP] feat: better borders in tabs/layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Introduced `StateV2` property as a replacement for `State`. It has additional config properties compared to its predecesor.
 - Introduced `RandomV2`, `ConsumeV2`, `RepeatV2` and `SingleV2` properties as a replacement for their respective earlier versions.
 They have additional config properties compared to their predecesors.
+- `borders` configuration in the tabs configuration
 
 ### Changed
 
@@ -51,6 +52,7 @@ They have additional config properties compared to their predecesors.
 
 ### Deprecated
 
+- `border_type` in tabs config. It has been replaced by the new and more powerful `borders`
 - `theme.tab_bar.enabled` replaced by layout configuration
 - `State` header property
 - `RandomV2`, `ConsumeV2`, `RepeatV2` and `SingleV2` header properties

--- a/docs/src/content/docs/next/assets/example_config.ron
+++ b/docs/src/content/docs/next/assets/example_config.ron
@@ -114,7 +114,6 @@
     tabs: [
         (
             name: "Queue",
-            border_type: None,
             pane: Split(
                 direction: Horizontal,
                 panes: [(size: "40%", pane: Pane(AlbumArt)), (size: "60%", pane: Pane(Queue))],
@@ -122,32 +121,26 @@
         ),
         (
             name: "Directories",
-            border_type: None,
             pane: Pane(Directories),
         ),
         (
             name: "Artists",
-            border_type: None,
             pane: Pane(Artists),
         ),
         (
             name: "Album Artists",
-            border_type: None,
             pane: Pane(AlbumArtists),
         ),
         (
             name: "Albums",
-            border_type: None,
             pane: Pane(Albums),
         ),
         (
             name: "Playlists",
-            border_type: None,
             pane: Pane(Playlists),
         ),
         (
             name: "Search",
-            border_type: None,
             pane: Pane(Search),
         ),
     ],

--- a/docs/src/content/docs/next/configuration/tabs.mdx
+++ b/docs/src/content/docs/next/configuration/tabs.mdx
@@ -17,24 +17,15 @@ Check out the <a href={path("reference/config/")}>default config</a> for referen
 
 ## tab
 
-<ConfigValue name="tab" customText='(name: "<string>", border_type: None | Single | Full, pane: Pane | Split)' />
+<ConfigValue name="tab" customText='(name: "<string>", pane: Pane | Split)' />
 
-A single tab that will be shown by rmpc. Each tab has a name that is displayed in the tab bar, the type of border that are
-going to be displayed and either a single or multiple `Pane`s.
+A single tab that will be shown by rmpc. Each tab has a name that is displayed in the tab bar and either a single or multiple `Pane`s.
 
 ### name
 
 <ConfigValue name="name" type="string" />
 
 Each tab has a name which will be displayed in the tab bar and can be used in the `SwitchToTab(<name>)` keybind.
-
-### border_type
-
-<ConfigValue name="border_type" type={["None", "Single", "Full"]} />
-
-Kind of borders that will be displayed around each pane. `None` means no borders, `Single` means only borders between
-panes and `Full` means borders on each side of each pane. The borders use `highlight_border_style` for the currently
-focused pane and `borders_style` for all others.
 
 ### pane
 
@@ -45,9 +36,9 @@ into multiple sub panes. `Pane` simply displays the given `pane_type`.
 
 ## Pane | Split
 
--   `Pane(<pane_type>)` - Displays the given pane type itself.
--   `Split(direction: Horizontal | Vertical, panes: <sub_panes[]>)` splits the pane into multiple sub panes. Each split has
-    a direction and a list of sub panes.
+- `Pane(<pane_type>)` - Displays the given pane type itself.
+- `Split(direction: Horizontal | Vertical, borders: <borders>, panes: <sub_panes[]>)` splits the pane into multiple sub panes. Each split has
+  a direction and a list of sub panes. More info on borders in [their section](#borders).
 
 ### direction
 
@@ -57,24 +48,97 @@ Determines which direction the pane will be split into.
 
 ### panes
 
-<ConfigValue name="panes" customText="(size: '50%', pane: Split() | Pane(<pane_type>)" />
+<ConfigValue name="panes" customText="(size: '50%', borders: <borders>, pane: Split() | Pane(<pane_type>)" />
 
 Sub panes for the given split. The size can be either percent (`50%`) or exact value(`3`). Exact value will reserve exactly that many rows/columns.
-Each sub pane can be either a `Pane` or another `Split`.
+Each sub pane can be either a `Pane` or another `Split`. Sub pane can also have borders, more info in [their section](#borders).
 
 ## pane_type
 
 Rmpc has several pane_types which can be displayed. These are:
 
--   `AlbumArt` - The album art. Cannot be focused.
--   `Queue` - Table of the current song queue.
--   `Directories` - Browse music library by directory.
--   `Artists` - Browse music library by `artist` tag.
--   `AlbumArtists` - Browse music library by `albumartist` tag.
--   `Albums` - Browse music library by `album` tag.
--   `Playlists` - Browse saved playlists.
--   `Search` - Search music library.
--   `Lyrics` - Display synced lyrics.
--   `ProgressBar` - Displays the progress of the currently playing song
--   `Header` - Displays various information about the current song and MPD's states, configurable in your theme
--   `Tabs` - Displays a simple tab bar showing what tabs are available and which one is active
+- `AlbumArt` - The album art. Cannot be focused.
+- `Queue` - Table of the current song queue.
+- `Directories` - Browse music library by directory.
+- `Artists` - Browse music library by `artist` tag.
+- `AlbumArtists` - Browse music library by `albumartist` tag.
+- `Albums` - Browse music library by `album` tag.
+- `Playlists` - Browse saved playlists.
+- `Search` - Search music library.
+- `Lyrics` - Display synced lyrics.
+- `ProgressBar` - Displays the progress of the currently playing song
+- `Header` - Displays various information about the current song and MPD's states, configurable in your theme
+- `Tabs` - Displays a simple tab bar showing what tabs are available and which one is active
+
+## borders
+
+<ConfigValue name="borders" type={['"NONE"', '"ALL"', '"LEFT"', '"RIGHT"', '"TOP"', '"BOTTOM"']} />
+
+Define what borders are rendered around a tab or one of its panes. Default is `"NONE"`, meaning no borders.
+By specifying `"ALL"` the borders will be on all sides of the pane/tab. The above values can also be combined,
+if you for example want borders on the left and right, you can achieve it by defining `"LEFT" | "RIGHT"`.
+
+## Examples
+
+Some tabs config examples below.
+
+### Single border between panes
+
+Single tab with queue and album art, with a border between them and also border around the whole split.
+
+<details>
+
+<summary>Click to expand</summary>
+
+```rust
+tabs: [
+    (
+        name: "Queue",
+        pane: Split(
+            direction: Horizontal,
+            borders: "ALL",
+            panes: [
+                (
+                    size: "40%",
+                    borders: "RIGHT",
+                    pane: Pane(AlbumArt),
+                ),
+                (
+                    size: "60%",
+                    pane: Pane(Queue),
+                ),
+            ],
+        ),
+    ),
+]
+```
+
+</details>
+
+### Single pane tab, border on left and right
+
+You have to use `Split` here even for a single pane if you want a border.
+
+<details>
+
+<summary>Click to expand</summary>
+
+```rust
+tabs: [
+    (
+        name: "Tab",
+        pane: Split(
+            direction: Horizontal,
+            borders: "LEFT | RIGHT",
+            panes: [
+                (
+                    size: "100%",
+                    pane: Pane(Queue),
+                ),
+            ],
+        ),
+    ),
+]
+```
+
+</details>

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -203,10 +203,11 @@ impl ConfigFile {
         let active_panes = tabs
             .tabs
             .iter()
-            .flat_map(|(_, tab)| tab.panes.panes_iter().map(|pane| pane.pane))
-            .chain(theme.layout.panes_iter().map(|pane| pane.pane))
+            .flat_map(|(_, tab)| tab.panes.panes_iter().map(|pane| &pane.pane))
+            .chain(theme.layout.panes_iter().map(|pane| &pane.pane))
             .sorted()
             .dedup()
+            .cloned()
             .collect_vec()
             .leak();
 

--- a/src/config/tabs.rs
+++ b/src/config/tabs.rs
@@ -141,10 +141,11 @@ impl TryFrom<TabsFile> for Tabs {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum BorderTypeFile {
     Full,
     Single,
+    #[default]
     None,
 }
 
@@ -178,6 +179,7 @@ pub struct Tabs {
 struct TabFile {
     name: String,
     #[deprecated]
+    #[serde(default)]
     border_type: BorderTypeFile,
     pane: PaneOrSplitFile,
 }

--- a/src/config/tabs.rs
+++ b/src/config/tabs.rs
@@ -149,23 +149,6 @@ pub enum BorderTypeFile {
     None,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum BorderType {
-    Full,
-    Single,
-    None,
-}
-
-impl From<BorderTypeFile> for BorderType {
-    fn from(value: BorderTypeFile) -> Self {
-        match value {
-            BorderTypeFile::Full => BorderType::Full,
-            BorderTypeFile::Single => BorderType::Single,
-            BorderTypeFile::None => BorderType::None,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(super) struct TabsFile(Vec<TabFile>);
 

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -23,12 +23,12 @@ pub use style::{ConfigColor, StyleFile};
 pub use self::queue_table::{PercentOrLength, SongTableColumn};
 use super::{
     defaults,
-    tabs::{BorderTypeFile, PaneOrSplitFile, SizedPaneOrSplit},
+    tabs::{PaneOrSplitFile, SizedPaneOrSplit},
 };
 
 const DEFAULT_ART: &[u8; 58599] = include_bytes!("../../../assets/default.jpg");
 
-#[derive(Default, Clone)]
+#[derive(derive_more::Debug, Default, Clone)]
 pub struct UiConfig {
     pub draw_borders: bool,
     pub background_color: Option<Color>,
@@ -48,34 +48,9 @@ pub struct UiConfig {
     pub show_song_table_header: bool,
     pub song_table_format: &'static [SongTableColumn],
     pub header: HeaderConfig,
+    #[debug("{}", default_album_art.len())]
     pub default_album_art: &'static [u8],
     pub layout: SizedPaneOrSplit,
-}
-
-impl std::fmt::Debug for UiConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "UiConfig {{ draw_borders: {}, background_color: {:?}, header_background_color: {:?}, background_color_modal: {:?}, borders_style: {:?}, highlighted_item_style: {:?}, current_item_style: {:?}, highlight_border_style: {:?}, tab_bar: {:?}, column_widths: {:?}, symbols: {:?}, progress_bar: {:?}, scrollbar: {:?}, show_song_table_header: {}, song_table_format: {:?}, header: {:?}, default_album_art: [u8; {}] }}",
-            self.draw_borders,
-            self.background_color,
-            self.header_background_color,
-            self.modal_background_color,
-            self.borders_style,
-            self.highlighted_item_style,
-            self.current_item_style,
-            self.highlight_border_style,
-            self.tab_bar,
-            self.column_widths,
-            self.symbols,
-            self.progress_bar,
-            self.scrollbar,
-            self.show_song_table_header,
-            self.song_table_format,
-            self.header,
-            self.default_album_art.len()
-        )
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -214,7 +189,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
         let fallback_border_fg = Color::White;
 
         Ok(Self {
-            layout: value.layout.convert(BorderTypeFile::None)?,
+            layout: value.layout.convert()?,
             background_color: bg_color,
             draw_borders: value.draw_borders,
             modal_background_color: StringColor(value.modal_background_color)

--- a/src/config/theme/properties.rs
+++ b/src/config/theme/properties.rs
@@ -8,7 +8,7 @@ use strum::Display;
 use super::style::ToConfigOr;
 use crate::config::{Leak, defaults, theme::StyleFile};
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum SongPropertyFile {
     Filename,
     File,
@@ -32,7 +32,7 @@ pub enum SongProperty {
     Other(&'static str),
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub enum StatusPropertyFile {
     Volume,
     Repeat,
@@ -96,15 +96,15 @@ pub enum StatusProperty {
     Bitrate,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PropertyKindFile {
     Song(SongPropertyFile),
     Status(StatusPropertyFile),
     Widget(WidgetPropertyFile),
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum PropertyKindFileOrText<T> {
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PropertyKindFileOrText<T: Clone> {
     Text(String),
     Sticker(String),
     Property(T),
@@ -112,8 +112,8 @@ pub enum PropertyKindFileOrText<T> {
 }
 
 #[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct PropertyFile<T> {
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PropertyFile<T: Clone> {
     pub kind: PropertyKindFileOrText<T>,
     pub style: Option<StyleFile>,
     pub default: Option<Box<PropertyFile<T>>>,
@@ -154,7 +154,7 @@ pub struct Property<'a, T> {
     pub default: Option<&'a Property<'a, T>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum WidgetPropertyFile {
     States { active_style: Option<StyleFile>, separator_style: Option<StyleFile> },
     Volume,
@@ -323,7 +323,7 @@ impl TryFrom<PropertyFile<PropertyKindFile>> for Property<'static, PropertyKind>
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SongFormatFile(pub Vec<PropertyFile<SongPropertyFile>>);
 
-#[derive(Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct SongFormat(pub &'static [&'static Property<'static, SongProperty>]);
 
 impl TryFrom<SongFormatFile> for SongFormat {

--- a/src/config/theme/style.rs
+++ b/src/config/theme/style.rs
@@ -22,7 +22,7 @@ impl StringColor {
 }
 
 #[skip_serializing_none]
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StyleFile {
     pub(super) fg: Option<String>,
     pub(super) bg: Option<String>,
@@ -195,7 +195,7 @@ impl TryFrom<&[u8]> for crate::config::ConfigColor {
 }
 
 bitflags! {
-    #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize, Eq, PartialEq)]
     pub struct Modifiers: u16 {
         const Bold       = 0b0000_0000_0001;
         const Dim        = 0b0000_0000_0010;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -113,8 +113,8 @@ impl<'ui> Ui<'ui> {
     }
 
     fn change_tab(&mut self, new_tab: TabName, context: &AppContext) -> Result<()> {
-        self.layout.for_each_pane(None, self.area, context, &mut |pane, _, _, _| {
-            match self.panes.get_mut(pane.pane) {
+        self.layout.for_each_pane(self.area, &mut |pane, _, _, _| {
+            match self.panes.get_mut(&pane.pane) {
                 Panes::TabContent => {
                     active_tab_call!(self, on_hide(context))?;
                 }
@@ -126,8 +126,8 @@ impl<'ui> Ui<'ui> {
         self.active_tab = new_tab;
         self.on_event(UiEvent::TabChanged(new_tab), context)?;
 
-        self.layout.for_each_pane(None, self.area, context, &mut |pane, pane_area, _, _| {
-            match self.panes.get_mut(pane.pane) {
+        self.layout.for_each_pane(self.area, &mut |pane, pane_area, _, _| {
+            match self.panes.get_mut(&pane.pane) {
                 Panes::TabContent => {
                     active_tab_call!(self, before_show(pane_area, context))?;
                 }
@@ -144,12 +144,11 @@ impl<'ui> Ui<'ui> {
                 .render_widget(Block::default().style(Style::default().bg(bg_color)), frame.area());
         }
 
-        self.layout.for_each_pane(
-            None,
+        self.layout.for_each_pane_custom_data(
             self.area,
-            context,
-            &mut |pane, pane_area, block, block_area| {
-                match self.panes.get_mut(pane.pane) {
+            &mut *frame,
+            &mut |pane, pane_area, block, block_area, frame| {
+                match self.panes.get_mut(&pane.pane) {
                     Panes::TabContent => {
                         active_tab_call!(self, render(frame, pane_area, context))?;
                     }
@@ -157,7 +156,17 @@ impl<'ui> Ui<'ui> {
                         pane_call!(pane_instance, render(frame, pane_area, context))?;
                     }
                 };
-                frame.render_widget(block, block_area);
+                frame.render_widget(
+                    block.border_style(context.config.as_border_style()),
+                    block_area,
+                );
+                Ok(())
+            },
+            &mut |block, block_area, frame| {
+                frame.render_widget(
+                    block.border_style(context.config.as_border_style()),
+                    block_area,
+                );
                 Ok(())
             },
         )?;
@@ -179,8 +188,8 @@ impl<'ui> Ui<'ui> {
             return Ok(());
         }
 
-        self.layout.for_each_pane(None, self.area, context, &mut |pane, _, _, _| {
-            match self.panes.get_mut(pane.pane) {
+        self.layout.for_each_pane(self.area, &mut |pane, _, _, _| {
+            match self.panes.get_mut(&pane.pane) {
                 Panes::TabContent => {
                     active_tab_call!(self, handle_mouse_event(event, context))?;
                 }
@@ -393,8 +402,8 @@ impl<'ui> Ui<'ui> {
     pub fn before_show(&mut self, area: Rect, context: &mut AppContext) -> Result<()> {
         self.calc_areas(area, context);
 
-        self.layout.for_each_pane(None, self.area, context, &mut |pane, pane_area, _, _| {
-            match self.panes.get_mut(pane.pane) {
+        self.layout.for_each_pane(self.area, &mut |pane, pane_area, _, _| {
+            match self.panes.get_mut(&pane.pane) {
                 Panes::TabContent => {
                     active_tab_call!(self, before_show(pane_area, context))?;
                 }
@@ -428,8 +437,8 @@ impl<'ui> Ui<'ui> {
         log::trace!(area:?; "Terminal was resized");
         self.calc_areas(area, context);
 
-        self.layout.for_each_pane(None, self.area, context, &mut |pane, pane_area, _, _| {
-            match self.panes.get_mut(pane.pane) {
+        self.layout.for_each_pane(self.area, &mut |pane, pane_area, _, _| {
+            match self.panes.get_mut(&pane.pane) {
                 Panes::TabContent => {
                     active_tab_call!(self, resize(pane_area, context))?;
                 }
@@ -460,7 +469,7 @@ impl<'ui> Ui<'ui> {
         };
 
         for name in context.config.active_panes {
-            match self.panes.get_mut(*name) {
+            match self.panes.get_mut(name) {
                 #[cfg(debug_assertions)]
                 Panes::Logs(p) => p.on_event(&mut event, contains_pane(PaneType::Logs), context),
                 Panes::Queue(p) => p.on_event(&mut event, contains_pane(PaneType::Queue), context),
@@ -520,7 +529,7 @@ impl<'ui> Ui<'ui> {
                 || self.layout.panes_iter().any(|pane| pane.pane == p)
         };
         match pane {
-            Some(pane) => match self.panes.get_mut(pane) {
+            Some(pane) => match self.panes.get_mut(&pane) {
                 #[cfg(debug_assertions)]
                 Panes::Logs(p) => {
                     p.on_query_finished(id, data, contains_pane(PaneType::Logs), context)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -101,7 +101,7 @@ impl<'ui> Ui<'ui> {
                 .tabs
                 .iter()
                 .map(|(name, screen)| -> Result<_> {
-                    Ok((*name, TabScreen::new(screen.panes.clone())))
+                    Ok((*name, TabScreen::new(screen.panes.clone())?))
                 })
                 .try_collect()?,
             area: Rect::default(),

--- a/src/ui/tab_screen.rs
+++ b/src/ui/tab_screen.rs
@@ -6,10 +6,7 @@ use ratatui::{Frame, layout::Rect};
 
 use super::{Pane as _, PaneContainer, Panes, panes::pane_call};
 use crate::{
-    config::{
-        keys::CommonAction,
-        tabs::{Pane, SizedPaneOrSplit},
-    },
+    config::{keys::CommonAction, tabs::SizedPaneOrSplit},
     context::AppContext,
     shared::{
         ext::{rect::RectExt, vec::VecExt},
@@ -40,7 +37,7 @@ impl PaneData {
 
 #[derive(Debug)]
 pub struct TabScreen {
-    focused: Option<Pane>, // can focused ever be none?
+    focused: Option<Id>, // can focused ever be none?
     pub panes: SizedPaneOrSplit,
     pane_data: HashMap<Id, PaneData>,
     initialized: bool,
@@ -48,13 +45,12 @@ pub struct TabScreen {
 
 impl TabScreen {
     pub fn new(panes: SizedPaneOrSplit) -> Self {
-        let focused = panes.panes_iter().next();
-        Self { panes, focused, initialized: false, pane_data: HashMap::default() }
+        Self { panes, focused: None, initialized: false, pane_data: HashMap::default() }
     }
 
-    fn set_focused(&mut self, pane: Option<Pane>) {
+    fn set_focused(&mut self, pane: Option<Id>) {
         self.focused = pane.or(self.focused);
-        if let Some(data) = pane.and_then(|pane| self.pane_data.get_mut(&pane.id)) {
+        if let Some(data) = pane.and_then(|id| self.pane_data.get_mut(&id)) {
             data.active = Instant::now();
         }
     }
@@ -68,20 +64,33 @@ impl TabScreen {
         area: Rect,
         context: &AppContext,
     ) -> Result<()> {
-        self.panes.for_each_pane(
-            self.focused,
+        let focused = self.panes.panes_iter().find(|pane| Some(pane.id) == self.focused);
+        self.panes.for_each_pane_custom_data(
             area,
-            context,
-            &mut |pane, area, block, block_area| {
+            frame,
+            &mut |pane, area, block, block_area, frame| {
                 let pane_data = self
                     .pane_data
                     .entry(pane.id)
                     .or_insert_with(|| PaneData::new(pane.is_focusable()));
                 pane_data.area = area;
                 pane_data.block_area = block_area;
-                let pane_instance = &mut pane_container.get_mut(pane.pane);
+                let block = block.border_style(if focused.is_some_and(|p| p.id == pane.id) {
+                    context.config.as_focused_border_style()
+                } else {
+                    context.config.as_border_style()
+                });
+
+                let pane_instance = &mut pane_container.get_mut(&pane.pane);
                 pane_call!(pane_instance, render(frame, area, context))?;
                 frame.render_widget(block, block_area);
+                Ok(())
+            },
+            &mut |block, block_area, frame| {
+                frame.render_widget(
+                    block.border_style(context.config.as_border_style()),
+                    block_area,
+                );
                 Ok(())
             },
         )?;
@@ -98,7 +107,7 @@ impl TabScreen {
             return Ok(());
         };
 
-        let Some(focused_pane_data) = self.pane_data.get(&focused.id) else {
+        let Some(focused_pane_data) = self.pane_data.get(&focused) else {
             log::warn!(focused:?, pane_areas:? = self.pane_data; "Tried to find focused pane area but it does not exist");
             return Ok(());
         };
@@ -114,7 +123,7 @@ impl TabScreen {
                     .max_by_key(|(_, data)| data.active)
                     .and_then(|(id, _)| self.panes.panes_iter().find(|pane| pane.id == *id));
 
-                self.set_focused(pane_to_focus);
+                self.set_focused(pane_to_focus.map(|pane| pane.id));
                 context.render()?;
             }
             Some(CommonAction::PaneDown) => {
@@ -126,7 +135,7 @@ impl TabScreen {
                     .max_by_key(|(_, data)| data.active)
                     .and_then(|(id, _)| self.panes.panes_iter().find(|pane| pane.id == *id));
 
-                self.set_focused(pane_to_focus);
+                self.set_focused(pane_to_focus.map(|pane| pane.id));
                 context.render()?;
             }
             Some(CommonAction::PaneRight) => {
@@ -138,7 +147,7 @@ impl TabScreen {
                     .max_by_key(|(_, data)| data.active)
                     .and_then(|(id, _)| self.panes.panes_iter().find(|pane| pane.id == *id));
 
-                self.set_focused(pane_to_focus);
+                self.set_focused(pane_to_focus.map(|pane| pane.id));
                 context.render()?;
             }
             Some(CommonAction::PaneLeft) => {
@@ -150,12 +159,18 @@ impl TabScreen {
                     .max_by_key(|(_, data)| data.active)
                     .and_then(|(id, _)| self.panes.panes_iter().find(|pane| pane.id == *id));
 
-                self.set_focused(pane_to_focus);
+                self.set_focused(pane_to_focus.map(|pane| pane.id));
                 context.render()?;
             }
             Some(_) | None => {
                 event.abandon();
-                let mut pane = panes.get_mut(focused.pane);
+                let Some(focused) = self.panes.panes_iter().find(|pane| pane.id == focused) else {
+                    log::error!(
+                        "Unable to find focused pane, this should not happen. Please report this issue."
+                    );
+                    return Ok(());
+                };
+                let mut pane = panes.get_mut(&focused.pane);
                 pane_call!(pane, handle_action(event, context))?;
             }
         };
@@ -180,7 +195,7 @@ impl TabScreen {
             else {
                 return Ok(());
             };
-            self.set_focused(Some(pane));
+            self.set_focused(Some(pane.id));
             context.render()?;
         }
 
@@ -188,14 +203,20 @@ impl TabScreen {
             return Ok(());
         };
 
-        let mut pane = panes.get_mut(focused.pane);
+        let Some(focused) = self.panes.panes_iter().find(|pane| pane.id == focused) else {
+            log::error!(
+                "Unable to find focused pane, this should not happen. Please report this issue."
+            );
+            return Ok(());
+        };
+        let mut pane = panes.get_mut(&focused.pane);
         pane_call!(pane, handle_mouse_event(event, context))?;
         Ok(())
     }
 
     pub fn on_hide(&mut self, panes: &mut PaneContainer, context: &AppContext) -> Result<()> {
         for pane in self.panes.panes_iter() {
-            let mut pane = panes.get_mut(pane.pane);
+            let mut pane = panes.get_mut(&pane.pane);
             pane_call!(pane, on_hide(context))?;
         }
         Ok(())
@@ -207,23 +228,16 @@ impl TabScreen {
         area: Rect,
         context: &AppContext,
     ) -> Result<()> {
-        self.panes.for_each_pane(
-            self.focused,
-            area,
-            context,
-            &mut |pane, pane_area, _, block_area| {
-                let pane_data = self
-                    .pane_data
-                    .entry(pane.id)
-                    .or_insert_with(|| PaneData::new(pane.is_focusable()));
-                pane_data.area = area;
-                pane_data.block_area = block_area;
-                let pane_instance = &mut pane_container.get_mut(pane.pane);
-                pane_call!(pane_instance, calculate_areas(pane_area, context))?;
-                pane_call!(pane_instance, before_show(context))?;
-                Ok(())
-            },
-        )?;
+        self.panes.for_each_pane(area, &mut |pane, pane_area, _, block_area| {
+            let pane_data =
+                self.pane_data.entry(pane.id).or_insert_with(|| PaneData::new(pane.is_focusable()));
+            pane_data.area = pane_area;
+            pane_data.block_area = block_area;
+            let pane_instance = &mut pane_container.get_mut(&pane.pane);
+            pane_call!(pane_instance, calculate_areas(pane_area, context))?;
+            pane_call!(pane_instance, before_show(context))?;
+            Ok(())
+        })?;
         if !self.initialized {
             self.set_focused(
                 self.pane_data
@@ -232,7 +246,8 @@ impl TabScreen {
                     .min_by(|(_, PaneData { area: a, .. }), (_, PaneData { area: b, .. })| {
                         a.left().cmp(&b.left()).then(a.top().cmp(&b.top()))
                     })
-                    .and_then(|entry| self.panes.panes_iter().find(|pane| &pane.id == entry.0)),
+                    .and_then(|entry| self.panes.panes_iter().find(|pane| &pane.id == entry.0))
+                    .map(|pane| pane.id),
             );
             self.initialized = true;
         };
@@ -246,23 +261,16 @@ impl TabScreen {
         area: Rect,
         context: &AppContext,
     ) -> Result<()> {
-        self.panes.for_each_pane(
-            self.focused,
-            area,
-            context,
-            &mut |pane, pane_area, _, block_area| {
-                let pane_data = self
-                    .pane_data
-                    .entry(pane.id)
-                    .or_insert_with(|| PaneData::new(pane.is_focusable()));
-                pane_data.area = area;
-                pane_data.block_area = block_area;
-                let pane_instance = &mut pane_container.get_mut(pane.pane);
-                pane_call!(pane_instance, calculate_areas(pane_area, context))?;
-                pane_call!(pane_instance, resize(pane_area, context))?;
-                Ok(())
-            },
-        )
+        self.panes.for_each_pane(area, &mut |pane, pane_area, _, block_area| {
+            let pane_data =
+                self.pane_data.entry(pane.id).or_insert_with(|| PaneData::new(pane.is_focusable()));
+            pane_data.area = area;
+            pane_data.block_area = block_area;
+            let pane_instance = &mut pane_container.get_mut(&pane.pane);
+            pane_call!(pane_instance, calculate_areas(pane_area, context))?;
+            pane_call!(pane_instance, resize(pane_area, context))?;
+            Ok(())
+        })
     }
 
     fn panes_directly_above(&self, focused_area: Rect) -> impl Iterator<Item = (&Id, &PaneData)> {


### PR DESCRIPTION
This PR deprecates the `border_type` property on tabs, it will be silently ignored. Instead you can now configure the borders per Pane/Split which allows you to replicate the former behavior while providing more control over them at the same time.

The borders are specified as `borders: "<value>"` where value can be `NONE`, `ALL`, `RIGHT`, `LEFT`, `TOP`, `BOTTOM`, their combination, ie. `borders: "RIGHT | LEFT"` or omitted altogether which implies `NONE`.

Note that you now have to account for the borders if you use exact sizing of panes. For example if your `Header` is supposed to be 2 rows tall and has borders at `TOP` and `BOTTOM` you must set its size as `4` as seen in the example below.

Consider this layout:  

<details>

<summary>Click to expand</summary>

```rust
layout: Split(
    direction: Vertical,
    panes: [
        (
            borders: "ALL",
            pane: Pane(Header),
            size: "4",
        ),
        (
            pane: Pane(Tabs),
            size: "3",
        ),
        (
            borders: "ALL",
            pane: Pane(TabContent),
            size: "100%",
        ),
        (
            size: "3",
            pane: Split(
                direction: Horizontal,
                panes: [
                    (
                        borders: "ALL",
                        pane: Pane(ProgressBar),
                        size: "100%",
                    ),
                ]
            ),
        ),
    ],
),
```

</details>

Along with this tab definition:

<details>

<summary>Click to expand</summary>

```rust
(
    name: "Queue",
    pane: Split(
        direction: Horizontal,
        panes: [
            (
                size: "40%",
                borders: "RIGHT",
                pane: Pane(AlbumArt),
            ),
            (
                size: "60%",
                pane: Pane(Queue),
            ),
        ],
    ),
),

```

</details>

Produces this result:

![image](https://github.com/user-attachments/assets/30a5b541-b5ec-405c-9d41-5bf5840ffd41)
