### PR TITLE
feat: add FileExtension property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ All notable changes to this project will be documented in this file.
 - new `Browser` pane
 - Add ability to scroll and cycle `Property` panes when they do not fit their area
 - `browser_song_sort` which is a list of properties which defines how the songs are sorted in the browser panes
+- `FileExtension` property
 
 ### Changed
 
 - The first lyrics will now only be highlighted once reached
 - **Breaking**: Songs are no longer sorted by their `browser_song_format`. The new `browser_song_sort` is used instead
+- `Filename` property no longer includes file extension, use `FileExtension` if you want to keep it
 
 ### Fixed
 

--- a/docs/src/content/docs/next/configuration/song-table.mdx
+++ b/docs/src/content/docs/next/configuration/song-table.mdx
@@ -102,6 +102,7 @@ property and the song's `filename` will be displayed instead. A group can also c
     type={[
         "Property(File)",
         "Property(Filename)",
+        "Property(FileExtension)",
         "Property(Title)",
         "Property(Artist)",
         "Property(Album)",

--- a/src/config/theme/properties.rs
+++ b/src/config/theme/properties.rs
@@ -12,6 +12,7 @@ use crate::config::{defaults, theme::StyleFile};
 pub enum SongPropertyFile {
     Filename,
     File,
+    FileExtension,
     Title,
     Artist,
     Album,
@@ -25,6 +26,7 @@ pub enum SongPropertyFile {
 pub enum SongProperty {
     Filename,
     File,
+    FileExtension,
     Title,
     Artist,
     Album,
@@ -237,6 +239,7 @@ impl From<SongPropertyFile> for SongProperty {
     fn from(value: SongPropertyFile) -> Self {
         match value {
             SongPropertyFile::Filename => SongProperty::Filename,
+            SongPropertyFile::FileExtension => SongProperty::FileExtension,
             SongPropertyFile::File => SongProperty::File,
             SongPropertyFile::Title => SongProperty::Title,
             SongPropertyFile::Artist => SongProperty::Artist,

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -544,12 +544,17 @@ impl Song {
     }
 
     pub fn file_name(&self) -> Option<Cow<str>> {
-        std::path::Path::new(&self.file).file_name().map(|file_name| file_name.to_string_lossy())
+        std::path::Path::new(&self.file).file_stem().map(|file_name| file_name.to_string_lossy())
+    }
+
+    pub fn file_ext(&self) -> Option<Cow<str>> {
+        std::path::Path::new(&self.file).extension().map(|ext| ext.to_string_lossy())
     }
 
     fn format<'song>(&'song self, property: &SongProperty) -> Option<Cow<'song, str>> {
         match property {
             SongProperty::Filename => self.file_name(),
+            SongProperty::FileExtension => self.file_ext(),
             SongProperty::File => Some(Cow::Borrowed(self.file.as_str())),
             SongProperty::Title => self.title().map(|v| Cow::Borrowed(v.as_ref())),
             SongProperty::Artist => self.artist().map(|v| Cow::Borrowed(v.as_ref())),
@@ -566,6 +571,12 @@ impl Song {
     fn cmp_by_prop(&self, other: &Self, property: &SongProperty) -> Ordering {
         match property {
             SongProperty::Filename => match (self.file_name(), other.file_name()) {
+                (Some(a), Some(b)) => UniCase::new(a).cmp(&UniCase::new(b)),
+                (_, Some(_)) => Ordering::Greater,
+                (Some(_), _) => Ordering::Less,
+                (None, None) => Ordering::Equal,
+            },
+            SongProperty::FileExtension => match (self.file_ext(), other.file_ext()) {
                 (Some(a), Some(b)) => UniCase::new(a).cmp(&UniCase::new(b)),
                 (_, Some(_)) => Ordering::Greater,
                 (Some(_), _) => Ordering::Less,


### PR DESCRIPTION
Removes extension from the `Filename` property and introduces a new `FileExtension` property instead.