### PR TITLE
feat: support multiple tag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 - `browser_song_sort` which is a list of properties which defines how the songs are sorted in the browser panes
 - `FileExtension` property
 - Better error message inside a modal when reading of config fails
+- Support for multiple entries in one tag. In formats they get separated by `format_tag_separator` and in metadata
+lists they are listed as multiple entries.
 
 ### Changed
 

--- a/docs/src/content/docs/next/assets/example_theme.ron
+++ b/docs/src/content/docs/next/assets/example_theme.ron
@@ -5,6 +5,7 @@
     default_album_art_path: None,
     show_song_table_header: true,
     draw_borders: true,
+    format_tag_separator: " | ",
     browser_column_widths: [20, 38, 42],
     background_color: None,
     text_color: None,

--- a/docs/src/content/docs/next/assets/themes/default/theme.ron
+++ b/docs/src/content/docs/next/assets/themes/default/theme.ron
@@ -5,6 +5,7 @@
     default_album_art_path: None,
     show_song_table_header: true,
     draw_borders: true,
+    format_tag_separator: " | ",
     browser_column_widths: [20, 38, 42],
     background_color: None,
     text_color: None,

--- a/docs/src/content/docs/next/configuration/theme.mdx
+++ b/docs/src/content/docs/next/configuration/theme.mdx
@@ -211,6 +211,13 @@ Style for all tabs except the active one.
 
 <ConfigValue name="highlight_border_style" type="other" customText="<style>" />
 
+### format_tag_separator
+
+<ConfigValue name="format_tag_separator" type="string" />
+
+Use this to separate entries when a song has multiple values for a tag. For example, a song with
+two values for `artist` and `|` as a separator will show `artist1 | artist2`. Default is `|`.
+
 ### song_table_format
 
 <ConfigValue

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -86,3 +86,7 @@ pub fn default_song_sort() -> Vec<SongPropertyFile> {
         SongPropertyFile::Title,
     ]
 }
+
+pub fn default_tag_separator() -> String {
+    " | ".to_string()
+}

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -52,6 +52,7 @@ pub struct UiConfig {
     #[debug("{}", default_album_art.len())]
     pub default_album_art: &'static [u8],
     pub layout: SizedPaneOrSplit,
+    pub format_tag_separator: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -82,6 +83,8 @@ pub struct UiConfigFile {
     pub(super) default_album_art_path: Option<String>,
     #[serde(default)]
     pub(super) layout: PaneOrSplitFile,
+    #[serde(default = "defaults::default_tag_separator")]
+    pub(super) format_tag_separator: String,
 }
 
 impl Default for UiConfigFile {
@@ -137,6 +140,7 @@ impl Default for UiConfigFile {
             },
             song_table_format: QueueTableColumnsFile::default(),
             browser_song_format: SongFormatFile::default(),
+            format_tag_separator: " | ".to_owned(),
         }
     }
 }
@@ -195,6 +199,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
             layout: value.layout.convert()?,
             background_color: bg_color,
             draw_borders: value.draw_borders,
+            format_tag_separator: value.format_tag_separator,
             modal_background_color: StringColor(value.modal_background_color)
                 .to_color()?
                 .or(bg_color),

