### PR TITLE
fix(lyrics): parse lyric timestamps with frations of seconds which aren't to 2s.f.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Lyrics with fractions of seconds which weren't to 2s.f. being
+  parsed incorrectly
+
 - Album art staying on the old one when in tmux and not visible
 
 ## [0.8.0] - 2025-02-16


### PR DESCRIPTION
Ik that it's not mentioned on the Wikipedia page (prob since LRC isn't really standardised), but some lyric providers (Netease and Apple Music for example) use 3s.f. for the fraction part of a second, causing the most significant digit to be treated as a second. This fixes the issue, by letting any number of s.f. to be used.