### PR TITLE
feat: new browser pane with configurable root tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - remote command to change theme
 - `on_resize` which is called whenever rmpc is resized
 - `--theme` cli argument to override theme in the config file
+- new `Browser` pane which
 
 ### Changed
 

--- a/docs/src/content/docs/next/configuration/tabs.mdx
+++ b/docs/src/content/docs/next/configuration/tabs.mdx
@@ -62,8 +62,10 @@ Rmpc has several pane_types which can be displayed. These are:
 - `AlbumArt` - The album art. Cannot be focused.
 - `Queue` - Table of the current song queue.
 - `Directories` - Browse music library by directory.
-- `Artists` - Browse music library by `artist` tag.
-- `AlbumArtists` - Browse music library by `albumartist` tag.
+- `Browser` - A music library browser. Allows you to specify a root tag and an optional separator. `Browser(root_tag: "<tag>", separator: ";")`.
+  Separator can be used to create multiple entries from one tag value, for example if a song has multiple `genre` values separated by `;`.
+- `Artists` - Browse music library by `artist` tag. Equivalent to `Browser(root_tag: "artist")`
+- `AlbumArtists` - Browse music library by `albumartist` tag. Equivalent to `Browser(root_tag: "albumartist")`
 - `Albums` - Browse music library by `album` tag.
 - `Playlists` - Browse saved playlists.
 - `Search` - Search music library.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,7 +15,7 @@ use itertools::Itertools;
 use rustix::path::Arg;
 use search::SearchFile;
 use serde::{Deserialize, Serialize};
-use tabs::{PaneTypeDiscriminants, Tabs, TabsFile, validate_tabs};
+use tabs::{PaneType, Tabs, TabsFile, validate_tabs};
 use utils::tilde_expand;
 
 pub mod address;
