### PR TITLE
feat(lyrics): Implement word wrapping for lyrics pane.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ lists they are listed as multiple entries.
 - `Filename` property no longer includes file extension, use `FileExtension` if you want to keep it
 - Migrate to Rust 2024 and raise MSRV to 1.85
 - refactor `DirOrSong` to a separate file
+- Lyrics will be wrapped if it is longer than the pane width
 
 ### Fixed
 

--- a/src/ui/panes/lyrics.rs
+++ b/src/ui/panes/lyrics.rs
@@ -43,13 +43,19 @@ impl Pane for LyricsPane {
         let areas = Layout::vertical((0..rows).map(|_| Constraint::Length(1))).split(area);
         let middle_row = rows / 2;
 
-        let mut current_area_cursor = middle_row;
-        let current_line_wrapped =
-            textwrap::wrap(&lrc.lines[current_line_idx].content, area.width as usize);
-        for l in current_line_wrapped {
-            let p = Text::from(l).centered().style(context.config.theme.highlighted_item_style);
-            frame.render_widget(p, areas[current_area_cursor as usize]);
-            current_area_cursor += 1;
+        let middle_style = if first_line_reached {
+            context.config.theme.highlighted_item_style
+        } else {
+            Style::default().fg(context.config.theme.text_color.unwrap_or_default())
+        };
+
+        let mut current_area = middle_row as usize;
+        for line in textwrap::wrap(&lrc.lines[current_line_idx].content, area.width as usize) {
+            frame.render_widget(
+                Text::from(line).centered().style(middle_style),
+                areas[current_area],
+            );
+            current_area += 1;
         }
 
         let mut before_lyrics_cursor = current_line_idx;
@@ -67,12 +73,15 @@ impl Pane for LyricsPane {
                 if before_area_cursor == 0 {
                     break;
                 }
+                let Some(area) = areas.get(before_area_cursor - 1) else {
+                    break;
+                };
+                frame.render_widget(p, *area);
                 before_area_cursor -= 1;
-                frame.render_widget(p, areas[before_area_cursor]);
             }
         }
         let mut after_lyrics_cursor = current_line_idx;
-        let mut after_area_cursor = (current_area_cursor - 1) as usize;
+        let mut after_area_cursor = current_area - 1;
 
         while after_lyrics_cursor < lrc.lines.len() - 1 && after_area_cursor < areas.len() - 1 {
             after_lyrics_cursor += 1;
@@ -84,63 +93,13 @@ impl Pane for LyricsPane {
                 let p = Text::from(l).centered().style(
                     Style::default().fg(context.config.theme.text_color.unwrap_or_default()),
                 );
-                after_area_cursor += 1;
-                if after_area_cursor >= areas.len() {
+                let Some(area) = areas.get(after_area_cursor + 1) else {
                     break;
-                }
-                frame.render_widget(p, areas[after_area_cursor]);
+                };
+                frame.render_widget(p, *area);
+                after_area_cursor += 1;
             }
         }
-
-        // let cum_prev_line_wrap_count = if current_line_idx > 0 {
-        //     lrc.lines[..current_line_idx]
-        //         .iter()
-        //         .map(|line| textwrap::wrap(&line.content, area.width as usize).len()
-        // - 1)         .sum::<usize>()
-        // } else {
-        //     0
-        // };
-        //
-        // while area_idx < (rows as usize) {
-        //     if (current_line_idx + area_idx + cum_prev_line_wrap_count)
-        //         .checked_sub(middle_row as usize)
-        //         .is_none()
-        //     {
-        //         area_idx += 1;
-        //         continue;
-        //     }
-        //
-        //     let Some(idx) = (current_line_idx +
-        // lyrics_fetch_idx).checked_sub(middle_row as usize)     else {
-        //         lyrics_fetch_idx += 1;
-        //         continue;
-        //     };
-        //
-        //     let Some(line) = lrc.lines.get(idx) else {
-        //         lyrics_fetch_idx += 1;
-        //         continue;
-        //     };
-        //
-        //     let wrapped_line = textwrap::wrap(&line.content, area.width as usize);
-        //
-        //     let darken = (middle_row as usize).abs_diff(area_idx) > 0 ||
-        // !first_line_reached;
-        //
-        //     for l in wrapped_line {
-        //         let p = Text::from(l).centered().style(if darken {
-        //
-        // Style::default().fg(context.config.theme.text_color.unwrap_or_default())
-        //         } else {
-        //             context.config.theme.highlighted_item_style
-        //         });
-        //         frame.render_widget(p, areas[area_idx]);
-        //         area_idx += 1;
-        //         if area_idx >= (rows as usize) {
-        //             break;
-        //         }
-        //     }
-        //     lyrics_fetch_idx += 1;
-        // }
 
         // Try to schedule the next line to be displayed on time
         if self.last_requested_line_idx != current_line_idx + 1 {

--- a/src/ui/panes/lyrics.rs
+++ b/src/ui/panes/lyrics.rs
@@ -50,7 +50,10 @@ impl Pane for LyricsPane {
         };
 
         let mut current_area = middle_row as usize;
-        for line in textwrap::wrap(&lrc.lines[current_line_idx].content, area.width as usize) {
+        let Some(current_line) = lrc.lines.get(current_line_idx) else {
+            return Ok(());
+        };
+        for line in textwrap::wrap(&current_line.content, area.width as usize) {
             let Some(area) = areas.get(current_area) else {
                 break;
             };
@@ -65,8 +68,7 @@ impl Pane for LyricsPane {
             let Some(line) = lrc.lines.get(before_lyrics_cursor) else {
                 break;
             };
-            let wrapped_line = textwrap::wrap(&line.content, area.width as usize);
-            for l in wrapped_line.iter().rev() {
+            for l in textwrap::wrap(&line.content, area.width as usize).iter().rev() {
                 let p = Text::from(l.clone()).centered().style(
                     Style::default().fg(context.config.theme.text_color.unwrap_or_default()),
                 );
@@ -91,8 +93,7 @@ impl Pane for LyricsPane {
             let Some(line) = lrc.lines.get(after_lyrics_cursor) else {
                 break;
             };
-            let wrapped_line = textwrap::wrap(&line.content, area.width as usize);
-            for l in wrapped_line {
+            for l in textwrap::wrap(&line.content, area.width as usize) {
                 let p = Text::from(l).centered().style(
                     Style::default().fg(context.config.theme.text_color.unwrap_or_default()),
                 );

--- a/src/ui/panes/lyrics.rs
+++ b/src/ui/panes/lyrics.rs
@@ -54,10 +54,7 @@ impl Pane for LyricsPane {
             let Some(area) = areas.get(current_area) else {
                 break;
             };
-            frame.render_widget(
-                Text::from(line).centered().style(middle_style),
-                *area,
-            );
+            frame.render_widget(Text::from(line).centered().style(middle_style), *area);
             current_area += 1;
         }
 
@@ -84,9 +81,12 @@ impl Pane for LyricsPane {
             }
         }
         let mut after_lyrics_cursor = current_line_idx;
-        let mut after_area_cursor = current_area - 1;
+        let mut after_area_cursor = current_area.saturating_sub(1);
 
-        while after_lyrics_cursor < lrc.lines.len() - 1 && after_area_cursor < areas.len() - 1 {
+        while !areas.is_empty()
+            && after_lyrics_cursor < lrc.lines.len() - 1
+            && after_area_cursor < areas.len() - 1
+        {
             after_lyrics_cursor += 1;
             let Some(line) = lrc.lines.get(after_lyrics_cursor) else {
                 break;

--- a/src/ui/panes/lyrics.rs
+++ b/src/ui/panes/lyrics.rs
@@ -51,9 +51,12 @@ impl Pane for LyricsPane {
 
         let mut current_area = middle_row as usize;
         for line in textwrap::wrap(&lrc.lines[current_line_idx].content, area.width as usize) {
+            let Some(area) = areas.get(current_area) else {
+                break;
+            };
             frame.render_widget(
                 Text::from(line).centered().style(middle_style),
-                areas[current_area],
+                *area,
             );
             current_area += 1;
         }


### PR DESCRIPTION
When displaying long lyrics line, current implementation will truncate the line if it‘s longer than the pane width. (as shown below).
![image](https://github.com/user-attachments/assets/cd488caf-c8cb-46b1-8b08-eced71242205)

With this PR, the long lyrics line will be wrapped.
![image](https://github.com/user-attachments/assets/ae54b20d-4b78-4432-9477-16f47cfa0b60)
