### PR TITLE
[WIP] feat: property template string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "chumsky"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14377e276b2c8300513dff55ba4cc4142b44e5d6de6d00eb5b2307d650bb4ec1"
+dependencies = [
+ "hashbrown 0.15.2",
+ "regex-automata 0.3.9",
+ "serde",
+ "stacker",
+ "unicode-ident",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,6 +1646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,8 +1823,19 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -1812,8 +1846,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -1842,6 +1882,7 @@ dependencies = [
  "bitflags 2.9.0",
  "bon",
  "chrono",
+ "chumsky",
  "clap",
  "clap_complete",
  "clap_mangen",
@@ -2152,6 +2193,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601f9201feb9b09c00266478bf459952b9ef9a6b94edb2f21eba14ab681a60a9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ unicode-width = "0.2.0"
 unicase = "2.8.1"
 serde_path_to_error = "0.1.17"
 serde_json = "1.0.140"
+chumsky = "0.10.1"
 
 [build-dependencies]
 clap = { workspace = true }

--- a/src/config/tabs.rs
+++ b/src/config/tabs.rs
@@ -1,7 +1,8 @@
 #![allow(deprecated)] // TODO remove after cleanup
 use std::collections::HashMap;
 
-use anyhow::{Result, ensure};
+use anyhow::{Result, bail, ensure};
+use chumsky::Parser;
 use derive_more::{Deref, Display, Into};
 use itertools::Itertools;
 use ratatui::{layout::Direction, widgets::Borders};
@@ -9,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use super::theme::{
     PercentOrLength,
+    parser,
     properties::{Property, PropertyFile, PropertyKind, PropertyKindFile},
 };
 use crate::shared::id::{self, Id};
@@ -53,7 +55,10 @@ pub enum PaneTypeFile {
     #[cfg(debug_assertions)]
     FrameCount,
     Property {
-        content: Vec<PropertyFile<PropertyKindFile>>,
+        #[serde(default)]
+        content: Option<Vec<PropertyFile<PropertyKindFile>>>,
+        #[serde(default)]
+        format: Option<String>,
         #[serde(default)]
         align: super::theme::properties::Alignment,
         #[serde(default)]
@@ -128,9 +133,11 @@ impl Pane {
     }
 }
 
-impl From<PaneTypeFile> for PaneType {
-    fn from(value: PaneTypeFile) -> Self {
-        match value {
+impl TryFrom<PaneTypeFile> for PaneType {
+    type Error = anyhow::Error;
+
+    fn try_from(value: PaneTypeFile) -> std::result::Result<PaneType, anyhow::Error> {
+        Ok(match value {
             PaneTypeFile::Queue => PaneType::Queue,
             #[cfg(debug_assertions)]
             PaneTypeFile::Logs => PaneType::Logs,
@@ -148,20 +155,34 @@ impl From<PaneTypeFile> for PaneType {
             PaneTypeFile::TabContent => PaneType::TabContent,
             #[cfg(debug_assertions)]
             PaneTypeFile::FrameCount => PaneType::FrameCount,
-            PaneTypeFile::Property { content: properties, align, scroll_speed } => {
-                PaneType::Property {
-                    content: properties
-                        .into_iter()
-                        .map(|prop| prop.try_into().expect(""))
-                        .collect_vec(),
-                    align: align.into(),
-                    scroll_speed,
-                }
-            }
+            PaneTypeFile::Property { content, align, scroll_speed, format } => PaneType::Property {
+                content: {
+                    match (format, content) {
+                        (Some(format), Some(_)) | (Some(format), None) => parser::parser()
+                            .parse(&format)
+                            .into_result()
+                            .map_err(|e| {
+                                anyhow::anyhow!("Failed to parse property format: {:?}", e)
+                            })?
+                            .into_iter()
+                            .map(|prop| -> Result<_> { prop.try_into() })
+                            .try_collect()?,
+                        (None, Some(content)) => content
+                            .into_iter()
+                            .map(|prop| -> Result<_> { prop.try_into() })
+                            .try_collect()?,
+                        (None, None) => {
+                            bail!("One of config or format has to be specified for a Property pane")
+                        }
+                    }
+                },
+                align: align.into(),
+                scroll_speed,
+            },
             PaneTypeFile::Browser { root_tag: tag, separator } => {
                 PaneType::Browser { root_tag: tag, separator }
             }
-        }
+        })
     }
 }
 
@@ -342,7 +363,7 @@ impl PaneOrSplitFile {
     pub fn convert_recursive(&self, b: Borders) -> Result<SizedPaneOrSplit> {
         Ok(match self {
             PaneOrSplitFile::Pane(pane_type_file) => SizedPaneOrSplit::Pane(Pane {
-                pane: pane_type_file.clone().into(),
+                pane: pane_type_file.clone().try_into()?,
                 borders: b,
                 id: id::new(),
             }),

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -12,6 +12,7 @@ use self::{
 };
 
 mod header;
+pub mod parser;
 mod progress_bar;
 pub mod properties;
 mod queue_table;

--- a/src/config/theme/parser.rs
+++ b/src/config/theme/parser.rs
@@ -1,0 +1,661 @@
+use std::collections::HashMap;
+
+use chumsky::prelude::*;
+
+use super::{
+    StyleFile,
+    properties::{
+        PropertyFile,
+        PropertyKindFile,
+        PropertyKindFileOrText,
+        SongPropertyFile,
+        StatusPropertyFile,
+        WidgetPropertyFile,
+    },
+    style::Modifiers,
+};
+
+pub fn parser<'a>()
+-> impl Parser<'a, &'a str, Vec<PropertyFile<PropertyKindFile>>, extra::Err<Rich<'a, char>>> {
+    let ident = text::ascii::ident();
+
+    let escape_double_quoted_str = just('\\')
+        .then(choice((
+            just('\\'),
+            just('/'),
+            just('"'),
+            just('b').to('\x08'),
+            just('f').to('\x0C'),
+            just('n').to('\n'),
+            just('r').to('\r'),
+            just('t').to('\t'),
+            just('u').ignore_then(text::digits(16).exactly(4).to_slice().validate(
+                |digits, e, emitter| {
+                    char::from_u32(
+                        u32::from_str_radix(digits, 16)
+                            .expect("Only valid digits should have been parsed in text::digits"),
+                    )
+                    .unwrap_or_else(|| {
+                        emitter.emit(Rich::custom(e.span(), "invalid unicode character"));
+                        '\u{FFFD}'
+                    })
+                },
+            )),
+        )))
+        .ignored()
+        .boxed();
+
+    let escape_single_queoted_str =
+        choice((
+            just('\\').then(just('\'')).to('a').ignored(),
+            just('\\')
+                .then(choice((
+                    just('\\'),
+                    just('/'),
+                    just('b').to('\x08'),
+                    just('f').to('\x0C'),
+                    just('n').to('\n'),
+                    just('r').to('\r'),
+                    just('t').to('\t'),
+                    just('u').ignore_then(text::digits(16).exactly(4).to_slice().validate(
+                        |digits, e, emitter| {
+                            char::from_u32(u32::from_str_radix(digits, 16).expect(
+                                "Only valid digits should have been parsed in text::digits",
+                            ))
+                            .unwrap_or_else(|| {
+                                emitter.emit(Rich::custom(e.span(), "invalid unicode character"));
+                                '\u{FFFD}'
+                            })
+                        },
+                    )),
+                )))
+                .ignored(),
+        ))
+        .boxed();
+
+    let double_quoted_string = none_of("\\\"")
+        .ignored()
+        .or(escape_double_quoted_str)
+        .repeated()
+        .to_slice()
+        .map(ToString::to_string)
+        .delimited_by(just('"'), just('"'))
+        .boxed();
+
+    let single_quoted_string = none_of("\\'")
+        .ignored()
+        .or(escape_single_queoted_str)
+        .repeated()
+        .to_slice()
+        .map(ToString::to_string)
+        .delimited_by(just("'"), just("'"))
+        .boxed();
+
+    let string = double_quoted_string.clone().or(single_quoted_string.clone()).labelled("string");
+
+    let modifiers = choice((
+        just("bold"),
+        just("dim"),
+        just("italic"),
+        just("underlined"),
+        just("reversed"),
+        just("crossedout"),
+    ))
+    .separated_by(just(',').padded())
+    .collect::<Vec<_>>()
+    .map(|val| {
+        if val.is_empty() {
+            return None;
+        }
+
+        let mut res = Modifiers::empty();
+        for modifier in val {
+            res = match modifier {
+                "bold" => res.union(Modifiers::Bold),
+                "dim" => res.union(Modifiers::Dim),
+                "italic" => res.union(Modifiers::Italic),
+                "underlined" => res.union(Modifiers::Underlined),
+                "reversed" => res.union(Modifiers::Reversed),
+                "crossedout" => res.union(Modifiers::CrossedOut),
+                _ => res,
+            };
+        }
+
+        Some(res)
+    });
+
+    let color = choice((
+        ident.map(|c: &str| StringOrModifiers::String(c.to_owned())),
+        just('#').then(ident).map(|(_, hex): (_, &str)| {
+            let mut hex = hex.to_owned();
+            hex.insert(0, '#');
+            StringOrModifiers::String(hex)
+        }),
+        text::int(10).map(|n: &str| StringOrModifiers::String(n.to_owned())),
+    ));
+
+    let style_file = choice((
+        just("fg").then_ignore(just(':').padded()).then(color),
+        just("bg").then_ignore(just(':').padded()).then(color),
+        just("mods")
+            .then_ignore(just(':').padded())
+            .then(modifiers.map(StringOrModifiers::Modifiers)),
+    ))
+    .separated_by(just(',').padded())
+    .collect::<HashMap<_, _>>()
+    .map(|mut m| StyleFile {
+        fg: m.remove("fg").get_string(),
+        bg: m.remove("bg").get_string(),
+        modifiers: m.remove("mods").get_modifiers(),
+    })
+    .delimited_by(just('{'), just('}'));
+
+    let label = string.clone().map(|v: String| StyleOrLabel::Label(v));
+    let style = style_file.map(StyleOrLabel::Style);
+
+    let status_property = choice((
+        just("volume").map(|_| PropertyKindFile::Status(StatusPropertyFile::Volume)),
+        just("repeat")
+            .ignored()
+            .then(
+                choice((
+                    just("onStyle").then_ignore(just(':').padded()).then(style),
+                    just("offStyle").then_ignore(just(':').padded()).then(style),
+                    just("onLabel").then_ignore(just(':').padded()).then(label.clone()),
+                    just("offLabel").then_ignore(just(':').padded()).then(label.clone()),
+                ))
+                .separated_by(just(',').padded())
+                .collect::<HashMap<_, _>>()
+                .delimited_by(just('('), just(')')),
+            )
+            .map(|((), mut val)| {
+                PropertyKindFile::Status(StatusPropertyFile::RepeatV2 {
+                    on_label: val.remove("onLabel").get_label("On"),
+                    off_label: val.remove("offLabel").get_label("Off"),
+                    on_style: val.remove("onStyle").get_style(),
+                    off_style: val.remove("offStyle").get_style(),
+                })
+            }),
+        just("random")
+            .ignored()
+            .then(
+                choice((
+                    just("onStyle").then_ignore(just(':').padded()).then(style),
+                    just("offStyle").then_ignore(just(':').padded()).then(style),
+                    just("onLabel").then_ignore(just(':').padded()).then(label.clone()),
+                    just("offLabel").then_ignore(just(':').padded()).then(label.clone()),
+                ))
+                .separated_by(just(',').padded())
+                .collect::<HashMap<_, _>>()
+                .delimited_by(just('('), just(')')),
+            )
+            .map(|((), mut val)| {
+                PropertyKindFile::Status(StatusPropertyFile::RandomV2 {
+                    on_label: val.remove("onLabel").get_label("On"),
+                    off_label: val.remove("offLabel").get_label("Off"),
+                    on_style: val.remove("onStyle").get_style(),
+                    off_style: val.remove("offStyle").get_style(),
+                })
+            }),
+        just("single")
+            .ignored()
+            .then(
+                choice((
+                    just("onStyle").then_ignore(just(':').padded()).then(style),
+                    just("offStyle").then_ignore(just(':').padded()).then(style),
+                    just("oneshotStyle").then_ignore(just(':').padded()).then(style),
+                    just("onLabel").then_ignore(just(':').padded()).then(label.clone()),
+                    just("offLabel").then_ignore(just(':').padded()).then(label.clone()),
+                    just("oneshotLabel").then_ignore(just(':').padded()).then(label.clone()),
+                ))
+                .separated_by(just(',').padded())
+                .collect::<HashMap<_, _>>()
+                .delimited_by(just('('), just(')')),
+            )
+            .map(|((), mut val)| {
+                PropertyKindFile::Status(StatusPropertyFile::SingleV2 {
+                    on_label: val.remove("onLabel").get_label("On"),
+                    off_label: val.remove("offLabel").get_label("Off"),
+                    oneshot_label: val.remove("oneshotLabel").get_label("Oneshot"),
+                    on_style: val.remove("onStyle").get_style(),
+                    off_style: val.remove("offStyle").get_style(),
+                    oneshot_style: val.remove("oneshotStyle").get_style(),
+                })
+            }),
+        just("consume")
+            .ignored()
+            .then(
+                choice((
+                    just("onStyle").then_ignore(just(':').padded()).then(style),
+                    just("offStyle").then_ignore(just(':').padded()).then(style),
+                    just("oneshotStyle").then_ignore(just(':').padded()).then(style),
+                    just("onLabel").then_ignore(just(':').padded()).then(label.clone()),
+                    just("offLabel").then_ignore(just(':').padded()).then(label.clone()),
+                    just("oneshotLabel").then_ignore(just(':').padded()).then(label.clone()),
+                ))
+                .separated_by(just(',').padded())
+                .collect::<HashMap<_, _>>()
+                .delimited_by(just('('), just(')')),
+            )
+            .map(|((), mut val)| {
+                PropertyKindFile::Status(StatusPropertyFile::ConsumeV2 {
+                    on_label: val.remove("onLabel").get_label("On"),
+                    off_label: val.remove("offLabel").get_label("Off"),
+                    oneshot_label: val.remove("oneshotLabel").get_label("Oneshot"),
+                    on_style: val.remove("onStyle").get_style(),
+                    off_style: val.remove("offStyle").get_style(),
+                    oneshot_style: val.remove("oneshotStyle").get_style(),
+                })
+            }),
+        just("state")
+            .ignored()
+            .then(
+                choice((
+                    just("playingStyle").then_ignore(just(':').padded()).then(style),
+                    just("pausedStyle").then_ignore(just(':').padded()).then(style),
+                    just("stoppedStyle").then_ignore(just(':').padded()).then(style),
+                    just("playingLabel").then_ignore(just(':').padded()).then(label.clone()),
+                    just("pausedLabel").then_ignore(just(':').padded()).then(label.clone()),
+                    just("stoppedLabel").then_ignore(just(':').padded()).then(label.clone()),
+                ))
+                .separated_by(just(',').padded())
+                .collect::<HashMap<_, _>>()
+                .delimited_by(just('('), just(')')),
+            )
+            .map(|((), mut val)| {
+                PropertyKindFile::Status(StatusPropertyFile::StateV2 {
+                    playing_label: val.remove("playingLabel").get_label("Playing"),
+                    paused_label: val.remove("pausedLabel").get_label("Paused"),
+                    stopped_label: val.remove("stoppedLabel").get_label("Stopped"),
+                    playing_style: val.remove("playingStyle").get_style(),
+                    paused_style: val.remove("pausedStyle").get_style(),
+                    stopped_style: val.remove("stoppedStyle").get_style(),
+                })
+            }),
+        just("elapsed").map(|_| PropertyKindFile::Status(StatusPropertyFile::Elapsed)),
+        just("duration").map(|_| PropertyKindFile::Status(StatusPropertyFile::Duration)),
+        just("crossfade").map(|_| PropertyKindFile::Status(StatusPropertyFile::Crossfade)),
+        just("bitrate").map(|_| PropertyKindFile::Status(StatusPropertyFile::Bitrate)),
+    ))
+    .boxed();
+
+    let song_property = choice((
+        just("filename").map(|_| PropertyKindFile::Song(SongPropertyFile::Filename)),
+        just("file").map(|_| PropertyKindFile::Song(SongPropertyFile::File)),
+        just("fileextension").map(|_| PropertyKindFile::Song(SongPropertyFile::FileExtension)),
+        just("title").map(|_| PropertyKindFile::Song(SongPropertyFile::Title)),
+        just("artist").map(|_| PropertyKindFile::Song(SongPropertyFile::Artist)),
+        just("album").map(|_| PropertyKindFile::Song(SongPropertyFile::Album)),
+        just("track").map(|_| PropertyKindFile::Song(SongPropertyFile::Track)),
+        just("disc").map(|_| PropertyKindFile::Song(SongPropertyFile::Disc)),
+        just("tag")
+            .ignored()
+            .then(
+                just("value")
+                    .ignored()
+                    .then_ignore(just(':').padded())
+                    .then(ident.delimited_by(just("\""), just("\"")))
+                    .delimited_by(just('('), just(')')),
+            )
+            .map(|((), ((), v)): (_, (_, &str))| {
+                PropertyKindFile::Song(SongPropertyFile::Other(v.to_owned()))
+            }),
+        // just("duration").map(|_| PropertyKind::Song(SongProperty::Duration)),
+    ))
+    .boxed();
+
+    let widget_property = choice((
+        just("volume").map(|_| PropertyKindFile::Widget(WidgetPropertyFile::Volume)),
+        just("states")
+            .ignored()
+            .then(
+                choice((
+                    just("activeStyle").then_ignore(just(':').padded()).then(style),
+                    just("separatorStyle").then_ignore(just(':').padded()).then(style),
+                ))
+                .separated_by(just(',').padded())
+                .collect::<HashMap<_, _>>()
+                .delimited_by(just('('), just(')')),
+            )
+            .map(|((), mut val)| {
+                PropertyKindFile::Widget(WidgetPropertyFile::States {
+                    active_style: val.remove("activeStyle").get_style(),
+                    separator_style: val.remove("separatorStyle").get_style(),
+                })
+            }),
+    ))
+    .boxed();
+
+    let property =
+        choice((status_property, song_property, widget_property)).labelled("property").boxed();
+
+    let sticker = just("sticker")
+        .ignored()
+        .then(
+            just("name")
+                .ignored()
+                .then_ignore(just(':').padded())
+                .then(double_quoted_string.clone())
+                .delimited_by(just('('), just(')')),
+        )
+        .labelled("sticker");
+
+    recursive(|prop| {
+        let group = prop
+            .clone()
+            .padded()
+            .repeated()
+            .at_least(1)
+            .collect::<Vec<_>>()
+            .delimited_by(just('[').padded(), just(']').padded())
+            .labelled("group");
+
+        let prop_kind_or_text = choice((
+            string.map(PropertyKindFileOrText::<PropertyKindFile>::Text),
+            property.clone().map(PropertyKindFileOrText::Property),
+            sticker.map(|((), ((), name)): (_, (_, String))| {
+                PropertyKindFileOrText::<PropertyKindFile>::Sticker(name)
+            }),
+            group.map(PropertyKindFileOrText::Group),
+        ));
+
+        just('$')
+            .ignored()
+            .then(prop_kind_or_text)
+            .then(style_file.or_not())
+            .then(just('|').ignored().then(prop).or_not())
+            .map(
+                |((((), kind), style), default): (
+                    (((), PropertyKindFileOrText<PropertyKindFile>), Option<StyleFile>),
+                    Option<(_, PropertyFile<PropertyKindFile>)>,
+                )| {
+                    PropertyFile { kind, style, default: default.map(|((), def)| Box::new(def)) }
+                },
+            )
+    })
+    .padded()
+    .repeated()
+    .collect::<Vec<_>>()
+    .boxed()
+}
+
+#[derive(Debug)]
+enum StyleOrLabel {
+    Style(StyleFile),
+    Label(String),
+}
+
+trait StyleOrLabelExt {
+    fn get_label(self, default: impl Into<String>) -> String;
+    fn get_style(self) -> Option<StyleFile>;
+}
+
+impl StyleOrLabelExt for Option<StyleOrLabel> {
+    fn get_label(self, default: impl Into<String>) -> String {
+        if let Some(StyleOrLabel::Label(val)) = self { val } else { default.into() }
+    }
+
+    fn get_style(self) -> Option<StyleFile> {
+        if let Some(StyleOrLabel::Style(val)) = self { Some(val) } else { None }
+    }
+}
+
+#[derive(Debug)]
+enum StringOrModifiers {
+    String(String),
+    Modifiers(Option<Modifiers>),
+}
+
+trait StringOrModifiersExt {
+    fn get_string(self) -> Option<String>;
+    fn get_modifiers(self) -> Option<Modifiers>;
+}
+
+impl StringOrModifiersExt for Option<StringOrModifiers> {
+    fn get_string(self) -> Option<String> {
+        if let Some(StringOrModifiers::String(val)) = self { Some(val) } else { None }
+    }
+
+    fn get_modifiers(self) -> Option<Modifiers> {
+        if let Some(StringOrModifiers::Modifiers(val)) = self { val } else { None }
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+#[cfg(test)]
+mod parser2 {
+    use chumsky::Parser;
+
+    use super::*;
+
+    #[test]
+    fn group() {
+        let result = parser().parse(
+            r#"$[ $filename{fg: black, bg: red, mods: bold} $" - " $file ]{fg: blue, bg: yellow, mods: crossedout}"#,
+        );
+
+        assert_eq!(
+            PropertyFile {
+                kind: PropertyKindFileOrText::Group(vec![
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Property(PropertyKindFile::Song(
+                            SongPropertyFile::Filename
+                        )),
+                        style: Some(StyleFile {
+                            fg: Some("black".to_owned()),
+                            bg: Some("red".to_owned()),
+                            modifiers: Some(Modifiers::Bold),
+                        }),
+                        default: None,
+                    },
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Text(" - ".to_owned()),
+                        style: None,
+                        default: None,
+                    },
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Property(PropertyKindFile::Song(
+                            SongPropertyFile::File
+                        )),
+                        style: None,
+                        default: None,
+                    }
+                ]),
+                style: Some(StyleFile {
+                    fg: Some("blue".to_owned()),
+                    bg: Some("yellow".to_owned()),
+                    modifiers: Some(Modifiers::CrossedOut),
+                }),
+                default: None
+            },
+            result.unwrap().pop().unwrap()
+        );
+    }
+
+    #[test]
+    fn filename_with_style_and_default() {
+        let result = parser().parse(
+            "$filename{fg: black, bg: red, mods: bold}|$file{fg: black, bg: red, mods: bold}|$bitrate{fg: #FF0000, bg: 1, mods: underlined}",
+        );
+
+        assert_eq!(
+            PropertyFile {
+                kind: PropertyKindFileOrText::Property(PropertyKindFile::Song(
+                    SongPropertyFile::Filename
+                )),
+                style: Some(StyleFile {
+                    fg: Some("black".to_owned()),
+                    bg: Some("red".to_owned()),
+                    modifiers: Some(Modifiers::Bold),
+                }),
+                default: Some(Box::new(PropertyFile {
+                    kind: PropertyKindFileOrText::Property(PropertyKindFile::Song(
+                        SongPropertyFile::File
+                    )),
+                    style: Some(StyleFile {
+                        fg: Some("black".to_owned()),
+                        bg: Some("red".to_owned()),
+                        modifiers: Some(Modifiers::Bold),
+                    }),
+                    default: Some(Box::new(PropertyFile {
+                        kind: PropertyKindFileOrText::Property(PropertyKindFile::Status(
+                            StatusPropertyFile::Bitrate
+                        )),
+                        style: Some(StyleFile {
+                            fg: Some("#FF0000".to_owned()),
+                            bg: Some("1".to_owned()),
+                            modifiers: Some(Modifiers::Underlined),
+                        }),
+                        default: None,
+                    }))
+                })),
+            },
+            result.unwrap().pop().unwrap()
+        );
+    }
+
+    #[test]
+    fn sticker_with_style() {
+        let result = parser().parse(r#"$sticker(name: "artist"){fg: black, bg: red, mods: bold}"#);
+
+        assert_eq!(
+            PropertyFile {
+                kind: PropertyKindFileOrText::Sticker("artist".to_owned()),
+                style: Some(StyleFile {
+                    fg: Some("black".to_owned()),
+                    bg: Some("red".to_owned()),
+                    modifiers: Some(Modifiers::Bold),
+                }),
+                default: None,
+            },
+            result.unwrap().pop().unwrap()
+        );
+    }
+
+    #[test]
+    fn filename_with_style() {
+        let result = parser().parse("$filename{fg: black, bg: red, mods: bold}");
+
+        assert_eq!(
+            PropertyFile {
+                kind: PropertyKindFileOrText::Property(PropertyKindFile::Song(
+                    SongPropertyFile::Filename
+                )),
+                style: Some(StyleFile {
+                    fg: Some("black".to_owned()),
+                    bg: Some("red".to_owned()),
+                    modifiers: Some(Modifiers::Bold),
+                }),
+                default: None,
+            },
+            result.unwrap().pop().unwrap()
+        );
+    }
+
+    #[test]
+    fn other_with_tag() {
+        let result = parser().parse(r#"$tag(value: "artist")"#);
+
+        assert_eq!(
+            PropertyFile {
+                kind: PropertyKindFileOrText::Property(PropertyKindFile::Song(
+                    SongPropertyFile::Other("artist".to_owned())
+                )),
+                style: None,
+                default: None,
+            },
+            result.unwrap().pop().unwrap()
+        );
+    }
+
+    #[test]
+    fn filename_simple() {
+        let result = parser().parse("$filename");
+
+        assert_eq!(
+            PropertyFile {
+                kind: PropertyKindFileOrText::Property(PropertyKindFile::Song(
+                    SongPropertyFile::Filename
+                )),
+                style: None,
+                default: None,
+            },
+            result.unwrap().pop().unwrap()
+        );
+    }
+
+    #[test]
+    fn consume() {
+        let result = parser().parse(
+            r#"$consume(onLabel: "test", offLabel: "im off boi",offStyle: {fg: black, bg: red, mods: bold})"#,
+        );
+
+        assert_eq!(
+            PropertyFile {
+                kind: PropertyKindFileOrText::Property(PropertyKindFile::Status(
+                    StatusPropertyFile::ConsumeV2 {
+                        on_label: "test".to_owned(),
+                        off_label: "im off boi".to_owned(),
+                        oneshot_label: "Oneshot".to_owned(),
+                        on_style: None,
+                        off_style: Some(StyleFile {
+                            fg: Some("black".to_owned()),
+                            bg: Some("red".to_owned()),
+                            modifiers: Some(Modifiers::Bold),
+                        }),
+                        oneshot_style: None
+                    }
+                )),
+                style: None,
+                default: None,
+            },
+            result.unwrap().pop().unwrap()
+        );
+    }
+
+    #[test]
+    fn string_with_special_chars() {
+        let result = parser().parse(r#"$consume(onLabel: "test \" test ' test $#    ")"#);
+
+        assert_eq!(
+            PropertyFile {
+                kind: PropertyKindFileOrText::Property(PropertyKindFile::Status(
+                    StatusPropertyFile::ConsumeV2 {
+                        on_label: r#"test \" test ' test $#    "#.to_owned(),
+                        off_label: "Off".to_owned(),
+                        oneshot_label: "Oneshot".to_owned(),
+                        on_style: None,
+                        off_style: None,
+                        oneshot_style: None
+                    }
+                )),
+                style: None,
+                default: None,
+            },
+            result.unwrap().pop().unwrap()
+        );
+    }
+
+    #[test]
+    fn single_quoted_string_with_special_chars() {
+        let result = parser().parse(r#"$consume(onLabel: 'test " test \' test $#    ')"#);
+
+        assert_eq!(
+            PropertyFile {
+                kind: PropertyKindFileOrText::Property(PropertyKindFile::Status(
+                    StatusPropertyFile::ConsumeV2 {
+                        on_label: r#"test " test \' test $#    "#.to_owned(),
+                        off_label: "Off".to_owned(),
+                        oneshot_label: "Oneshot".to_owned(),
+                        on_style: None,
+                        off_style: None,
+                        oneshot_style: None
+                    }
+                )),
+                style: None,
+                default: None,
+            },
+            result.unwrap().pop().unwrap()
+        );
+    }
+}


### PR DESCRIPTION
This is a working implementation of templating as discussed here https://github.com/mierak/rmpc/issues/263. I am mostly looking at opinions/suggestions at this point. Tagging you because you have shown interest in this @roxwize.

Currently it works only for `Property` panes in the layout and you have to provide `format` instead of `content`.

It allows to transform for example this: 
```ron
(
    size: "23",
    pane: Pane(Property(
        content: [
            (kind: Property(Status(Elapsed))), 
            (kind: Text(" / ")), 
            (kind: Property(Status(Duration))), 
            (kind: Group([
                (kind: Text(" (")), 
                (kind: Property(Status(Bitrate))), 
                (kind: Text(" kbps)")),
            ])),
        ], 
        align: Left,
    )),
),
```

into this:
```ron
(
    size: "23",
    pane: Pane(Property(
        format: "$elapsed$' / '$duration$[$' ('$bitrate$' kpbs)']",
        align: Left,
    )),
),
```

These definitions are equivalent.

Groups are 

Some syntax remarks:
* `Group` kind are specified as a dollar sign and square brackets`$[ ... ]`
* `Text` kind is a dollar sign and either single or double quotes: `$'this is raw text'`, `$"also raw text"`, `$"escaping \"works too\""`
* `Sticker` is currently `$sticker(name: "playCount")`'
* other properties are similar: `$consume(onLabel: "on", offLabel: "off")`
* `default`(fallback value) is delimited by `|`: `$title|$'No song'`
* styles are in square braces following a property: `$title{fg: yellow, bg: black, mods: bold}|$'No song'{fg: red, bg: black}`

You can see some tests in parser.rs to see more examples.