--- a/src/core/event_loop.rs
+++ b/src/core/event_loop.rs
@@ -289,9 +289,9 @@ fn main_task<B: Backend + std::io::Write>(
                                             .clone()
                                             .metadata
                                             .into_iter()
-                                            .map(|(mut k, v)| {
+                                            .map(|(mut k, mut v)| {
                                                 k.make_ascii_uppercase();
-                                                (k, v)
+                                                (k, std::mem::take(v.last_mut()))
                                             })
                                             .collect_vec();
 

--- a/src/mpd/commands/metadata_tag.rs
+++ b/src/mpd/commands/metadata_tag.rs
@@ -1,0 +1,109 @@
+use std::borrow::Cow;
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize, PartialEq, Eq, Clone, Ord, PartialOrd)]
+#[serde(untagged)]
+/// Either a single or multiple tags. Extra care must be taken to never
+/// construct the [`MetadataTag::Multiple`] variant with no items as that would
+/// make [last] and [`last_mut`] panic.
+pub enum MetadataTag {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+impl From<String> for MetadataTag {
+    fn from(value: String) -> Self {
+        MetadataTag::Single(value)
+    }
+}
+
+impl From<Vec<String>> for MetadataTag {
+    fn from(value: Vec<String>) -> Self {
+        MetadataTag::Multiple(value)
+    }
+}
+
+impl From<&str> for MetadataTag {
+    fn from(value: &str) -> Self {
+        MetadataTag::Single(value.to_owned())
+    }
+}
+
+#[allow(unused)]
+pub trait MetadataTagExt<'s> {
+    fn last(&self) -> Option<&str>;
+    fn join(&'s self, separator: &str) -> Option<Cow<'s, str>>;
+}
+
+impl MetadataTag {
+    pub fn last(&self) -> &str {
+        match self {
+            MetadataTag::Single(v) => v.as_str(),
+            MetadataTag::Multiple(items) => items
+                .last()
+                .map(|s| s.as_str())
+                .expect("Multiple tags to contain at least one value"),
+        }
+    }
+
+    pub fn last_mut(&mut self) -> &mut String {
+        match self {
+            MetadataTag::Single(v) => v,
+            MetadataTag::Multiple(items) => {
+                items.last_mut().expect("Multiple tags to contain at least one value")
+            }
+        }
+    }
+
+    pub fn join<'s>(&'s self, separator: &str) -> Cow<'s, str> {
+        match self {
+            MetadataTag::Single(v) => Cow::Borrowed(v),
+            MetadataTag::Multiple(items) => Cow::Owned(items.join(separator)),
+        }
+    }
+
+    pub fn for_each(&self, mut cb: impl FnMut(&str)) {
+        match self {
+            MetadataTag::Single(item) => (cb)(item),
+            MetadataTag::Multiple(items) => {
+                for item in items {
+                    (cb)(item);
+                }
+            }
+        }
+    }
+
+    pub fn iter(&self) -> MetadataTagIterator {
+        MetadataTagIterator { inner: self, current: 0 }
+    }
+}
+
+pub struct MetadataTagIterator<'a> {
+    inner: &'a MetadataTag,
+    current: usize,
+}
+
+impl<'a> Iterator for MetadataTagIterator<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let res = match self.inner {
+            MetadataTag::Single(item) if self.current == 0 => Some(item.as_str()),
+            MetadataTag::Single(_item) => None,
+            MetadataTag::Multiple(items) => items.get(self.current).map(|v| v.as_str()),
+        };
+        self.current += 1;
+        res
+    }
+}
+
+impl<'s> MetadataTagExt<'s> for Option<&'s MetadataTag> {
+    fn last(&self) -> Option<&str> {
+        self.map(|s| s.last())
+    }
+
+    fn join(&'s self, separator: &str) -> Option<Cow<'s, str>> {
+        self.map(|s| s.join(separator))
+    }
+}

--- a/src/mpd/commands/mod.rs
+++ b/src/mpd/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod list_mounts;
 pub mod list_playlist;
 pub mod list_playlists;
 pub mod lsinfo;
+pub mod metadata_tag;
 pub mod mpd_config;
 pub mod outputs;
 pub mod playlist_info;

