### PR TITLE
feat(ui): add backdrop support for modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `theme.modal_backdrop` adds a visual backdrop to modals
+
 ### Changed
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://mierak.github.io/rmpc/"
 repository = "https://github.com/mierak/rmpc"
 readme = "README.md"
 rust-version = "1.82.0"
+exclude = ["/docs/**/*", "!/docs/src/content/docs/next/assets/example_theme.ron", "!/docs/src/content/docs/next/assets/example_config.ron"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/docs/src/content/docs/next/assets/example_theme.ron
+++ b/docs/src/content/docs/next/assets/example_theme.ron
@@ -10,6 +10,7 @@
     text_color: None,
     header_background_color: None,
     modal_background_color: None,
+    modal_backdrop: false,
     tab_bar: (
         enabled: true,
         active_style: (fg: "black", bg: "blue", modifiers: "Bold"),

--- a/docs/src/content/docs/next/assets/themes/catppuccin-macchiato/theme.ron
+++ b/docs/src/content/docs/next/assets/themes/catppuccin-macchiato/theme.ron
@@ -23,6 +23,7 @@
     background_color: "#24273a",
     header_background_color: "#1e2030",
     modal_background_color: None,
+    modal_backdrop: false,
     tab_bar: (
         enabled: false,
         active_style: (fg: "black", bg: "#c6a0f6", modifiers: "Bold"),

--- a/docs/src/content/docs/next/configuration/theme.mdx
+++ b/docs/src/content/docs/next/configuration/theme.mdx
@@ -163,6 +163,12 @@ data.
 
 Background color of modal dialogs.
 
+### modal_backdrop
+
+<ConfigValue name="modal_backdrop" type="boolean" />
+
+Enables a backdrop behind modals for increased visual clarity. Defaults to `false`.
+
 ### text_color
 
 <ConfigValue name="text_color" type="string" customText="color" />

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -34,6 +34,7 @@ pub struct UiConfig {
     pub background_color: Option<Color>,
     pub header_background_color: Option<Color>,
     pub modal_background_color: Option<Color>,
+    pub modal_backdrop: bool,
     pub text_color: Option<Color>,
     pub borders_style: Style,
     pub highlighted_item_style: Style,
@@ -69,6 +70,8 @@ pub struct UiConfigFile {
     pub(super) text_color: Option<String>,
     pub(super) header_background_color: Option<String>,
     pub(super) modal_background_color: Option<String>,
+    #[serde(default)]
+    pub(super) modal_backdrop: bool,
     pub(super) borders_style: Option<StyleFile>,
     pub(super) highlighted_item_style: Option<StyleFile>,
     pub(super) current_item_style: Option<StyleFile>,
@@ -93,6 +96,7 @@ impl Default for UiConfigFile {
             show_song_table_header: true,
             header: HeaderConfigFile::default(),
             modal_background_color: None,
+            modal_backdrop: false,
             borders_style: Some(StyleFile {
                 fg: Some("blue".to_string()),
                 bg: None,
@@ -195,6 +199,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
             modal_background_color: StringColor(value.modal_background_color)
                 .to_color()?
                 .or(bg_color),
+            modal_backdrop: value.modal_backdrop,
             text_color: StringColor(value.text_color).to_color()?,
             header_background_color: header_bg_color,
             borders_style: value.borders_style.to_config_or(Some(fallback_border_fg), None)?,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -171,6 +171,11 @@ impl<'ui> Ui<'ui> {
             },
         )?;
 
+        if context.config.theme.modal_backdrop && !self.modals.is_empty() {
+            let buffer = frame.buffer_mut();
+            buffer.set_style(*buffer.area(), Style::default().fg(Color::DarkGray));
+        };
+
         for modal in &mut self.modals {
             modal.render(frame, context)?;
         }


### PR DESCRIPTION
This change enhances the UI by optionally dimming the background when
modals are displayed, improving focus and user experience.

An opt-in setting `modal_backdrop` is introduced in the theme
configuration to enable or disable (default) modal backdrops.
