### PR TITLE
Update documentation to mention `Alt` key`

### DIFF
--- a/docs/src/content/docs/next/configuration/keybinds.mdx
+++ b/docs/src/content/docs/next/configuration/keybinds.mdx
@@ -32,6 +32,7 @@ You can also bind multiple keys to a single action by specfying it multiple time
 Keybind syntax is similar to vim keybinds. To map action to letter `a` you write `a` and to map an action to an uppercase `A`
 you would write `A`. To combine `a` key with a modifiers like `Ctrl` you would write `<C-a>` and likewise for an uppercase
 `A`: `<C-A>`. If a special key like `Tab` is used on its own you have to wrap it angle brackets like so: `<Tab>`.
+In case of the `Alt` key (sometimes also called `Meta` key) you would write `<A-x>`.
 
 ### ExternalCommand
 


### PR DESCRIPTION
In emacs `Alt` is called `Meta`. I also mentioned that in order to make searching for `meta` possible.