@@ -67,7 +67,7 @@ pub struct Config {
     pub search: Search,
     pub artists: Artists,
     pub tabs: Tabs,
-    pub active_panes: Vec<PaneTypeDiscriminants>,
+    pub active_panes: Vec<PaneType>,
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -234,10 +234,8 @@ impl ConfigFile {
         let active_panes = tabs
             .tabs
             .iter()
-            .flat_map(|(_, tab)| {
-                tab.panes.panes_iter().map(|pane| PaneTypeDiscriminants::from(&pane.pane))
-            })
-            .chain(theme.layout.panes_iter().map(|pane| PaneTypeDiscriminants::from(&pane.pane)))
+            .flat_map(|(_, tab)| tab.panes.panes_iter().map(|pane| pane.pane.clone()))
+            .chain(theme.layout.panes_iter().map(|pane| pane.pane.clone()))
             .unique()
             .collect_vec();
 

--- a/src/config/tabs.rs
+++ b/src/config/tabs.rs
@@ -57,6 +57,10 @@ pub enum PaneTypeFile {
         #[serde(default)]
         align: super::theme::properties::Alignment,
     },
+    Browser {
+        root_tag: String,
+        separator: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, strum::Display, strum::EnumDiscriminants)]
@@ -82,6 +86,10 @@ pub enum PaneType {
     Property {
         content: Vec<Property<PropertyKind>>,
         align: ratatui::layout::Alignment,
+    },
+    Browser {
+        root_tag: String,
+        separator: Option<String>,
     },
 }
 
@@ -144,6 +152,9 @@ impl From<PaneTypeFile> for PaneType {
                     .collect_vec(),
                 align: (align).into(),
             },
+            PaneTypeFile::Browser { root_tag: tag, separator } => {
+                PaneType::Browser { root_tag: tag, separator }
+            }
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,7 +10,7 @@ use crate::{
     MpdQuery,
     MpdQueryResult,
     WorkRequest,
-    config::{Config, album_art::ImageMethod, tabs::PaneTypeDiscriminants},
+    config::{Config, album_art::ImageMethod, tabs::PaneType},
     core::scheduler::{Scheduler, time_provider::DefaultTimeProvider},
     mpd::{
         client::Client,
@@ -139,7 +139,7 @@ impl AppContext {
         + Send
         + 'static,
         id: &'static str,
-        target: Option<PaneTypeDiscriminants>,
+        target: Option<PaneType>,
         replace_id: Option<&'static str>,
     ) {
         let query = MpdQuery { id, target, replace_id, callback: Box::new(on_done) };

--- a/src/mpd/mpd_client.rs
+++ b/src/mpd/mpd_client.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     ops::{Range, RangeInclusive},
     str::FromStr,
 };
@@ -896,7 +897,7 @@ pub enum FilterKind {
 #[derive(Debug)]
 pub struct Filter<'value> {
     pub tag: Tag,
-    pub value: &'value str,
+    pub value: Cow<'value, str>,
     pub kind: FilterKind,
 }
 
@@ -908,12 +909,16 @@ impl From<String> for Tag {
 
 #[allow(dead_code)]
 impl<'value> Filter<'value> {
-    pub fn new<T: Into<Tag>>(tag: T, value: &'value str) -> Self {
-        Self { tag: tag.into(), value, kind: FilterKind::Exact }
+    pub fn new<T: Into<Tag>, V: Into<Cow<'value, str>>>(tag: T, value: V) -> Self {
+        Self { tag: tag.into(), value: value.into(), kind: FilterKind::Exact }
     }
 
-    pub fn new_with_kind<T: Into<Tag>>(tag: T, value: &'value str, kind: FilterKind) -> Self {
-        Self { tag: tag.into(), value, kind }
+    pub fn new_with_kind<T: Into<Tag>, V: Into<Cow<'value, str>>>(
+        tag: T,
+        value: V,
+        kind: FilterKind,
+    ) -> Self {
+        Self { tag: tag.into(), value: value.into(), kind }
     }
 
     pub fn with_type(mut self, t: FilterKind) -> Self {

--- a/src/shared/events.rs
+++ b/src/shared/events.rs
@@ -10,7 +10,7 @@ use super::{
     mpd_query::{MpdCommand, MpdQuery, MpdQueryResult, MpdQuerySync},
 };
 use crate::{
-    config::{Config, cli::Command, tabs::PaneTypeDiscriminants, theme::UiConfig},
+    config::{Config, cli::Command, tabs::PaneType, theme::UiConfig},
     mpd::commands::IdleEvent,
     ui::UiAppEvent,
 };
@@ -39,17 +39,9 @@ pub(crate) enum WorkRequest {
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)] // the instances are short lived events, its fine.
 pub(crate) enum WorkDone {
-    LyricsIndexed {
-        index: LrcIndex,
-    },
-    SingleLrcIndexed {
-        lrc_entry: Option<LrcIndexEntry>,
-    },
-    MpdCommandFinished {
-        id: &'static str,
-        target: Option<PaneTypeDiscriminants>,
-        data: MpdQueryResult,
-    },
+    LyricsIndexed { index: LrcIndex },
+    SingleLrcIndexed { lrc_entry: Option<LrcIndexEntry> },
+    MpdCommandFinished { id: &'static str, target: Option<PaneType>, data: MpdQueryResult },
     None,
 }
 

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -13,5 +13,6 @@ pub mod macros;
 pub mod mouse_event;
 pub mod mpd_query;
 pub mod percent;
+pub mod string_util;
 pub mod tmux;
 pub mod ytdlp;

--- a/src/shared/mpd_query.rs
+++ b/src/shared/mpd_query.rs
@@ -7,7 +7,7 @@ use ratatui::widgets::ListItem;
 
 use super::events::AppEvent;
 use crate::{
-    config::tabs::PaneTypeDiscriminants,
+    config::tabs::PaneType,
     mpd::{
         client::Client,
         commands::{Decoder, Output, Song, Status, Volume},
@@ -26,7 +26,7 @@ pub const GLOBAL_QUEUE_UPDATE: &str = "global_queue_update";
 pub(crate) struct MpdQuery {
     pub id: &'static str,
     pub replace_id: Option<&'static str>,
-    pub target: Option<PaneTypeDiscriminants>,
+    pub target: Option<PaneType>,
     #[debug(skip)]
     pub callback: Box<dyn FnOnce(&mut Client<'_>) -> Result<MpdQueryResult> + Send>,
 }

--- a/src/shared/string_util.rs
+++ b/src/shared/string_util.rs
@@ -1,0 +1,45 @@
+pub(crate) trait CharExt {
+    fn is_regex_special_char(&self) -> bool;
+}
+
+pub(crate) trait StringExt {
+    fn escape_regex_chars(&self) -> String;
+}
+
+impl StringExt for String {
+    fn escape_regex_chars(&self) -> String {
+        let mut buf = String::with_capacity(self.len());
+        for char in self.chars() {
+            if char.is_regex_special_char() {
+                buf.push('\\');
+            }
+            buf.push(char);
+        }
+        buf
+    }
+}
+
+impl CharExt for char {
+    fn is_regex_special_char(&self) -> bool {
+        matches!(
+            self,
+            '\\' | '.'
+                | '+'
+                | '*'
+                | '?'
+                | '('
+                | ')'
+                | '|'
+                | '['
+                | ']'
+                | '{'
+                | '}'
+                | '^'
+                | '$'
+                | '#'
+                | '&'
+                | '-'
+                | '~'
+        )
+    }
+}

--- a/src/tests/fixtures/mpd_client.rs
+++ b/src/tests/fixtures/mpd_client.rs
@@ -312,15 +312,17 @@ impl MpdClient for TestMpdClient {
 
                 for filter in filter {
                     let value = match filter.tag {
-                        Tag::Any => {
-                            values.iter().any(|a| a.is_some_and(|a| a.contains(filter.value)))
+                        Tag::Any => values
+                            .iter()
+                            .any(|a| a.is_some_and(|a| a.contains(filter.value.as_ref()))),
+                        Tag::Artist => values[0].is_some_and(|a| a.contains(filter.value.as_ref())),
+                        Tag::AlbumArtist => {
+                            values[1].is_some_and(|a| a.contains(filter.value.as_ref()))
                         }
-                        Tag::Artist => values[0].is_some_and(|a| a.contains(filter.value)),
-                        Tag::AlbumArtist => values[1].is_some_and(|a| a.contains(filter.value)),
-                        Tag::Album => values[2].is_some_and(|a| a.contains(filter.value)),
-                        Tag::Title => values[3].is_some_and(|a| a.contains(filter.value)),
-                        Tag::File => values[4].is_some_and(|a| a.contains(filter.value)),
-                        Tag::Genre => values[5].is_some_and(|a| a.contains(filter.value)),
+                        Tag::Album => values[2].is_some_and(|a| a.contains(filter.value.as_ref())),
+                        Tag::Title => values[3].is_some_and(|a| a.contains(filter.value.as_ref())),
+                        Tag::File => values[4].is_some_and(|a| a.contains(filter.value.as_ref())),
+                        Tag::Genre => values[5].is_some_and(|a| a.contains(filter.value.as_ref())),
                         Tag::Custom(_) => false,
                     };
                     if !value {

--- a/src/ui/panes/album_art.rs
+++ b/src/ui/panes/album_art.rs
@@ -4,7 +4,7 @@ use ratatui::{Frame, layout::Rect};
 use super::Pane;
 use crate::{
     MpdQueryResult,
-    config::tabs::PaneTypeDiscriminants,
+    config::tabs::PaneType,
     context::AppContext,
     mpd::mpd_client::MpdClient,
     shared::{image::ImageProtocol, key_event::KeyEvent},
@@ -45,7 +45,7 @@ impl AlbumArtPane {
         }
 
         let song_uri = song_uri.to_owned();
-        context.query().id(ALBUM_ART).replace_id(ALBUM_ART).target(PaneTypeDiscriminants::AlbumArt).query(move |client| {
+        context.query().id(ALBUM_ART).replace_id(ALBUM_ART).target(PaneType::AlbumArt).query(move |client| {
             let start = std::time::Instant::now();
             log::debug!(file = song_uri.as_str(); "Searching for album art");
             let result = client.find_album_art(&song_uri)?;
@@ -171,7 +171,7 @@ mod tests {
 
     use super::AlbumArtPane;
     use crate::{
-        config::{Config, album_art::ImageMethod, tabs::PaneTypeDiscriminants},
+        config::{Config, album_art::ImageMethod, tabs::PaneType},
         mpd::commands::{Song, State},
         shared::{
             events::{ClientRequest, WorkRequest},
@@ -213,7 +213,7 @@ mod tests {
                 ClientRequest::Query(MpdQuery {
                     id: ALBUM_ART,
                     replace_id: Some(ALBUM_ART),
-                    target: Some(PaneTypeDiscriminants::AlbumArt),
+                    target: Some(PaneType::AlbumArt),
                     ..
                 })
             ));
@@ -254,7 +254,7 @@ mod tests {
                 ClientRequest::Query(MpdQuery {
                     id: ALBUM_ART,
                     replace_id: Some(ALBUM_ART),
-                    target: Some(PaneTypeDiscriminants::AlbumArt),
+                    target: Some(PaneType::AlbumArt),
                     ..
                 })
             ));

--- a/src/ui/panes/albums.rs
+++ b/src/ui/panes/albums.rs
@@ -5,7 +5,7 @@ use ratatui::{Frame, prelude::Rect};
 use super::{Pane, browser::DirOrSong};
 use crate::{
     MpdQueryResult,
-    config::tabs::PaneTypeDiscriminants,
+    config::tabs::PaneType,
     context::AppContext,
     mpd::{
         client::Client,
@@ -74,7 +74,7 @@ impl AlbumsPane {
                     .query()
                     .id(OPEN_OR_PLAY)
                     .replace_id(OPEN_OR_PLAY)
-                    .target(PaneTypeDiscriminants::Albums)
+                    .target(PaneType::Albums)
                     .query(move |client| {
                         let data = list_titles(client, current.as_path())?.collect();
                         Ok(MpdQueryResult::DirOrSong { data, origin_path: Some(next_path) })
@@ -107,7 +107,7 @@ impl Pane for AlbumsPane {
 
     fn before_show(&mut self, context: &AppContext) -> Result<()> {
         if !self.initialized {
-            context.query().id(INIT).replace_id(INIT).target(PaneTypeDiscriminants::Albums).query(
+            context.query().id(INIT).replace_id(INIT).target(PaneType::Albums).query(
                 move |client| {
                     let result = client.list_tag(Tag::Album, None).context("Cannot list tags")?;
                     Ok(MpdQueryResult::LsInfo { data: result.0, origin_path: None })
@@ -127,16 +127,13 @@ impl Pane for AlbumsPane {
     ) -> Result<()> {
         match event {
             UiEvent::Database => {
-                context
-                    .query()
-                    .id(INIT)
-                    .replace_id(INIT)
-                    .target(PaneTypeDiscriminants::Albums)
-                    .query(move |client| {
+                context.query().id(INIT).replace_id(INIT).target(PaneType::Albums).query(
+                    move |client| {
                         let result =
                             client.list_tag(Tag::Album, None).context("Cannot list tags")?;
                         Ok(MpdQueryResult::LsInfo { data: result.0, origin_path: None })
-                    });
+                    },
+                );
             }
             UiEvent::Reconnected => {
                 self.initialized = false;
@@ -320,7 +317,7 @@ impl BrowserPane<DirOrSong> for AlbumsPane {
                     .query()
                     .id(PREVIEW)
                     .replace_id("albums_preview")
-                    .target(PaneTypeDiscriminants::Albums)
+                    .target(PaneType::Albums)
                     .query(move |client| {
                         let data = Some(
                             find_songs(client, &album, &current)?
@@ -340,7 +337,7 @@ impl BrowserPane<DirOrSong> for AlbumsPane {
                     .query()
                     .id(PREVIEW)
                     .replace_id("albums_preview")
-                    .target(PaneTypeDiscriminants::Albums)
+                    .target(PaneType::Albums)
                     .query(move |client| {
                         let data = list_titles(client, &current)?
                             .map(|v| v.to_list_item_simple(&config))

--- a/src/ui/panes/directories.rs
+++ b/src/ui/panes/directories.rs
@@ -5,7 +5,7 @@ use ratatui::{Frame, prelude::Rect};
 use super::{Pane, browser::DirOrSong};
 use crate::{
     MpdQueryResult,
-    config::tabs::PaneTypeDiscriminants,
+    config::tabs::PaneType,
     context::AppContext,
     mpd::{
         client::Client,
@@ -65,7 +65,7 @@ impl DirectoriesPane {
                     .query()
                     .id(OPEN_OR_PLAY)
                     .replace_id(OPEN_OR_PLAY)
-                    .target(PaneTypeDiscriminants::Directories)
+                    .target(PaneType::Directories)
                     .query(move |client| {
                         let new_current = client.lsinfo(Some(&next_path.join("/").to_string()))?;
                         let res = new_current
@@ -118,12 +118,8 @@ impl Pane for DirectoriesPane {
 
     fn before_show(&mut self, context: &AppContext) -> Result<()> {
         if !self.initialized {
-            context
-                .query()
-                .id(INIT)
-                .replace_id(INIT)
-                .target(PaneTypeDiscriminants::Directories)
-                .query(move |client| {
+            context.query().id(INIT).replace_id(INIT).target(PaneType::Directories).query(
+                move |client| {
                     let result = client
                         .lsinfo(None)?
                         .into_iter()
@@ -131,7 +127,8 @@ impl Pane for DirectoriesPane {
                         .sorted()
                         .collect::<Vec<_>>();
                     Ok(MpdQueryResult::DirOrSong { data: result, origin_path: None })
-                });
+                },
+            );
             self.initialized = true;
         }
 
@@ -146,12 +143,8 @@ impl Pane for DirectoriesPane {
     ) -> Result<()> {
         match event {
             UiEvent::Database => {
-                context
-                    .query()
-                    .id(INIT)
-                    .replace_id(INIT)
-                    .target(PaneTypeDiscriminants::Directories)
-                    .query(move |client| {
+                context.query().id(INIT).replace_id(INIT).target(PaneType::Directories).query(
+                    move |client| {
                         let result = client
                             .lsinfo(None)?
                             .into_iter()
@@ -159,7 +152,8 @@ impl Pane for DirectoriesPane {
                             .sorted()
                             .collect::<Vec<_>>();
                         Ok(MpdQueryResult::DirOrSong { data: result, origin_path: None })
-                    });
+                    },
+                );
             }
             UiEvent::Reconnected => {
                 self.initialized = false;
@@ -323,7 +317,7 @@ impl BrowserPane<DirOrSong> for DirectoriesPane {
                     .query()
                     .id(PREVIEW)
                     .replace_id("directories_preview")
-                    .target(PaneTypeDiscriminants::Directories)
+                    .target(PaneType::Directories)
                     .query(move |client| {
                         let data: Vec<_> = match client.lsinfo(Some(&next_path)) {
                             Ok(val) => val,
@@ -360,7 +354,7 @@ impl BrowserPane<DirOrSong> for DirectoriesPane {
                     .query()
                     .id(PREVIEW)
                     .replace_id("directories_preview")
-                    .target(PaneTypeDiscriminants::Directories)
+                    .target(PaneType::Directories)
                     .query(move |client| {
                         Ok(MpdQueryResult::Preview {
                             data: client

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -1,9 +1,9 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::HashMap};
 
 use album_art::AlbumArtPane;
 use albums::AlbumsPane;
-use anyhow::Result;
-use artists::{ArtistsPane, ArtistsPaneMode};
+use anyhow::{Context, Result};
+use artists::ArtistsPane;
 use directories::DirectoriesPane;
 use either::Either;
 use header::HeaderPane;
@@ -30,7 +30,7 @@ use crate::{
     MpdQueryResult,
     config::{
         keys::CommonAction,
-        tabs::{Pane as ConfigPane, PaneType, PaneTypeDiscriminants, SizedPaneOrSplit},
+        tabs::{Pane as ConfigPane, PaneType, SizedPaneOrSplit},
         theme::{
             SymbolsConfig,
             properties::{
@@ -44,7 +44,10 @@ use crate::{
         },
     },
     context::AppContext,
-    mpd::commands::{Song, State, Status, status::OnOffOneshot, volume::Bound},
+    mpd::{
+        commands::{Song, State, Status, status::OnOffOneshot, volume::Bound},
+        mpd_client::Tag,
+    },
     shared::{ext::duration::DurationExt, key_event::KeyEvent, mouse_event::MouseEvent},
 };
 
@@ -85,7 +88,12 @@ pub enum Panes<'pane_ref, 'pane> {
     FrameCount(&'pane_ref mut FrameCountPane),
     TabContent,
     Property(PropertyPane<'pane_ref>),
+    Others(&'pane_ref mut Box<dyn BoxedPane>),
 }
+
+pub trait BoxedPane: Pane + std::fmt::Debug {}
+
+impl<P: Pane + std::fmt::Debug> BoxedPane for P {}
 
 #[derive(Debug)]
 pub struct PaneContainer<'panes> {
@@ -105,6 +113,7 @@ pub struct PaneContainer<'panes> {
     pub tabs: TabsPane<'panes>,
     #[cfg(debug_assertions)]
     pub frame_count: FrameCountPane,
+    pub others: HashMap<PaneType, Box<dyn BoxedPane>>,
 }
 
 impl<'panes> PaneContainer<'panes> {
@@ -115,8 +124,13 @@ impl<'panes> PaneContainer<'panes> {
             logs: LogsPane::new(),
             directories: DirectoriesPane::new(context),
             albums: AlbumsPane::new(context),
-            artists: ArtistsPane::new(ArtistsPaneMode::Artist, context),
-            album_artists: ArtistsPane::new(ArtistsPaneMode::AlbumArtist, context),
+            artists: ArtistsPane::new(Tag::Artist, PaneType::Artists, None, context),
+            album_artists: ArtistsPane::new(
+                Tag::AlbumArtist,
+                PaneType::AlbumArtists,
+                None,
+                context,
+            ),
             playlists: PlaylistsPane::new(context),
             search: SearchPane::new(context),
             album_art: AlbumArtPane::new(context),
@@ -126,63 +140,60 @@ impl<'panes> PaneContainer<'panes> {
             tabs: TabsPane::new(context)?,
             #[cfg(debug_assertions)]
             frame_count: FrameCountPane::new(),
+            others: Self::init_other_panes(context).collect(),
         })
     }
 
-    pub fn get_mut_by_discr<'pane_ref>(
-        &'pane_ref mut self,
-        pane: PaneTypeDiscriminants,
-    ) -> Option<Panes<'pane_ref, 'panes>> {
-        match pane {
-            PaneTypeDiscriminants::Queue => Some(Panes::Queue(&mut self.queue)),
-            #[cfg(debug_assertions)]
-            PaneTypeDiscriminants::Logs => Some(Panes::Logs(&mut self.logs)),
-            PaneTypeDiscriminants::Directories => Some(Panes::Directories(&mut self.directories)),
-            PaneTypeDiscriminants::Artists => Some(Panes::Artists(&mut self.artists)),
-            PaneTypeDiscriminants::AlbumArtists => {
-                Some(Panes::AlbumArtists(&mut self.album_artists))
-            }
-            PaneTypeDiscriminants::Albums => Some(Panes::Albums(&mut self.albums)),
-            PaneTypeDiscriminants::Playlists => Some(Panes::Playlists(&mut self.playlists)),
-            PaneTypeDiscriminants::Search => Some(Panes::Search(&mut self.search)),
-            PaneTypeDiscriminants::AlbumArt => Some(Panes::AlbumArt(&mut self.album_art)),
-            PaneTypeDiscriminants::Lyrics => Some(Panes::Lyrics(&mut self.lyrics)),
-            PaneTypeDiscriminants::ProgressBar => Some(Panes::ProgressBar(&mut self.progress_bar)),
-            PaneTypeDiscriminants::Header => Some(Panes::Header(&mut self.header)),
-            PaneTypeDiscriminants::Tabs => Some(Panes::Tabs(&mut self.tabs)),
-            PaneTypeDiscriminants::TabContent => Some(Panes::TabContent),
-            #[cfg(debug_assertions)]
-            PaneTypeDiscriminants::FrameCount => Some(Panes::FrameCount(&mut self.frame_count)),
-            PaneTypeDiscriminants::Property => None,
-        }
+    pub fn init_other_panes(
+        context: &AppContext,
+    ) -> impl Iterator<Item = (PaneType, Box<dyn BoxedPane>)> + use<'_> {
+        context.config.tabs.tabs.iter().flat_map(|(_name, tab)| {
+            tab.panes.panes_iter().filter_map(|pane| match &pane.pane {
+                PaneType::Browser { root_tag, separator } => Some((
+                    pane.pane.clone(),
+                    Box::new(ArtistsPane::new(
+                        Tag::Custom(root_tag.clone()),
+                        pane.pane.clone(),
+                        separator.clone(),
+                        context,
+                    )) as Box<dyn BoxedPane>,
+                )),
+                _ => None,
+            })
+        })
     }
 
     pub fn get_mut<'pane_ref, 'pane_type_ref: 'pane_ref>(
         &'pane_ref mut self,
         pane: &'pane_type_ref PaneType,
         context: &AppContext,
-    ) -> Panes<'pane_ref, 'panes> {
+    ) -> Result<Panes<'pane_ref, 'panes>> {
         match pane {
-            PaneType::Queue => Panes::Queue(&mut self.queue),
+            PaneType::Queue => Ok(Panes::Queue(&mut self.queue)),
             #[cfg(debug_assertions)]
-            PaneType::Logs => Panes::Logs(&mut self.logs),
-            PaneType::Directories => Panes::Directories(&mut self.directories),
-            PaneType::Artists => Panes::Artists(&mut self.artists),
-            PaneType::AlbumArtists => Panes::AlbumArtists(&mut self.album_artists),
-            PaneType::Albums => Panes::Albums(&mut self.albums),
-            PaneType::Playlists => Panes::Playlists(&mut self.playlists),
-            PaneType::Search => Panes::Search(&mut self.search),
-            PaneType::AlbumArt => Panes::AlbumArt(&mut self.album_art),
-            PaneType::Lyrics => Panes::Lyrics(&mut self.lyrics),
-            PaneType::ProgressBar => Panes::ProgressBar(&mut self.progress_bar),
-            PaneType::Header => Panes::Header(&mut self.header),
-            PaneType::Tabs => Panes::Tabs(&mut self.tabs),
-            PaneType::TabContent => Panes::TabContent,
+            PaneType::Logs => Ok(Panes::Logs(&mut self.logs)),
+            PaneType::Directories => Ok(Panes::Directories(&mut self.directories)),
+            PaneType::Artists => Ok(Panes::Artists(&mut self.artists)),
+            PaneType::AlbumArtists => Ok(Panes::AlbumArtists(&mut self.album_artists)),
+            PaneType::Albums => Ok(Panes::Albums(&mut self.albums)),
+            PaneType::Playlists => Ok(Panes::Playlists(&mut self.playlists)),
+            PaneType::Search => Ok(Panes::Search(&mut self.search)),
+            PaneType::AlbumArt => Ok(Panes::AlbumArt(&mut self.album_art)),
+            PaneType::Lyrics => Ok(Panes::Lyrics(&mut self.lyrics)),
+            PaneType::ProgressBar => Ok(Panes::ProgressBar(&mut self.progress_bar)),
+            PaneType::Header => Ok(Panes::Header(&mut self.header)),
+            PaneType::Tabs => Ok(Panes::Tabs(&mut self.tabs)),
+            PaneType::TabContent => Ok(Panes::TabContent),
             #[cfg(debug_assertions)]
-            PaneType::FrameCount => Panes::FrameCount(&mut self.frame_count),
+            PaneType::FrameCount => Ok(Panes::FrameCount(&mut self.frame_count)),
             PaneType::Property { content, align } => {
-                Panes::Property(PropertyPane::<'pane_type_ref>::new(content, *align, context))
+                Ok(Panes::Property(PropertyPane::<'pane_type_ref>::new(content, *align, context)))
             }
+            p @ PaneType::Browser { .. } => Ok(Panes::Others(
+                self.others
+                    .get_mut(pane)
+                    .with_context(|| format!("expected pane to be defined {p:?}"))?,
+            )),
         }
     }
 }
@@ -208,13 +219,14 @@ macro_rules! pane_call {
             #[cfg(debug_assertions)]
             Panes::FrameCount(ref mut s) => s.$fn($($param),+),
             Panes::Property(ref mut s) => s.$fn($($param),+),
+            Panes::Others(ref mut s) => s.$fn($($param),+),
         }
     }
 }
 pub(crate) use pane_call;
 
 #[allow(unused_variables)]
-pub(super) trait Pane {
+pub(crate) trait Pane {
     fn render(&mut self, frame: &mut Frame, area: Rect, context: &AppContext) -> Result<()>;
 
     /// For any cleanup operations, ran when the screen hides

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -3,7 +3,6 @@ use std::{borrow::Cow, collections::HashMap};
 use album_art::AlbumArtPane;
 use albums::AlbumsPane;
 use anyhow::{Context, Result};
-use artists::ArtistsPane;
 use directories::DirectoriesPane;
 use either::Either;
 use header::HeaderPane;
@@ -22,6 +21,7 @@ use ratatui::{
 use search::SearchPane;
 use strum::Display;
 use tabs::TabsPane;
+use tag_browser::TagBrowserPane;
 
 #[cfg(debug_assertions)]
 use self::{frame_count::FrameCountPane, logs::LogsPane};
@@ -53,7 +53,6 @@ use crate::{
 
 pub mod album_art;
 pub mod albums;
-pub mod artists;
 pub mod directories;
 #[cfg(debug_assertions)]
 pub mod frame_count;
@@ -67,6 +66,7 @@ pub mod property;
 pub mod queue;
 pub mod search;
 pub mod tabs;
+pub mod tag_browser;
 
 #[derive(Debug, Display, strum::EnumDiscriminants)]
 pub enum Panes<'pane_ref, 'pane> {
@@ -74,8 +74,8 @@ pub enum Panes<'pane_ref, 'pane> {
     #[cfg(debug_assertions)]
     Logs(&'pane_ref mut LogsPane),
     Directories(&'pane_ref mut DirectoriesPane),
-    Artists(&'pane_ref mut ArtistsPane),
-    AlbumArtists(&'pane_ref mut ArtistsPane),
+    Artists(&'pane_ref mut TagBrowserPane),
+    AlbumArtists(&'pane_ref mut TagBrowserPane),
     Albums(&'pane_ref mut AlbumsPane),
     Playlists(&'pane_ref mut PlaylistsPane),
     Search(&'pane_ref mut SearchPane),
@@ -102,8 +102,8 @@ pub struct PaneContainer<'panes> {
     pub logs: LogsPane,
     pub directories: DirectoriesPane,
     pub albums: AlbumsPane,
-    pub artists: ArtistsPane,
-    pub album_artists: ArtistsPane,
+    pub artists: TagBrowserPane,
+    pub album_artists: TagBrowserPane,
     pub playlists: PlaylistsPane,
     pub search: SearchPane,
     pub album_art: AlbumArtPane,
@@ -124,8 +124,8 @@ impl<'panes> PaneContainer<'panes> {
             logs: LogsPane::new(),
             directories: DirectoriesPane::new(context),
             albums: AlbumsPane::new(context),
-            artists: ArtistsPane::new(Tag::Artist, PaneType::Artists, None, context),
-            album_artists: ArtistsPane::new(
+            artists: TagBrowserPane::new(Tag::Artist, PaneType::Artists, None, context),
+            album_artists: TagBrowserPane::new(
                 Tag::AlbumArtist,
                 PaneType::AlbumArtists,
                 None,
@@ -151,7 +151,7 @@ impl<'panes> PaneContainer<'panes> {
             tab.panes.panes_iter().filter_map(|pane| match &pane.pane {
                 PaneType::Browser { root_tag, separator } => Some((
                     pane.pane.clone(),
-                    Box::new(ArtistsPane::new(
+                    Box::new(TagBrowserPane::new(
                         Tag::Custom(root_tag.clone()),
                         pane.pane.clone(),
                         separator.clone(),

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -17,7 +17,7 @@ use crate::{
     MpdQueryResult,
     config::{
         keys::{GlobalAction, QueueActions},
-        tabs::PaneTypeDiscriminants,
+        tabs::PaneType,
         theme::properties::{Property, SongProperty},
     },
     context::AppContext,
@@ -522,7 +522,7 @@ impl Pane for QueuePane {
                             .query()
                             .id(ADD_TO_PLAYLIST)
                             .replace_id(ADD_TO_PLAYLIST)
-                            .target(PaneTypeDiscriminants::Queue)
+                            .target(PaneType::Queue)
                             .query(move |client| {
                                 let playlists = client
                                     .list_playlists()?

--- a/src/ui/panes/search.rs
+++ b/src/ui/panes/search.rs
@@ -13,7 +13,7 @@ use ratatui::{
 use super::{CommonAction, Pane};
 use crate::{
     MpdQueryResult,
-    config::{Config, Search, keys::GlobalAction, tabs::PaneTypeDiscriminants},
+    config::{Config, Search, keys::GlobalAction, tabs::PaneType},
     context::AppContext,
     core::command::{create_env, run_external},
     mpd::{
@@ -163,14 +163,9 @@ impl SearchPane {
                     None,
                     self.songs_dir.to_list_items(&context.config),
                 )]);
-                context
-                    .query()
-                    .id(PREVIEW)
-                    .replace_id("preview")
-                    .target(PaneTypeDiscriminants::Search)
-                    .query(|_| {
-                        Ok(MpdQueryResult::Preview { data, origin_path: Some(origin_path) })
-                    });
+                context.query().id(PREVIEW).replace_id("preview").target(PaneType::Search).query(
+                    |_| Ok(MpdQueryResult::Preview { data, origin_path: Some(origin_path) }),
+                );
             }
             Phase::BrowseResults { .. } => {
                 let Some(current) = self.songs_dir.selected() else {
@@ -178,12 +173,8 @@ impl SearchPane {
                 };
                 let file = current.file.clone();
 
-                context
-                    .query()
-                    .id(PREVIEW)
-                    .replace_id("preview")
-                    .target(PaneTypeDiscriminants::Search)
-                    .query(move |client| {
+                context.query().id(PREVIEW).replace_id("preview").target(PaneType::Search).query(
+                    move |client| {
                         let data = Some(
                             client
                                 .find(&[Filter::new(Tag::File, &file)])?
@@ -192,7 +183,8 @@ impl SearchPane {
                                 .to_preview(),
                         );
                         Ok(MpdQueryResult::Preview { data, origin_path: Some(origin_path) })
-                    });
+                    },
+                );
             }
         }
     }
@@ -380,7 +372,7 @@ impl SearchPane {
             return;
         }
 
-        context.query().id(SEARCH).replace_id(SEARCH).target(PaneTypeDiscriminants::Search).query(
+        context.query().id(SEARCH).replace_id(SEARCH).target(PaneType::Search).query(
             move |client| {
                 let filter = filter
                     .iter_mut()

--- a/src/ui/tab_screen.rs
+++ b/src/ui/tab_screen.rs
@@ -83,7 +83,7 @@ impl TabScreen {
                     context.config.as_border_style()
                 });
 
-                let pane_instance = &mut pane_container.get_mut(&pane.pane, context);
+                let pane_instance = &mut pane_container.get_mut(&pane.pane, context)?;
                 pane_call!(pane_instance, render(frame, area, context))?;
                 frame.render_widget(block, block_area);
                 Ok(())
@@ -177,7 +177,7 @@ impl TabScreen {
                     );
                     return Ok(());
                 };
-                let mut pane = panes.get_mut(&focused.pane, context);
+                let mut pane = panes.get_mut(&focused.pane, context)?;
                 pane_call!(pane, handle_action(event, context))?;
             }
         };
@@ -212,14 +212,14 @@ impl TabScreen {
             );
             return Ok(());
         };
-        let mut pane = panes.get_mut(&focused.pane, context);
+        let mut pane = panes.get_mut(&focused.pane, context)?;
         pane_call!(pane, handle_mouse_event(event, context))?;
         Ok(())
     }
 
     pub fn on_hide(&mut self, panes: &mut PaneContainer, context: &AppContext) -> Result<()> {
         for pane in self.panes.panes_iter() {
-            let mut pane = panes.get_mut(&pane.pane, context);
+            let mut pane = panes.get_mut(&pane.pane, context)?;
             pane_call!(pane, on_hide(context))?;
         }
         Ok(())
@@ -236,7 +236,7 @@ impl TabScreen {
                 self.pane_data.entry(pane.id).or_insert_with(|| PaneData::new(pane.is_focusable()));
             pane_data.area = pane_area;
             pane_data.block_area = block_area;
-            let pane_instance = &mut pane_container.get_mut(&pane.pane, context);
+            let pane_instance = &mut pane_container.get_mut(&pane.pane, context)?;
             pane_call!(pane_instance, calculate_areas(pane_area, context))?;
             pane_call!(pane_instance, before_show(context))?;
             Ok(())
@@ -272,7 +272,7 @@ impl TabScreen {
                 self.pane_data.entry(pane.id).or_insert_with(|| PaneData::new(pane.is_focusable()));
             pane_data.area = area;
             pane_data.block_area = block_area;
-            let pane_instance = &mut pane_container.get_mut(&pane.pane, context);
+            let pane_instance = &mut pane_container.get_mut(&pane.pane, context)?;
             pane_call!(pane_instance, calculate_areas(pane_area, context))?;
             pane_call!(pane_instance, resize(pane_area, context))?;
             Ok(())


### PR DESCRIPTION
fixes https://github.com/mierak/rmpc/issues/265

This essentially converts the current `Artists`/`AlbumArtists` pane to a more generic one where you can define what tag is used for the first/root level of the browser. There is also an optional separator which lets you use tags containing a delimiter separated values as discrete entries in the browser's root level.
This is similar but a more powerful version of ncmpcpp's `media_library_primary_tag`

Usage:
```ron
(
    name: "Genre",
    border_type: None,
    pane: Pane(Browser(root_tag: "genre", separator: ";")),
),
```
Which means the `genere` tag value gets split by `;` and each value gets its separate entry in the browser.

`Artists` and `AlbumArtists` panes stay backwards compatible but are now internally represented as `Pane(Browser(root_tag: "artist"/"albumartist"))`