### PR TITLE
feat: config hot reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `theme.modal_backdrop` adds a visual backdrop to modals
+- rmpc will now reload config changes automatically
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,6 +677,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc904b9bbefcadbd8e3a9fb0d464a9b979de6324c03b3c663e8994f46a5be36"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +739,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1065,6 +1095,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.8.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,6 +1204,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lebe"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,6 +1243,17 @@ checksum = "9b9569d2f74e257076d8c6bfa73fb505b46b851e51ddaecc825944aa3bed17fa"
 dependencies = [
  "arbitrary",
  "cc",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.8.0",
+ "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1286,6 +1367,44 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "notify"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+dependencies = [
+ "bitflags 2.8.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d88b1a7538054351c8258338df7c931a590513fb3745e8c15eb9ff4199b8d1"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "ntapi"
@@ -1733,6 +1852,7 @@ dependencies = [
  "image",
  "itertools 0.14.0",
  "log",
+ "notify-debouncer-full",
  "ratatui",
  "ron",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ color_quant = "1.1.0"
 enum-map = "2.7.3"
 textwrap = "0.16.1"
 crossbeam = "0.8.4"
+notify-debouncer-full = "0.5.0"
 
 [build-dependencies]
 clap = { workspace = true }

--- a/docs/src/content/docs/next/assets/example_config.ron
+++ b/docs/src/content/docs/next/assets/example_config.ron
@@ -12,6 +12,7 @@
     scrolloff: 0,
     wrap_navigation: false,
     enable_mouse: true,
+    enable_config_hot_reload: true,
     status_update_interval_ms: 1000,
     select_current_song_on_change: false,
     album_art: (

--- a/docs/src/content/docs/next/configuration/index.mdx
+++ b/docs/src/content/docs/next/configuration/index.mdx
@@ -11,9 +11,9 @@ import { path } from "../data.ts";
 
 Rmpc uses [ron](https://github.com/ron-rs/ron) format for its configuration file. The file can be located at:
 
--   `$XDG_CONFIG_HOME/rmpc/config.ron`
--   `$HOME/.config/rmpc/config.ron`
--   `Specific path specified by the --config flag`
+- `$XDG_CONFIG_HOME/rmpc/config.ron`
+- `$HOME/.config/rmpc/config.ron`
+- `Specific path specified by the --config flag`
 
 ## Bootstrapping a config file
 
@@ -135,6 +135,15 @@ Whether to wrap around on Up/Down action in queue/browser panes upon reaching bo
 Enables mouse support. Currently only seeking the currently playing song by clicking on the progress bar at the bottom
 of the screen and switching tabs is supported. Enabled by default.
 
+### enable_config_hot_reload
+
+<ConfigValue name="enable_config_hot_reload" type="bool" />
+
+Whether rmpc should watch its config directory and reload the config when it changes. Most options can be changed during
+runtime but some will still require you to restart rmpc. These include things like album art method and MPD connection
+information.
+Config hot reload is enabled by default.
+
 ### status_update_interval_ms
 
 <ConfigValue name="status_update_interval_ms" type="number" optional />
@@ -184,16 +193,16 @@ artists: (
 
 Can be one of the following:
 
--   `SplitByDate` - songs in the album will be split into separate album entries, one for each date and the
-    album date will be displayed in front of the album name in the following format: `(<date value>) <album name>`
--   `NameOnly` - only one entry for an album will be created and the album date will not be displayed
+- `SplitByDate` - songs in the album will be split into separate album entries, one for each date and the
+  album date will be displayed in front of the album name in the following format: `(<date value>) <album name>`
+- `NameOnly` - only one entry for an album will be created and the album date will not be displayed
 
 #### album_sort_by
 
 Can be one of the following:
 
--   `Name` - albums are sorted by their name first and date second if their names are identical
--   `Date` - albums will be simply sorted by date.
+- `Name` - albums are sorted by their name first and date second if their names are identical
+- `Date` - albums will be simply sorted by date.
 
 :::caution
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -40,6 +40,7 @@ use crate::{
     tmux,
 };
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Default, Clone)]
 pub struct Config {
     pub address: MpdAddress,
@@ -52,6 +53,7 @@ pub struct Config {
     pub wrap_navigation: bool,
     pub keybinds: KeyConfig,
     pub enable_mouse: bool,
+    pub enable_config_hot_reload: bool,
     pub status_update_interval_ms: Option<u64>,
     pub select_current_song_on_change: bool,
     pub mpd_read_timeout: Duration,
@@ -66,6 +68,7 @@ pub struct Config {
     pub active_panes: Vec<PaneTypeDiscriminants>,
 }
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ConfigFile {
     #[serde(default = "defaults::mpd_address")]
@@ -94,8 +97,10 @@ pub struct ConfigFile {
     mpd_read_timeout_ms: u64,
     #[serde(default = "defaults::default_write_timeout")]
     mpd_write_timeout_ms: u64,
-    #[serde(default = "defaults::default_false")]
+    #[serde(default = "defaults::default_true")]
     enable_mouse: bool,
+    #[serde(default = "defaults::default_true")]
+    pub enable_config_hot_reload: bool,
     #[serde(default)]
     keybinds: KeyConfigFile,
     #[serde(default)]
@@ -151,6 +156,7 @@ impl Default for ConfigFile {
             search: SearchFile::default(),
             tabs: TabsFile::default(),
             enable_mouse: true,
+            enable_config_hot_reload: true,
             wrap_navigation: false,
             password: None,
             artists: ArtistsFile::default(),
@@ -234,6 +240,7 @@ impl ConfigFile {
             mpd_read_timeout: Duration::from_millis(self.mpd_read_timeout_ms),
             mpd_write_timeout: Duration::from_millis(self.mpd_write_timeout_ms),
             enable_mouse: self.enable_mouse,
+            enable_config_hot_reload: self.enable_config_hot_reload,
             keybinds: self.keybinds.into(),
             select_current_song_on_change: self.select_current_song_on_change,
             search: self.search.into(),

--- a/src/core/config_watcher.rs
+++ b/src/core/config_watcher.rs
@@ -1,0 +1,76 @@
+use std::{path::PathBuf, time::Duration};
+
+use anyhow::{Context, Result};
+use crossbeam::channel::Sender;
+use notify_debouncer_full::{
+    DebounceEventResult,
+    Debouncer,
+    RecommendedCache,
+    new_debouncer,
+    notify::{
+        EventKind,
+        RecommendedWatcher,
+        RecursiveMode,
+        event::{AccessKind, AccessMode},
+    },
+};
+
+use crate::{AppEvent, config::ConfigFile, status_warn};
+
+pub(crate) fn init(
+    config_path: PathBuf,
+    theme_name: Option<String>,
+    event_tx: Sender<AppEvent>,
+) -> Result<Debouncer<RecommendedWatcher, RecommendedCache>> {
+    let config_file_name = config_path
+        .file_name()
+        .with_context(|| format!("Invalid config path {config_path:?}"))?
+        .to_owned();
+    let config_directory = config_path
+        .parent()
+        .with_context(|| format!("Invalid config directory {config_path:?}"))?
+        .to_owned();
+
+    let mut theme_name = theme_name;
+    let mut watcher = new_debouncer(
+        Duration::from_millis(500),
+        None,
+        move |event: DebounceEventResult| {
+            let events = match event {
+                Ok(events) => events,
+                Err(err) => {
+                    log::error!(err:?, config_file_name:?; "Encountered error while watching config file");
+                    return;
+                }
+            };
+
+            for event in events {
+                if !event.paths.iter().any(|path| {
+                    path.ends_with(&config_file_name)
+                        || theme_name.as_ref().is_some_and(|theme| path.ends_with(theme))
+                }) {
+                    continue;
+                }
+                if !matches!(event.kind, EventKind::Access(AccessKind::Close(AccessMode::Write))) {
+                    continue;
+                }
+
+                log::debug!(event:?; "File event");
+                if let Err(err) = ConfigFile::read(&config_path)
+                    .and_then(|config| config.into_config(Some(&config_path), None, None, true))
+                    .inspect(|config| {
+                        theme_name = config.theme_name.as_ref().map(|c| format!("{c}.ron"));
+                    })
+                    .and_then(|config| Ok(event_tx.send(AppEvent::ConfigChanged { config })?))
+                {
+                    status_warn!(err:?, config_path:?; "Failed to read config. Keeping the current config. Check logs for more information");
+                }
+            }
+        },
+    )?;
+
+    watcher.watch(&config_directory, RecursiveMode::Recursive)?;
+    log::info!(config_directory:? = config_directory.to_str(); "Watching for changes");
+
+    Ok(watcher)
+}

--- a/src/core/config_watcher.rs
+++ b/src/core/config_watcher.rs
@@ -17,6 +17,7 @@ use notify_debouncer_full::{
 
 use crate::{AppEvent, config::ConfigFile, status_warn};
 
+#[must_use = "Returns a drop guard for the config directory watcher"]
 pub(crate) fn init(
     config_path: PathBuf,
     theme_name: Option<String>,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod client;
 pub mod command;
+pub mod config_watcher;
 pub mod event_loop;
 pub mod input;
 pub mod scheduler;

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,6 +235,13 @@ fn main() -> Result<()> {
                 Arc::clone(&context.config),
             )
             .context("Failed to initialize socket listener")?;
+
+            let _config_watcher = core::config_watcher::init(
+                args.config,
+                context.config.theme_name.clone(),
+                event_tx.clone(),
+            )?;
+
             let event_loop_handle = core::event_loop::init(context, event_rx, terminal)?;
 
             let original_hook = std::panic::take_hook();

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,11 +236,15 @@ fn main() -> Result<()> {
             )
             .context("Failed to initialize socket listener")?;
 
-            let _config_watcher = core::config_watcher::init(
-                args.config,
-                context.config.theme_name.clone(),
-                event_tx.clone(),
-            )?;
+            let _config_watcher_guard = context
+                .config
+                .enable_config_hot_reload
+                .then_some(core::config_watcher::init(
+                    args.config,
+                    context.config.theme_name.clone(),
+                    event_tx.clone(),
+                ))
+                .transpose()?;
 
             let event_loop_handle = core::event_loop::init(context, event_rx, terminal)?;
 

--- a/src/shared/events.rs
+++ b/src/shared/events.rs
@@ -10,7 +10,7 @@ use super::{
     mpd_query::{MpdCommand, MpdQuery, MpdQueryResult, MpdQuerySync},
 };
 use crate::{
-    config::{cli::Command, tabs::PaneTypeDiscriminants},
+    config::{Config, cli::Command, tabs::PaneTypeDiscriminants},
     mpd::commands::IdleEvent,
     ui::UiAppEvent,
 };
@@ -67,6 +67,7 @@ pub(crate) enum AppEvent {
     Reconnected,
     LostConnection,
     TmuxHook { hook: String },
+    ConfigChanged { config: Config },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Copy, Eq, Hash, PartialEq)]

--- a/src/ui/image/facade.rs
+++ b/src/ui/image/facade.rs
@@ -136,6 +136,15 @@ impl AlbumArtFacade {
     pub fn set_size(&mut self, area: Rect) {
         self.last_size = area;
     }
+
+    pub fn reinit(&mut self, config: &Config) {
+        let current_album_art = std::mem::take(&mut self.current_album_art);
+        let last_size = self.last_size;
+
+        *self = Self::new(config);
+        self.current_album_art = current_album_art;
+        self.last_size = last_size;
+    }
 }
 
 impl From<ImageMethod> for ImageProtocol {

--- a/src/ui/image/iterm2.rs
+++ b/src/ui/image/iterm2.rs
@@ -74,10 +74,12 @@ impl Iterm2 {
             .spawn(move || {
                 let mut pending_req = None;
                 loop {
-                    let Ok(DataToEncode { area, data }) =
-                        pending_req.take().ok_or(()).or_else(|()| receiver.recv_last())
-                    else {
-                        continue;
+                    let DataToEncode { area, data } = match pending_req.take().ok_or(()).or_else(|()| receiver.recv_last()) {
+                        Ok(data) => data,
+                        Err(err) => {
+                            log::warn!(err:?, msg = err.to_string().as_str(); "Failed to get image data to show");
+                            break;
+                        }
                     };
 
                     let encoded = try_cont!(

--- a/src/ui/image/sixel.rs
+++ b/src/ui/image/sixel.rs
@@ -68,10 +68,12 @@ impl Sixel {
             .spawn(move || {
                 let mut pending_req = None;
                 loop {
-                    let Ok(DataToEncode { area, data }) =
-                        pending_req.take().ok_or(()).or_else(|()| receiver.recv_last())
-                    else {
-                        continue;
+                    let DataToEncode { area, data } = match pending_req.take().ok_or(()).or_else(|()| receiver.recv_last()) {
+                        Ok(data) => data,
+                        Err(err) => {
+                            log::warn!(err:?, msg = err.to_string().as_str(); "Failed to get image data to show");
+                            break;
+                        }
                     };
 
                     let (buf, resized_area) = try_cont!(

--- a/src/ui/panes/album_art.rs
+++ b/src/ui/panes/album_art.rs
@@ -145,9 +145,11 @@ impl Pane for AlbumArtPane {
                 }
                 self.album_art.show_current()?;
             }
-            UiEvent::ConfigChanged if is_visible => {
+            UiEvent::ConfigChanged => {
                 self.album_art.reinit(&context.config);
-                self.album_art.show_current()?;
+                if is_visible && !self.is_modal_open {
+                    self.album_art.show_current()?;
+                }
             }
             UiEvent::Exit => {
                 self.album_art.cleanup()?;

--- a/src/ui/panes/album_art.rs
+++ b/src/ui/panes/album_art.rs
@@ -145,6 +145,10 @@ impl Pane for AlbumArtPane {
                 }
                 self.album_art.show_current()?;
             }
+            UiEvent::ConfigChanged if is_visible => {
+                self.album_art.reinit(&context.config);
+                self.album_art.show_current()?;
+            }
             UiEvent::Exit => {
                 self.album_art.cleanup()?;
             }

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -67,28 +67,33 @@ const ADD_TO_PLAYLIST: &str = "add_to_playlist";
 
 impl QueuePane {
     pub fn new(context: &AppContext) -> Self {
-        let config = &context.config;
+        let (header, column_widths, column_formats) = Self::init(context);
+
         Self {
             scrolling_state: DirState::default(),
             filter: None,
             filter_input_mode: false,
-            header: config.theme.song_table_format.iter().map(|v| v.label.clone()).collect_vec(),
-            column_widths: config
+            header,
+            column_widths,
+            column_formats,
+            areas: enum_map! {
+                _ => Rect::default(),
+            },
+        }
+    }
+
+    fn init(context: &AppContext) -> (Vec<String>, Vec<Constraint>, Vec<Property<SongProperty>>) {
+        (
+            context.config.theme.song_table_format.iter().map(|v| v.label.clone()).collect_vec(),
+            context
+                .config
                 .theme
                 .song_table_format
                 .iter()
                 .map(|v| Into::<Constraint>::into(v.width))
                 .collect_vec(),
-            column_formats: config
-                .theme
-                .song_table_format
-                .iter()
-                .map(|v| v.prop.clone())
-                .collect_vec(),
-            areas: enum_map! {
-                _ => Rect::default(),
-            },
-        }
+            context.config.theme.song_table_format.iter().map(|v| v.prop.clone()).collect_vec(),
+        )
     }
 }
 
@@ -279,6 +284,12 @@ impl Pane for QueuePane {
             }
             UiEvent::Reconnected => {
                 self.before_show(context)?;
+            }
+            UiEvent::ConfigChanged => {
+                let (header, column_widths, column_formats) = Self::init(context);
+                self.header = header;
+                self.column_formats = column_formats;
+                self.column_widths = column_widths;
             }
             _ => {}
         }

--- a/src/ui/panes/search.rs
+++ b/src/ui/panes/search.rs
@@ -573,6 +573,9 @@ impl Pane for SearchPane {
                 self.preview = None;
                 self.songs_dir = Dir::default();
             }
+            UiEvent::ConfigChanged => {
+                *self = Self::new(context);
+            }
             _ => {}
         }
         Ok(())

--- a/src/ui/tab_screen.rs
+++ b/src/ui/tab_screen.rs
@@ -261,6 +261,23 @@ impl TabScreen {
         Ok(())
     }
 
+    pub fn calculate_areas(
+        &mut self,
+        pane_container: &mut PaneContainer,
+        area: Rect,
+        context: &AppContext,
+    ) -> Result<()> {
+        self.panes.for_each_pane(area, &mut |pane, pane_area, _, block_area| {
+            let pane_data =
+                self.pane_data.entry(pane.id).or_insert_with(|| PaneData::new(pane.is_focusable()));
+            pane_data.area = area;
+            pane_data.block_area = block_area;
+            let pane_instance = &mut pane_container.get_mut(&pane.pane, context);
+            pane_call!(pane_instance, calculate_areas(pane_area, context))?;
+            Ok(())
+        })
+    }
+
     pub fn resize(
         &mut self,
         pane_container: &mut PaneContainer,

--- a/src/ui/widgets/tabs.rs
+++ b/src/ui/widgets/tabs.rs
@@ -53,19 +53,19 @@ use super::get_line_offset;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Tabs<'a> {
     /// A block to wrap this widget in if necessary
-    block: Option<Block<'a>>,
+    pub block: Option<Block<'a>>,
     /// One title for each tab
-    titles: Vec<Line<'a>>,
+    pub titles: Vec<Line<'a>>,
     /// The index of the selected tabs
     selected: usize,
     /// The style used to draw the text
-    style: Style,
+    pub style: Style,
     /// Style to apply to the selected item
-    highlight_style: Style,
+    pub highlight_style: Style,
     /// Tab divider
-    divider: Span<'a>,
+    pub divider: Span<'a>,
     /// Alignment of the tabs
-    alignment: Alignment,
+    pub alignment: Alignment,
     /// Vec of areas that tabs were last rendered in
     pub areas: Vec<Rect>,
 }
@@ -101,6 +101,12 @@ impl<'a> Tabs<'a> {
 
     pub fn style(mut self, style: Style) -> Tabs<'a> {
         self.style = style;
+        self
+    }
+
+    pub fn titles(&mut self, titles: Vec<impl Into<Line<'a>>>) -> &mut Tabs<'a> {
+        let titles: Vec<_> = titles.into_iter().map(Into::into).collect();
+        self.titles = titles;
         self
     }
 


### PR DESCRIPTION
Makes rmpc watch config file for changes and reload them automatically. Some config values are cont reloadable, mainly the album art backend and stuff dealing with mpd connection etc. These still need full restart. Still needs a little bit of work before merging, but its working well.

Fixes https://github.com/mierak/rmpc/issues/168