### PR TITLE
feat: cycling/scrolling property pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - `on_resize` which is called whenever rmpc is resized
 - `--theme` cli argument to override theme in the config file
 - new `Browser` pane
+- Add ability to scroll and cycle `Property` panes when they do not fit their area
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,6 +1865,7 @@ dependencies = [
  "test-case",
  "textwrap",
  "time",
+ "unicode-width 0.2.0",
  "url",
  "vergen-gitcl",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ enum-map = "2.7.3"
 textwrap = "0.16.1"
 crossbeam = "0.8.4"
 notify-debouncer-full = "0.5.0"
+unicode-width = "0.2.0"
 
 [build-dependencies]
 clap = { workspace = true }

--- a/docs/src/content/docs/next/configuration/tabs.mdx
+++ b/docs/src/content/docs/next/configuration/tabs.mdx
@@ -158,12 +158,16 @@ tabs: [
 
 <ConfigValue
     name="pane"
-    customText="Pane(Property(content: <property>[], align: Left | Right | Center))"
+    customText="Pane(Property(content: <property>[], align: Left | Right | Center, scroll_speed: <number>))"
     link={path("configuration/header/#header_property_kind")}
 />
 
 This config displays the `AlbumArt` and `Queue` panes and below them there are `Property` with pane with `StateV2`, `ProgressBar` pane and
 another `Property` pane with combination of `Elapsed` and `Duration` status properties next to each other in a line.
+
+The `Property` pane also scrolls around and cycles if the content is longer than its defined area when `scroll_speed` is set to a value higher
+than 0. The value determines how fast the `Property` pane cycles in columns per second. This is tied to the elapsed time of the currently playing
+song. This is disabled when set to 0 or not set at all.
 
 <details>
 

--- a/src/config/tabs.rs
+++ b/src/config/tabs.rs
@@ -56,6 +56,8 @@ pub enum PaneTypeFile {
         content: Vec<PropertyFile<PropertyKindFile>>,
         #[serde(default)]
         align: super::theme::properties::Alignment,
+        #[serde(default)]
+        scroll_speed: u16,
     },
     Browser {
         root_tag: String,
@@ -86,6 +88,7 @@ pub enum PaneType {
     Property {
         content: Vec<Property<PropertyKind>>,
         align: ratatui::layout::Alignment,
+        scroll_speed: u16,
     },
     Browser {
         root_tag: String,
@@ -145,13 +148,16 @@ impl From<PaneTypeFile> for PaneType {
             PaneTypeFile::TabContent => PaneType::TabContent,
             #[cfg(debug_assertions)]
             PaneTypeFile::FrameCount => PaneType::FrameCount,
-            PaneTypeFile::Property { content: properties, align } => PaneType::Property {
-                content: properties
-                    .into_iter()
-                    .map(|prop| prop.try_into().expect(""))
-                    .collect_vec(),
-                align: (align).into(),
-            },
+            PaneTypeFile::Property { content: properties, align, scroll_speed } => {
+                PaneType::Property {
+                    content: properties
+                        .into_iter()
+                        .map(|prop| prop.try_into().expect(""))
+                        .collect_vec(),
+                    align: align.into(),
+                    scroll_speed,
+                }
+            }
             PaneTypeFile::Browser { root_tag: tag, separator } => {
                 PaneType::Browser { root_tag: tag, separator }
             }

--- a/src/mpd/commands/status.rs
+++ b/src/mpd/commands/status.rs
@@ -78,7 +78,8 @@ impl FromMpd for Status {
             "updating_db" => self.updating_db = Some(value.parse().logerr(key, &value)?),
             "error" => self.error = Some(value),
             "bitrate" => self.bitrate = None,
-            "time" => {} // deprecated
+            "lastloadedplaylist" => {} // new in 0.24.0, not needed atm
+            "time" => {}               // deprecated
             _ => return Ok(LineHandled::No { value }),
         }
         Ok(LineHandled::Yes)

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -186,8 +186,13 @@ impl<'panes> PaneContainer<'panes> {
             PaneType::TabContent => Ok(Panes::TabContent),
             #[cfg(debug_assertions)]
             PaneType::FrameCount => Ok(Panes::FrameCount(&mut self.frame_count)),
-            PaneType::Property { content, align } => {
-                Ok(Panes::Property(PropertyPane::<'pane_type_ref>::new(content, *align, context)))
+            PaneType::Property { content, align, scroll_speed } => {
+                Ok(Panes::Property(PropertyPane::<'pane_type_ref>::new(
+                    content,
+                    *align,
+                    (*scroll_speed).into(),
+                    context,
+                )))
             }
             p @ PaneType::Browser { .. } => Ok(Panes::Others(
                 self.others

--- a/src/ui/widgets/mod.rs
+++ b/src/ui/widgets/mod.rs
@@ -11,6 +11,7 @@ pub mod button;
 pub mod header;
 pub mod input;
 pub mod progress_bar;
+pub mod scrolling_line;
 pub mod tabs;
 pub mod volume;
 

--- a/src/ui/widgets/scrolling_line.rs
+++ b/src/ui/widgets/scrolling_line.rs
@@ -1,0 +1,73 @@
+use std::time::Duration;
+
+use bon::Builder;
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Rect},
+    style::Style,
+    text::{Line, StyledGrapheme},
+    widgets::{Paragraph, Widget},
+};
+use unicode_width::UnicodeWidthStr;
+
+#[derive(Builder)]
+pub struct ScrollingLine<'a> {
+    scroll_speed: u64,
+    align: Alignment,
+    line: Line<'a>,
+    progress: Duration,
+}
+
+impl Widget for ScrollingLine<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+
+        let line_len = self.line.width() as u64;
+        let max_len = area.width as u64;
+
+        if line_len <= max_len || self.scroll_speed == 0 {
+            Paragraph::new(self.line).alignment(self.align).render(area, buf);
+            return;
+        }
+
+        let mut x = 0u64;
+
+        // +3 for the spaces and pipes
+        let line_len = line_len + 3;
+        let mut elapsed_sec = self.progress.as_secs();
+        if self.progress.subsec_millis() > 500 {
+            elapsed_sec += 1;
+        }
+        let cols_to_offset = (elapsed_sec * self.scroll_speed) % line_len;
+        let mut acc = 0;
+
+        let mut res = String::new();
+        for StyledGrapheme { symbol, style } in self
+            .line
+            .styled_graphemes(Style::default())
+            .chain(std::iter::once(StyledGrapheme::new(" ", Style::default())))
+            .chain(std::iter::once(StyledGrapheme::new("|", Style::default())))
+            .chain(std::iter::once(StyledGrapheme::new(" ", Style::default())))
+            .chain(self.line.styled_graphemes(Style::default()))
+            .skip_while(|StyledGrapheme { symbol, .. }| {
+                let result = acc < cols_to_offset as usize;
+                acc += symbol.width();
+                result
+            })
+        {
+            let width = symbol.width() as u64;
+            if width == 0 {
+                continue;
+            }
+            if x + width > max_len {
+                break;
+            }
+
+            buf[(area.left() + x as u16, area.top())].set_symbol(symbol).set_style(style);
+            res.push_str(symbol);
+            x += width;
+        }
+    }
+}


### PR DESCRIPTION
fixes https://github.com/mierak/rmpc/issues/226

Makes property panes cycle around when they do not fit their area.
Example:
```ron
(
    size: "60%",
    pane: Pane(Property(
        content: [
            (kind: Property(Song(Artist)), default: (kind: Text("Unknown"))),
            (kind: Text(" - ")),
            (kind: Property(Song(Album)), default: (kind: Text("Unknown Album")))
        ], align: Center, scroll_speed: 2
    )),
),
```
Makes the content of this property cycle by 2 columns each second(tied to the elapsed time of the currently playing song, so it wont cycle when paused). Not specifying `scroll_speed` or setting it to 0 disables this.