### PR TITLE
feat: theme cli arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - rmpc will now reload config changes automatically
 - remote command to change theme
 - `on_resize` which is called whenever rmpc is resized
+- `--theme` cli argument to override theme in the config file
 
 ### Changed
 

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -4,8 +4,10 @@ use clap::{Parser, Subcommand, ValueEnum, ValueHint};
 
 #[derive(Parser, Debug)]
 pub struct Args {
-    #[arg(short, long, value_name = "FILE", default_value = get_default_config_path().into_os_string())]
+    #[arg(short, long, value_hint = ValueHint::AnyPath, value_name = "FILE", default_value = get_default_config_path().into_os_string())]
     pub config: PathBuf,
+    #[arg(short, long, value_hint = ValueHint::AnyPath, value_name = "FILE")]
+    pub theme: Option<PathBuf>,
     #[command(subcommand)]
     pub command: Option<Command>,
     #[arg(short, long)]

--- a/src/core/config_watcher.rs
+++ b/src/core/config_watcher.rs
@@ -58,7 +58,9 @@ pub(crate) fn init(
 
                 log::debug!(event:?; "File event");
                 if let Err(err) = ConfigFile::read(&config_path)
-                    .and_then(|config| config.into_config(Some(&config_path), None, None, true))
+                    .and_then(|config| {
+                        config.into_config(None, Some(&config_path), None, None, true)
+                    })
                     .inspect(|config| {
                         theme_name = config.theme_name.as_ref().map(|c| format!("{c}.ron"));
                     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,7 @@ fn main() -> Result<()> {
             let config_file = ConfigFile::read(&args.config).unwrap_or_default();
             let config = config_file.clone().into_config(
                 Some(&args.config),
+                args.theme.as_deref(),
                 std::mem::take(&mut args.address),
                 std::mem::take(&mut args.password),
                 false,
@@ -173,6 +174,7 @@ fn main() -> Result<()> {
             let config = match ConfigFile::read(&args.config) {
                 Ok(val) => val.into_config(
                     Some(&args.config),
+                    args.theme.as_deref(),
                     std::mem::take(&mut args.address),
                     std::mem::take(&mut args.password),
                     false,
@@ -180,6 +182,7 @@ fn main() -> Result<()> {
                 Err(err) => {
                     status_warn!(err:?; "Failed to read config. Using default values. Check logs for more information");
                     ConfigFile::default().into_config(
+                        None,
                         None,
                         std::mem::take(&mut args.address),
                         std::mem::take(&mut args.password),

--- a/src/shared/ipc/commands/set.rs
+++ b/src/shared/ipc/commands/set.rs
@@ -27,7 +27,7 @@ impl SocketCommandExecute for SetIpcCommand {
     ) -> Result<()> {
         match self {
             SetIpcCommand::Config(config) => {
-                let config = config.into_config(None, None, None, true)?;
+                let config = config.into_config(None, None, None, None, true)?;
                 Ok(event_tx.send(AppEvent::ConfigChanged { config, keep_old_theme: true })?)
             }
             SetIpcCommand::Theme(theme) => {

--- a/src/tests/fixtures/mod.rs
+++ b/src/tests/fixtures/mod.rs
@@ -39,7 +39,7 @@ pub fn app_context(
 ) -> AppContext {
     let chan1 = unbounded();
     let config = ConfigFile::default()
-        .into_config(None, None, None, true)
+        .into_config(None, None, None, None, true)
         .expect("Test default config to convert correctly");
 
     let chan1 = Box::leak(Box::new(chan1));


### PR DESCRIPTION
@soifou Is it alright like this? It requires an absolute path to the theme, ie `~/.config/rmpc/themes/theme.ron`.

Changing it to be able to just use a theme name is possible but complicates it a bit because we have to check whether we even have config file etc.

edit: this way it is also consistent with the way the IPC theme command is done