### PR TITLE
Handle new value lastloadedplaylist from mpd

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer"
+  },
+  "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.rustfmt.extraArgs": ["+nightly"]
+}

--- a/src/mpd/commands/status.rs
+++ b/src/mpd/commands/status.rs
@@ -44,6 +44,7 @@ pub struct Status {
                                     * explanation. */
     pub updating_db: Option<u32>, // job id
     pub error: Option<String>,    // if there is an error, returns message here
+    pub lastloadedplaylist: Option<String>, // last loaded stored playlist
 }
 
 impl FromMpd for Status {
@@ -78,7 +79,7 @@ impl FromMpd for Status {
             "updating_db" => self.updating_db = Some(value.parse().logerr(key, &value)?),
             "error" => self.error = Some(value),
             "bitrate" => self.bitrate = None,
-            "lastloadedplaylist" => {} // new in 0.24.0, not needed atm
+            "lastloadedplaylist" => self.lastloadedplaylist = Some(value),
             "time" => {}               // deprecated
             _ => return Ok(LineHandled::No { value }),
         }

--- a/src/mpd/commands/status.rs
+++ b/src/mpd/commands/status.rs
@@ -42,8 +42,8 @@ pub struct Status {
                                     * bits:channels. See Global Audio Format for a
                                     * detailed
                                     * explanation. */
-    pub updating_db: Option<u32>, // job id
-    pub error: Option<String>,    // if there is an error, returns message here
+    pub updating_db: Option<u32>,           // job id
+    pub error: Option<String>,              // if there is an error, returns message here
     pub lastloadedplaylist: Option<String>, // last loaded stored playlist
 }
 
@@ -80,7 +80,7 @@ impl FromMpd for Status {
             "error" => self.error = Some(value),
             "bitrate" => self.bitrate = None,
             "lastloadedplaylist" => self.lastloadedplaylist = Some(value),
-            "time" => {}               // deprecated
+            "time" => {} // deprecated
             _ => return Ok(LineHandled::No { value }),
         }
         Ok(LineHandled::Yes)

--- a/src/mpd/mod.rs
+++ b/src/mpd/mod.rs
@@ -18,7 +18,7 @@ where
         match self.next_internal(key.to_lowercase().as_str(), value)? {
             LineHandled::Yes => {}
             LineHandled::No { value } => {
-                log::warn!(key = key.as_str(), value = value.as_str(); "Encountered unknow key/value pair");
+                log::warn!(key = key.as_str(), value = value.as_str(); "Encountered unknown key/value pair");
             }
         }
         Ok(())

--- a/src/shared/mpd_query.rs
+++ b/src/shared/mpd_query.rs
@@ -80,7 +80,7 @@ impl PreviewGroup {
 }
 
 #[derive(Debug)]
-#[allow(unused)]
+#[allow(unused, clippy::large_enum_variant)]
 pub(crate) enum MpdQueryResult {
     Preview { data: Option<Vec<PreviewGroup>>, origin_path: Option<Vec<String>> },
     SongsList { data: Vec<Song>, origin_path: Option<Vec<String>> },


### PR DESCRIPTION
Fixes terminal getting spammed with warnings that this key/value pair of `lastloadedplaylist` not being handled:

```
2025-03-31T08:09:45.862124626Z WARN  thread=request src/mpd/mod.rs:21 message="Encountered unknow key/value pair" key="lastloadedplaylist" value=""
```

I understand it's not being used at the moment, so if we want to we could probably just set this to `None` as well, let me know what you think.

Last loaded playlist is a string, which can be seen in [mpd's src/queue/Queue.hxx, tag v0.24.2](https://github.com/MusicPlayerDaemon/MPD/blob/v0.24.2/src/queue/Queue.hxx#L89).

Also went ahead and fixed that typo which existed [here](https://github.com/mierak/rmpc/blob/d5ec479eef0cb34df7b1d7ee5e5d034b7a33aca3/src/mpd/mod.rs#L21) for `FromMpd::next`, `LineHandled::No` case.