### PR TITLE
feat: property pane background color

### DIFF
--- a/docs/src/content/docs/next/configuration/tabs.mdx
+++ b/docs/src/content/docs/next/configuration/tabs.mdx
@@ -158,7 +158,7 @@ tabs: [
 
 <ConfigValue
     name="pane"
-    customText="Pane(Property(content: <property>[], align: Left | Right | Center, scroll_speed: <number>))"
+    customText="Pane(Property(content: <property>[], align: Left | Right | Center, scroll_speed: <number>, background_color: Option<String>))"
     link={path("configuration/header/#header_property_kind")}
 />
 
@@ -168,6 +168,9 @@ another `Property` pane with combination of `Elapsed` and `Duration` status prop
 The `Property` pane also scrolls around and cycles if the content is longer than its defined area when `scroll_speed` is set to a value higher
 than 0. The value determines how fast the `Property` pane cycles in columns per second. This is tied to the elapsed time of the currently playing
 song. This is disabled when set to 0 or not set at all.
+
+Additionally, `background_color` can also be configured for the whole pane. Falls back to theme's <a href={path("configuration/theme#background_color")}>background_color</a>
+if not specified.
 
 <details>
 

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -186,11 +186,12 @@ impl<'panes> PaneContainer<'panes> {
             PaneType::TabContent => Ok(Panes::TabContent),
             #[cfg(debug_assertions)]
             PaneType::FrameCount => Ok(Panes::FrameCount(&mut self.frame_count)),
-            PaneType::Property { content, align, scroll_speed } => {
+            PaneType::Property { content, align, scroll_speed, background_color } => {
                 Ok(Panes::Property(PropertyPane::<'pane_type_ref>::new(
                     content,
                     *align,
                     (*scroll_speed).into(),
+                    *background_color,
                     context,
                 )))
             }

--- a/src/ui/panes/property.rs
+++ b/src/ui/panes/property.rs
@@ -3,7 +3,9 @@ use either::Either;
 use ratatui::{
     Frame,
     layout::{Alignment, Rect},
+    style::{Color, Style},
     text::Line,
+    widgets::Block,
 };
 
 use super::Pane;
@@ -19,6 +21,7 @@ pub struct PropertyPane<'content> {
     content: &'content Vec<Property<PropertyKind>>,
     align: Alignment,
     scroll_speed: u64,
+    background_color: Option<Color>,
 }
 
 impl<'content> PropertyPane<'content> {
@@ -26,14 +29,18 @@ impl<'content> PropertyPane<'content> {
         content: &'content Vec<Property<PropertyKind>>,
         align: Alignment,
         scroll_speed: u64,
+        background_color: Option<Color>,
         _context: &AppContext,
     ) -> Self {
-        Self { content, align, scroll_speed }
+        Self { content, align, scroll_speed, background_color }
     }
 }
 
 impl Pane for PropertyPane<'_> {
     fn render(&mut self, frame: &mut Frame, area: Rect, context: &AppContext) -> Result<()> {
+        if let Some(bg_color) = self.background_color {
+            frame.render_widget(Block::default().style(Style::default().bg(bg_color)), area);
+        }
         let song = context.find_current_song_in_queue().map(|(_, song)| song);
 
         let line = Line::from(self.content.iter().fold(Vec::new(), |mut acc, val| {


### PR DESCRIPTION
Currently the property pane was not able to have a proper background different from the normal background color, only background color for the property could be specified, but that does not necessarily fill the whole pane.