### PR TITLE
feat: better errors when reading config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Add ability to scroll and cycle `Property` panes when they do not fit their area
 - `browser_song_sort` which is a list of properties which defines how the songs are sorted in the browser panes
 - `FileExtension` property
+- Better error message inside a modal when reading of config fails
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,6 +1859,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_with",
  "strum 0.27.1",
  "sysinfo",
@@ -1998,13 +1999,23 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ log = { version = "0.4.25", features = ["kv"] }
 flexi_logger = "0.29.8"
 chrono = "0.4.39"
 serde_with = "3.12.0"
-serde_json = "1.0.138"
 either = "1.13.0"
 walkdir = "2.5.0"
 which = "7.0.2"
@@ -46,6 +45,8 @@ crossbeam = "0.8.4"
 notify-debouncer-full = "0.5.0"
 unicode-width = "0.2.0"
 unicase = "2.8.1"
+serde_path_to_error = "0.1.17"
+serde_json = "1.0.140"
 
 [build-dependencies]
 clap = { workspace = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,14 +174,16 @@ fn main() -> Result<()> {
                 .name("dependency_check".to_string())
                 .spawn(|| DEPENDENCIES.iter().for_each(|d| d.log()))?;
 
-            let config = match ConfigFile::read(&config_path) {
-                Ok(val) => val.into_config(
+            let config = match ConfigFile::read(&config_path).and_then(|val| {
+                val.into_config(
                     Some(&config_path),
                     args.theme.as_deref(),
                     std::mem::take(&mut args.address),
                     std::mem::take(&mut args.password),
                     false,
-                )?,
+                )
+            }) {
+                Ok(cfg) => cfg,
                 Err(err) => {
                     try_skip!(
                         event_tx.send(AppEvent::InfoModal {

--- a/src/shared/events.rs
+++ b/src/shared/events.rs
@@ -10,7 +10,7 @@ use super::{
     mpd_query::{MpdCommand, MpdQuery, MpdQueryResult, MpdQuerySync},
 };
 use crate::{
-    config::{Config, cli::Command, tabs::PaneType, theme::UiConfig},
+    config::{Config, Size, cli::Command, tabs::PaneType, theme::UiConfig},
     mpd::commands::IdleEvent,
     ui::UiAppEvent,
 };
@@ -50,6 +50,7 @@ pub(crate) enum AppEvent {
     UserKeyInput(KeyEvent),
     UserMouseInput(MouseEvent),
     Status(String, Level),
+    InfoModal { message: Vec<String>, title: Option<String>, size: Option<Size> },
     Log(Vec<u8>),
     IdleEvent(IdleEvent),
     RequestRender,

--- a/src/shared/macros.rs
+++ b/src/shared/macros.rs
@@ -56,9 +56,8 @@ macro_rules! status_warn {
 
 macro_rules! modal {
     ( $i:ident, $e:expr ) => {{
-        $i.app_event_sender.send(crate::AppEvent::UiEvent(crate::ui::UiAppEvent::Modal(
-            crate::ui::ModalWrapper(Box::new($e)),
-        )))?;
+        $i.app_event_sender
+            .send(crate::AppEvent::UiEvent(crate::ui::UiAppEvent::Modal(Box::new($e))))?;
     }};
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -431,7 +431,7 @@ impl<'ui> Ui<'ui> {
     pub fn on_ui_app_event(&mut self, event: UiAppEvent, context: &mut AppContext) -> Result<()> {
         match event {
             UiAppEvent::Modal(modal) => {
-                self.modals.push(modal.0);
+                self.modals.push(modal);
                 self.on_event(UiEvent::ModalOpened, context)?;
                 context.render()?;
             }
@@ -604,11 +604,8 @@ impl<'ui> Ui<'ui> {
 }
 
 #[derive(Debug)]
-pub struct ModalWrapper(Box<dyn Modal + Send + Sync>);
-
-#[derive(Debug)]
 pub enum UiAppEvent {
-    Modal(ModalWrapper),
+    Modal(Box<dyn Modal + Send + Sync>),
     PopModal,
     ChangeTab(TabName),
 }

--- a/src/ui/modals/info_modal.rs
+++ b/src/ui/modals/info_modal.rs
@@ -1,0 +1,156 @@
+use std::borrow::Cow;
+
+use anyhow::Result;
+use bon::bon;
+use itertools::Itertools;
+use ratatui::{
+    Frame,
+    layout::Alignment,
+    prelude::{Constraint, Layout},
+    style::Style,
+    symbols::{self, border},
+    text::Line,
+    widgets::{Block, Borders, Clear},
+};
+
+use super::{Modal, RectExt};
+use crate::{
+    config::{Size, keys::CommonAction},
+    context::AppContext,
+    shared::{
+        key_event::KeyEvent,
+        macros::pop_modal,
+        mouse_event::{MouseEvent, MouseEventKind},
+    },
+    ui::widgets::button::{Button, ButtonGroup, ButtonGroupState},
+};
+
+const BUTTON_GROUP_SYMBOLS: symbols::border::Set = symbols::border::Set {
+    top_right: symbols::line::NORMAL.vertical_left,
+    top_left: symbols::line::NORMAL.vertical_right,
+    ..symbols::border::ROUNDED
+};
+
+#[derive(Debug)]
+pub struct InfoModal<'a> {
+    message: Vec<String>,
+    button_group_state: ButtonGroupState,
+    button_group: ButtonGroup<'a>,
+    size: Option<Size>,
+    title: Option<Cow<'a, str>>,
+}
+
+#[allow(dead_code)]
+#[bon]
+impl<'a> InfoModal<'a> {
+    #[builder]
+    pub fn new(
+        context: &AppContext,
+        size: Option<impl Into<Size>>,
+        confirm_label: Option<&'a str>,
+        message: Vec<String>,
+        title: Option<impl Into<Cow<'a, str>>>,
+    ) -> Self {
+        let mut button_group_state = ButtonGroupState::default();
+        let buttons = vec![Button::default().label(confirm_label.unwrap_or("Ok"))];
+        button_group_state.set_button_count(buttons.len());
+        let button_group = ButtonGroup::default()
+            .active_style(context.config.theme.current_item_style)
+            .inactive_style(context.config.as_text_style())
+            .buttons(buttons)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_set(BUTTON_GROUP_SYMBOLS)
+                    .border_style(context.config.as_border_style()),
+            );
+
+        Self {
+            message,
+            button_group_state,
+            button_group,
+            size: size.map(|s| s.into()),
+            title: title.map(|v| v.into()),
+        }
+    }
+}
+
+impl Modal for InfoModal<'_> {
+    fn render(&mut self, frame: &mut Frame, app: &mut AppContext) -> Result<()> {
+        let width = match (frame.area().width, self.size) {
+            (fw, Some(Size { width, .. })) => width.min(fw),
+            (fw, None) if fw > 60 => fw / 2,
+            (fw, None) => fw,
+        };
+
+        let lines = self
+            .message
+            .iter()
+            .flat_map(|message| message.lines())
+            .flat_map(|line| textwrap::wrap(line, (width as usize).saturating_sub(2)))
+            .collect_vec();
+
+        let popup_area = frame
+            .area()
+            .centered_exact(width, self.size.map_or(u16::try_from(lines.len())? + 4, |v| v.height));
+        frame.render_widget(Clear, popup_area);
+
+        if let Some(bg_color) = app.config.theme.modal_background_color {
+            frame.render_widget(Block::default().style(Style::default().bg(bg_color)), popup_area);
+        }
+
+        let mut block = Block::default()
+            .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
+            .border_set(border::ROUNDED)
+            .border_style(app.config.as_border_style())
+            .title_alignment(Alignment::Left);
+        if let Some(title) = &self.title {
+            block = block.title(title.as_ref());
+        }
+
+        let [content_area, buttons_area] =
+            Layout::vertical([Constraint::Min(2), Constraint::Length(3)]).areas(popup_area);
+
+        let areas = Layout::vertical((0..lines.len()).map(|_| Constraint::Length(1)))
+            .split(block.inner(content_area));
+        frame.render_widget(&block, content_area);
+
+        for (idx, message) in lines.iter().enumerate() {
+            let paragraph =
+                Line::from(message.as_ref()).style(app.config.as_text_style()).left_aligned();
+
+            let Some(area) = areas.get(idx) else {
+                continue;
+            };
+            frame.render_widget(paragraph, *area);
+        }
+
+        frame.render_stateful_widget(
+            &mut self.button_group,
+            buttons_area,
+            &mut self.button_group_state,
+        );
+        Ok(())
+    }
+
+    fn handle_key(&mut self, key: &mut KeyEvent, context: &mut AppContext) -> Result<()> {
+        if let Some(CommonAction::Close | CommonAction::Confirm) = key.as_common_action(context) {
+            pop_modal!(context);
+        }
+
+        Ok(())
+    }
+
+    fn handle_mouse_event(&mut self, event: MouseEvent, context: &mut AppContext) -> Result<()> {
+        match event.kind {
+            MouseEventKind::LeftClick | MouseEventKind::DoubleClick => {
+                if let Some(idx) = self.button_group.get_button_idx_at(event.into()) {
+                    self.button_group_state.select(idx);
+                    pop_modal!(context);
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/src/ui/modals/mod.rs
+++ b/src/ui/modals/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 
 pub mod confirm_modal;
 pub mod decoders;
+pub mod info_modal;
 pub mod input_modal;
 pub mod keybinds;
 pub mod outputs;
@@ -19,7 +20,7 @@ pub mod select_modal;
 pub mod song_info;
 
 #[allow(unused)]
-pub(super) trait Modal: std::fmt::Debug {
+pub(crate) trait Modal: std::fmt::Debug {
     fn render(&mut self, frame: &mut Frame, app: &mut crate::context::AppContext) -> Result<()>;
 
     fn handle_key(&mut self, key: &mut KeyEvent, app: &mut AppContext) -> Result<()>;

--- a/src/ui/panes/album_art.rs
+++ b/src/ui/panes/album_art.rs
@@ -129,7 +129,9 @@ impl Pane for AlbumArtPane {
                 self.before_show(context)?;
             }
             UiEvent::Displayed if is_visible => {
-                self.album_art.show_current()?;
+                if is_visible && !self.is_modal_open {
+                    self.album_art.show_current()?;
+                }
             }
             UiEvent::ModalOpened if is_visible => {
                 self.is_modal_open = true;

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -350,7 +350,8 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
                 let d = d.clone();
                 modal!(
                     context,
-                    ConfirmModal::new(context)
+                    ConfirmModal::builder()
+                    .context(context)
                         .message("Are you sure you want to delete this playlist? This action cannot be undone.")
                         .on_confirm(move |context| {
                             let d = d.clone();
@@ -362,7 +363,8 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
                             Ok(())
                         })
                         .confirm_label("Delete")
-                        .size(45, 6)
+                        .size((45, 6))
+                        .build()
                 );
             }
             DirOrSong::Song(s) => {

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -460,14 +460,15 @@ impl Pane for QueuePane {
                 QueueActions::DeleteAll => {
                     modal!(
                         context,
-                        ConfirmModal::new(context)
+                        ConfirmModal::builder().context(context)
                             .message("Are you sure you want to clear the queue? This action cannot be undone.")
                             .on_confirm(|context| {
                                 context.command(|client| Ok(client.clear()?));
                                 Ok(())
                             })
                             .confirm_label("Clear")
-                            .size(45, 6)
+                            .size((45, 6))
+                            .build()
                     );
                 }
                 QueueActions::Play => {


### PR DESCRIPTION
This adds a modal popup which shows a better description of where the error occurred when reading an invalid config file 
![image](https://github.com/user-attachments/assets/6cf58e33-1c94-4fe8-a894-b5ca0ff6186e)
