### PR TITLE
feat: configurable styles for new per state properties

### DIFF
--- a/src/config/theme/header.rs
+++ b/src/config/theme/header.rs
@@ -64,6 +64,9 @@ impl Default for HeaderConfigFile {
                                     playing_label: defaults::default_playing_label(),
                                     paused_label: defaults::default_paused_label(),
                                     stopped_label: defaults::default_stopped_label(),
+                                    playing_style: None,
+                                    paused_style: None,
+                                    stopped_style: None,
                                 },
                             )),
                             style: Some(StyleFile {

--- a/src/config/theme/style.rs
+++ b/src/config/theme/style.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, bail};
 use bitflags::bitflags;
+use bon::Builder;
 use ratatui::style::Color as RColor;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -22,7 +23,7 @@ impl StringColor {
 }
 
 #[skip_serializing_none]
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Builder)]
 pub struct StyleFile {
     pub(super) fg: Option<String>,
     pub(super) bg: Option<String>,


### PR DESCRIPTION
Inspired by: https://github.com/mierak/rmpc/issues/233#issuecomment-2634044814

Simplifies the provided configuration to not require two properties: 
```rust
(kind: Property(Status(RandomV2(
    on_label: " ",
    off_label: " ",
    on_style: (fg: "#5ea1ff", modifiers: "Bold"),
    off_style: (fg: "#5ea1ff", modifiers: "Dim"),
)))),
(kind: Property(Status(RepeatV2(
    on_label: " ",
    off_label: " ",
    on_style: (fg: "#5ea1ff", modifiers: "Bold"),
    off_style: (fg: "#5ea1ff", modifiers: "Dim"),
)))),
```
![image](https://github.com/user-attachments/assets/75278699-f167-4a40-8f87-4fc0248403e5)