--- a/src/shared/lrc/index.rs
+++ b/src/shared/lrc/index.rs
@@ -68,9 +68,16 @@ impl LrcIndex {
     }
 
     pub fn find_lrc_for_song(&self, song: &Song) -> Result<Option<Lrc>> {
-        match (song.artist(), song.title(), song.album(), song.duration) {
+        match (
+            song.metadata.get("artist"),
+            song.metadata.get("artist"),
+            song.metadata.get("album"),
+            song.duration,
+        ) {
             (Some(artist), Some(title), Some(album), length) => {
-                self.find_lrc(artist, title, album, length)
+                // TODO xxx.last() is called here to not change existing behavior. Consider
+                // supporting all the tag entries
+                self.find_lrc(artist.last(), title.last(), album.last(), length)
             }
             _ => None,
         }

--- a/src/tests/fixtures/mpd_client.rs
+++ b/src/tests/fixtures/mpd_client.rs
@@ -20,6 +20,7 @@ use crate::mpd::{
         Volume,
         list::MpdList,
         list_playlist::FileList,
+        metadata_tag::MetadataTagExt,
         mpd_config::MpdConfig,
         status::OnOffOneshot,
         stickers::Sticker,
@@ -47,9 +48,9 @@ pub fn client() -> TestMpdClient {
                 id: i,
                 file: format!("{}_{}_file_{i}", *artist, *album),
                 metadata: HashMap::from([
-                    ("artist".to_owned(), (*artist).to_string()),
-                    ("album".to_owned(), (*album).to_string()),
-                    ("title".to_owned(), format!("{}_{}_file_{i}", *artist, *album)),
+                    ("artist".to_owned(), (*artist).into()),
+                    ("album".to_owned(), (*album).into()),
+                    ("title".to_owned(), format!("{}_{}_file_{i}", *artist, *album).into()),
                 ]),
                 duration: Some(Duration::from_secs(i.into())),
                 stickers: None,
@@ -301,13 +302,18 @@ impl MpdClient for TestMpdClient {
             .iter()
             .filter(|s| {
                 let mut matches = true;
+                let albumartist = s.metadata.get("albumartist");
+                let genre = s.metadata.get("genre");
+                let album = s.metadata.get("album");
+                let artist = s.metadata.get("artist");
+                let title = s.metadata.get("title");
                 let values = [
-                    s.artist(),
-                    s.metadata.get("albumartist"),
-                    s.album(),
-                    s.title(),
+                    artist.last(),
+                    albumartist.last(),
+                    album.last(),
+                    title.last(),
                     Some(&s.file),
-                    s.metadata.get("genre"),
+                    genre.last(),
                 ];
 
                 for filter in filter {
@@ -342,13 +348,18 @@ impl MpdClient for TestMpdClient {
             .iter()
             .filter(|s| {
                 let mut matches = true;
+                let albumartist = s.metadata.get("albumartist");
+                let genre = s.metadata.get("genre");
+                let album = s.metadata.get("album");
+                let artist = s.metadata.get("artist");
+                let title = s.metadata.get("title");
                 let values = [
-                    s.artist(),
-                    s.metadata.get("albumartist"),
-                    s.album(),
-                    s.title(),
+                    artist.last(),
+                    albumartist.last(),
+                    album.last(),
+                    title.last(),
                     Some(&s.file),
-                    s.metadata.get("genre"),
+                    genre.last(),
                 ];
 
                 for filter in filter {

--- a/src/ui/dirstack/mod.rs
+++ b/src/ui/dirstack/mod.rs
@@ -71,11 +71,12 @@ impl DirStackItem for DirOrSong {
                 let spans =
                     [marker_span, Span::from(config.theme.symbols.song.clone()), Span::from(" ")]
                         .into_iter()
-                        .chain(
-                            config.theme.browser_song_format.0.iter().map(|prop| {
-                                Span::from(prop.as_string(Some(s)).unwrap_or_default())
-                            }),
-                        );
+                        .chain(config.theme.browser_song_format.0.iter().map(|prop| {
+                            Span::from(
+                                prop.as_string(Some(s), &config.theme.format_tag_separator)
+                                    .unwrap_or_default(),
+                            )
+                        }));
                 Line::from(spans.collect_vec())
             }
         };
@@ -112,8 +113,8 @@ impl DirStackItem for Song {
             Span::from(" ".repeat(config.theme.symbols.marker.chars().count()))
         };
 
-        let title = self.title_str().to_owned();
-        let artist = self.artist_str().to_owned();
+        let title = self.title_str(&config.theme.format_tag_separator).into_owned();
+        let artist = self.artist_str(&config.theme.format_tag_separator).into_owned();
         let separator_span = Span::from(" - ");
         let icon_span = Span::from(format!("{} ", config.theme.symbols.song));
         let mut result =

--- a/src/ui/modals/song_info.rs
+++ b/src/ui/modals/song_info.rs
@@ -103,15 +103,25 @@ impl Modal for SongInfoModal {
                 value_area.width,
             ));
         }
-        if let Some(title) = song.title() {
-            rows.extend(SongInfoModal::row("Title", tag_area.width, title, value_area.width));
+
+        if let Some(title) = song.metadata.get("title") {
+            rows.extend(title.iter().flat_map(|item| {
+                SongInfoModal::row("Title", tag_area.width, item, value_area.width)
+            }));
         }
-        if let Some(artist) = song.artist() {
-            rows.extend(SongInfoModal::row("Artist", tag_area.width, artist, value_area.width));
+
+        if let Some(artist) = song.metadata.get("artist") {
+            rows.extend(artist.iter().flat_map(|item| {
+                SongInfoModal::row("Artist", tag_area.width, item, value_area.width)
+            }));
         }
-        if let Some(album) = song.album() {
-            rows.extend(SongInfoModal::row("Album", tag_area.width, album, value_area.width));
+
+        if let Some(album) = song.metadata.get("album") {
+            rows.extend(album.iter().flat_map(|item| {
+                SongInfoModal::row("Album", tag_area.width, item, value_area.width)
+            }));
         }
+
         let duration = song.duration.as_ref().map(|d| d.as_secs().to_string()).unwrap_or_default();
         if !duration.is_empty() {
             rows.extend(SongInfoModal::row(
@@ -128,7 +138,11 @@ impl Modal for SongInfoModal {
                 .filter(|(key, _)| {
                     !["title", "album", "artist", "duration"].contains(&(*key).as_str())
                 })
-                .flat_map(|(k, v)| SongInfoModal::row(k, tag_area.width, v, value_area.width)),
+                .flat_map(|(k, v)| {
+                    v.iter().flat_map(|item| {
+                        SongInfoModal::row(k, tag_area.width, item, value_area.width)
+                    })
+                }),
         );
 
         self.scrolling_state.set_content_len(Some(rows.len()));

--- a/src/ui/panes/directories.rs
+++ b/src/ui/panes/directories.rs
@@ -274,14 +274,14 @@ impl BrowserPane<DirOrSong> for DirectoriesPane {
             }
             DirOrSong::Song(song) => {
                 let file = song.file.clone();
+                let artist_text =
+                    song.artist_str(&context.config.theme.format_tag_separator).into_owned();
+                let title_text =
+                    song.title_str(&context.config.theme.format_tag_separator).into_owned();
                 context.command(move |client| {
                     client.add(&file)?;
-                    if let Ok(Some(song)) = client.find_one(&[Filter::new(Tag::File, &file)]) {
-                        status_info!(
-                            "'{}' by '{}' added to queue",
-                            song.title_str(),
-                            song.artist_str()
-                        );
+                    if let Ok(Some(_song)) = client.find_one(&[Filter::new(Tag::File, &file)]) {
+                        status_info!("'{}' by '{}' added to queue", title_text, artist_text);
                     }
                     Ok(())
                 });

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -420,14 +420,14 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
             }
             DirOrSong::Song(s) => {
                 let file = s.file.clone();
+                let artist_text =
+                    s.artist_str(&context.config.theme.format_tag_separator).into_owned();
+                let title_text =
+                    s.title_str(&context.config.theme.format_tag_separator).into_owned();
                 context.command(move |client| {
                     client.add(&file)?;
-                    if let Ok(Some(song)) = client.find_one(&[Filter::new(Tag::File, &file)]) {
-                        status_info!(
-                            "'{}' by '{}' added to queue",
-                            song.title_str(),
-                            song.artist_str()
-                        );
+                    if let Ok(Some(_song)) = client.find_one(&[Filter::new(Tag::File, &file)]) {
+                        status_info!("'{}' by '{}' added to queue", title_text, artist_text);
                     }
                     Ok(())
                 });

--- a/src/ui/panes/property.rs
+++ b/src/ui/panes/property.rs
@@ -37,7 +37,7 @@ impl Pane for PropertyPane<'_> {
         let song = context.find_current_song_in_queue().map(|(_, song)| song);
 
         let line = Line::from(self.content.iter().fold(Vec::new(), |mut acc, val| {
-            match val.as_span(song, &context.status) {
+            match val.as_span(song, &context.status, &context.config.theme.format_tag_separator) {
                 Some(Either::Left(span)) => acc.push(span),
                 Some(Either::Right(ref mut spans)) => acc.append(spans),
                 None => {}

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -155,7 +155,12 @@ impl Pane for QueuePane {
                     }
 
                     let mut line = song
-                        .as_line_ellipsized(&formats[i].prop, max_len, &config.theme.symbols)
+                        .as_line_ellipsized(
+                            &formats[i].prop,
+                            max_len,
+                            &config.theme.symbols,
+                            &config.theme.format_tag_separator,
+                        )
                         .unwrap_or_default()
                         .alignment(formats[i].alignment.into());
 

--- a/src/ui/widgets/header.rs
+++ b/src/ui/widgets/header.rs
@@ -7,7 +7,10 @@ use ratatui::{
 };
 
 use crate::{
-    config::theme::properties::{Property, PropertyKind},
+    config::{
+        Config,
+        theme::properties::{Property, PropertyKind},
+    },
     context::AppContext,
     mpd::commands::{Song, Status},
 };
@@ -38,15 +41,18 @@ impl Widget for Header<'_> {
                 return;
             };
             let template = PropertyTemplates(&config.theme.header.rows[row].left);
-            let widget = template.format(song, &self.context.status).left_aligned();
+            let widget =
+                template.format(song, &self.context.status, &self.context.config).left_aligned();
             widget.render(left, buf);
 
             let template = PropertyTemplates(&config.theme.header.rows[row].center);
-            let widget = template.format(song, &self.context.status).centered();
+            let widget =
+                template.format(song, &self.context.status, &self.context.config).centered();
             widget.render(center, buf);
 
             let template = PropertyTemplates(&config.theme.header.rows[row].right);
-            let widget = template.format(song, &self.context.status).right_aligned();
+            let widget =
+                template.format(song, &self.context.status, &self.context.config).right_aligned();
             widget.render(right, buf);
         }
     }
@@ -54,9 +60,9 @@ impl Widget for Header<'_> {
 
 struct PropertyTemplates<'a>(&'a [Property<PropertyKind>]);
 impl<'a> PropertyTemplates<'a> {
-    fn format(&'a self, song: Option<&'a Song>, status: &'a Status) -> Line<'a> {
+    fn format(&'a self, song: Option<&'a Song>, status: &'a Status, config: &Config) -> Line<'a> {
         Line::from(self.0.iter().fold(Vec::new(), |mut acc, val| {
-            match val.as_span(song, status) {
+            match val.as_span(song, status, &config.theme.format_tag_separator) {
                 Some(Either::Left(span)) => acc.push(span),
                 Some(Either::Right(ref mut spans)) => acc.append(spans),
                 None => {}


### PR DESCRIPTION
fixes #303

This adds support for multiple values in a single tag. In the formatters they get joined by the new `format_tag_separator` and in the tag lists (info modal, browsers) they simply get listed multiple times for each value.
