### PR TITLE
fix: prevent album art rendering when modal is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ They have additional config properties compared to their predecesors.
 - rmpc waiting potentionally forever for MPD's response
 - Adding songs which do not belong to any album not working in `Artists` and `AlbumArtists` panes not working
 - Songs metadata not being sorted in preview column
+- Prevent album art rendering when modal is open
 
 ### Deprecated
 


### PR DESCRIPTION
Problem:
- Album art rerendering could overlap open modals, making content unreadable
- This occurred with events like `UiEvent::SongChanged`, `UiEvent::Reconnected`,
  and `AppEvent::Resized` while a modal was open on the queue list

Solution:
- Add an `is_modal_open` flag to AppContext to track modal state
- Implement checks to prevent album art rendering when a modal is open
- Defer album art updates until modal is closed
