### PR TITLE
feat: Add Insert and InsertAll commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ lists they are listed as multiple entries.
 - introduced `preview_label_style` and `preview_metadata_group_style` in theme config
 - added support for soundcloud to `addyt`
 - added `AddReplace` and `AddAllReplace` actions which work smimilarly to `Add` and `AddAll` but replace the current queue instead of appending
+- added `Insert` and `InsertAll` actions which work similarly to `Add` and `AddAll` but insert after the playing song
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ strum = { workspace = true }
 clap_complete = "4.5.45"
 clap_mangen = "0.2.26"
 vergen-gitcl = { version = "1.0.5", features = ["build"] }
+anyhow = "1.0.95"
 
 [dev-dependencies]
 rstest = "0.24.0"

--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,15 @@ use clap_complete::{
 use clap_mangen::Man;
 use vergen_gitcl::{Emitter, GitclBuilder};
 
+// Mock mpd::QueuePosition for cli.rs to be able to import it. Also see header
+// comment in cli.rs.
+#[path = "src/mpd/queue_position.rs"]
+mod queue_position;
+
+mod mpd {
+    pub use super::queue_position::QueuePosition;
+}
+
 static NAME: &str = "rmpc";
 
 fn generate_man_pages(cmd: ClapCommand) -> Result<(), Box<dyn Error>> {

--- a/docs/src/content/docs/next/configuration/keybinds.mdx
+++ b/docs/src/content/docs/next/configuration/keybinds.mdx
@@ -129,6 +129,8 @@ list and controlling search mode.
 |       `A`       | AddAll          | Add all items to queue                                                                                                             |
 |                 | AddReplace      | Replace current queue with the item                                                                                                |
 |                 | AddAllReplace   | Replace current queue with all items                                                                                               |
+|                 | Insert          | Insert item after current (playing) item                                                                                           |
+|                 | InsertAll       | Insert all items after current (playing) item                                                                                      |
 
 ### Queue
 

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -36,6 +36,8 @@ pub enum Command {
     AddRandom {
         tag: AddRandom,
         count: usize,
+        #[arg(short, long, default_value = "false")]
+        insert: bool,
     },
     /// Prints the default config. Can be used to bootstrap your config file.
     Config {
@@ -143,10 +145,14 @@ pub enum Command {
         /// this behaviour and rmpc will try to add all the files
         #[arg(long = "skip-ext-check", default_value = "false")]
         skip_ext_check: bool,
+        #[arg(short, long, default_value = "false")]
+        insert: bool,
     },
     /// Add a song from youtube to the current queue.
     AddYt {
         url: String,
+        #[arg(short, long, default_value = "false")]
+        insert: bool,
     },
     /// List MPD outputs
     Outputs,

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -1,7 +1,13 @@
+// NOTE: This file is also included from build.rs. crate:: may mean any of
+// build.rs or main.rs, so remember to replicate the crate imports in build.rs,
+// by using the `#[path = ""]` attribute for `mod`.
+
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueEnum, ValueHint};
 use strum::IntoStaticStr;
+
+use crate::mpd::QueuePosition;
 
 #[derive(Parser, Debug)]
 pub struct Args {
@@ -36,8 +42,6 @@ pub enum Command {
     AddRandom {
         tag: AddRandom,
         count: usize,
-        #[arg(short, long, default_value = "false")]
-        insert: bool,
     },
     /// Prints the default config. Can be used to bootstrap your config file.
     Config {
@@ -145,14 +149,18 @@ pub enum Command {
         /// this behaviour and rmpc will try to add all the files
         #[arg(long = "skip-ext-check", default_value = "false")]
         skip_ext_check: bool,
-        #[arg(short, long, default_value = "false")]
-        insert: bool,
+        /// If provided, queue the new item at this position. Possible positions
+        /// are <number> absolute +<number> and -<number> for relative positions
+        #[arg(short, long)]
+        position: Option<QueuePosition>,
     },
     /// Add a song from youtube to the current queue.
     AddYt {
         url: String,
-        #[arg(short, long, default_value = "false")]
-        insert: bool,
+        /// If provided, queue the new item at this position. Possible positions
+        /// are <number> absolute +<number> and -<number> for relative positions
+        #[arg(short, long)]
+        position: Option<QueuePosition>,
     },
     /// List MPD outputs
     Outputs,

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -151,7 +151,7 @@ pub enum Command {
         skip_ext_check: bool,
         /// If provided, queue the new item at this position. Possible positions
         /// are <number> absolute +<number> and -<number> for relative positions
-        #[arg(short, long)]
+        #[arg(short, long, allow_negative_numbers = true)]
         position: Option<QueuePosition>,
     },
     /// Add a song from youtube to the current queue.
@@ -159,7 +159,7 @@ pub enum Command {
         url: String,
         /// If provided, queue the new item at this position. Possible positions
         /// are <number> absolute +<number> and -<number> for relative positions
-        #[arg(short, long)]
+        #[arg(short, long, allow_negative_numbers = true)]
         position: Option<QueuePosition>,
     },
     /// List MPD outputs

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -149,16 +149,18 @@ pub enum Command {
         /// this behaviour and rmpc will try to add all the files
         #[arg(long = "skip-ext-check", default_value = "false")]
         skip_ext_check: bool,
-        /// If provided, queue the new item at this position. Possible positions
-        /// are <number> absolute +<number> and -<number> for relative positions
+        /// If provided, queue the new item at this position instead of the end
+        /// of the queue. Allowed positions are <number> (absolute) and
+        /// +<number> or -<number> (relative)
         #[arg(short, long, allow_negative_numbers = true)]
         position: Option<QueuePosition>,
     },
     /// Add a song from youtube to the current queue.
     AddYt {
         url: String,
-        /// If provided, queue the new item at this position. Possible positions
-        /// are <number> absolute +<number> and -<number> for relative positions
+        /// If provided, queue the new item at this position instead of the end
+        /// of the queue. Allowed positions are <number> (absolute) and
+        /// +<number> or -<number> (relative)
         #[arg(short, long, allow_negative_numbers = true)]
         position: Option<QueuePosition>,
     },

--- a/src/config/keys/actions.rs
+++ b/src/config/keys/actions.rs
@@ -353,6 +353,8 @@ pub enum CommonActionFile {
     AddAll,
     AddReplace,
     AddAllReplace,
+    Insert,
+    InsertAll,
 }
 
 #[derive(Debug, Display, PartialEq, Eq, Hash, Clone, Copy)]
@@ -387,6 +389,8 @@ pub enum CommonAction {
     AddAll,
     AddReplace,
     AddAllReplace,
+    Insert,
+    InsertAll,
 }
 
 impl ToDescription for CommonAction {
@@ -432,6 +436,8 @@ impl ToDescription for CommonAction {
             CommonAction::AddAll => "Add all items to queue",
             CommonAction::AddReplace => "Replace current queue with the item",
             CommonAction::AddAllReplace => "Replace current queue with all items",
+            CommonAction::Insert => "Add item after current song",
+            CommonAction::InsertAll => "Add all items after current song",
         }.into()
     }
 }
@@ -469,6 +475,8 @@ impl From<CommonActionFile> for CommonAction {
             CommonActionFile::PaneRight => CommonAction::PaneRight,
             CommonActionFile::AddReplace => CommonAction::AddReplace,
             CommonActionFile::AddAllReplace => CommonAction::AddAllReplace,
+            CommonActionFile::Insert => CommonAction::Insert,
+            CommonActionFile::InsertAll => CommonAction::InsertAll,
         }
     }
 }

--- a/src/mpd/mod.rs
+++ b/src/mpd/mod.rs
@@ -5,7 +5,9 @@ pub mod commands;
 pub mod errors;
 pub mod mpd_client;
 pub mod proto_client;
+mod queue_position;
 pub mod version;
+pub use queue_position::QueuePosition;
 
 pub(crate) trait FromMpd
 where

--- a/src/mpd/queue_position.rs
+++ b/src/mpd/queue_position.rs
@@ -25,24 +25,33 @@ impl std::str::FromStr for QueuePosition {
     type Err = anyhow::Error;
 
     fn from_str(v: &str) -> anyhow::Result<Self> {
-        v.get(0..0).ok_or(anyhow::anyhow!("Invalid (empty) position string: '{v}'")).and_then(|f| {
-            Ok(match f {
-                "+" => QueuePosition::RelativeAdd(
-                    v.get(1..)
-                        .ok_or(anyhow::anyhow!(
-                            "Invalid position string: '{v}'. Please add a number after the +"
-                        ))?
-                        .parse()?,
-                ),
-                "-" => QueuePosition::RelativeAdd(
-                    v.get(1..)
-                        .ok_or(anyhow::anyhow!(
-                            "Invalid position string: '{v}'. Please add a number after the -"
-                        ))?
-                        .parse()?,
-                ),
-                _ => Self::Absolute(v.parse()?),
-            })
+        let f =
+            v.chars().nth(0).ok_or(anyhow::anyhow!("Invalid (empty) position string: '{v}'"))?;
+        Ok(match f {
+            '+' => QueuePosition::RelativeAdd(parse_subsequent(v)?),
+            '-' => QueuePosition::RelativeSub(parse_subsequent(v)?),
+            _ => Self::Absolute(v.parse()?),
         })
+    }
+}
+
+fn parse_subsequent(v: &str) -> anyhow::Result<usize> {
+    Ok(v.get(1..)
+        .ok_or(anyhow::anyhow!("Invalid position string: '{v}'. Please add a number."))?
+        .parse()?)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+
+    #[test]
+    fn test_queue_position_fromstr() {
+        assert!("+0".parse::<QueuePosition>().unwrap() == QueuePosition::RelativeAdd(0));
+        assert!("-0".parse::<QueuePosition>().unwrap() == QueuePosition::RelativeSub(0));
+        assert!("-15".parse::<QueuePosition>().unwrap() == QueuePosition::RelativeSub(15));
+        assert!("0".parse::<QueuePosition>().unwrap() == QueuePosition::Absolute(0));
+        assert!("15".parse::<QueuePosition>().unwrap() == QueuePosition::Absolute(15));
     }
 }

--- a/src/mpd/queue_position.rs
+++ b/src/mpd/queue_position.rs
@@ -1,0 +1,48 @@
+#[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
+pub enum QueuePosition {
+    /// relative to the currently playing song; e.g. +0 moves to right after the
+    /// current song
+    RelativeAdd(usize),
+    /// relative to the currently playing song; e.g. -0 moves to right before
+    /// the current song
+    RelativeSub(usize),
+    Absolute(usize),
+}
+
+impl QueuePosition {
+    #[must_use]
+    pub fn as_mpd_str(&self) -> String {
+        match self {
+            QueuePosition::RelativeAdd(v) => format!("+{v}"),
+            QueuePosition::RelativeSub(v) => format!("-{v}"),
+            QueuePosition::Absolute(v) => format!("{v}"),
+        }
+    }
+}
+
+impl std::str::FromStr for QueuePosition {
+    type Err = anyhow::Error;
+
+    fn from_str(v: &str) -> anyhow::Result<Self> {
+        v.get(0..0).ok_or(anyhow::anyhow!("Invalid (empty) position string: '{v}'")).and_then(|f| {
+            Ok(match f {
+                "+" => QueuePosition::RelativeAdd(
+                    v.get(1..)
+                        .ok_or(anyhow::anyhow!(
+                            "Invalid position string: '{v}'. Please add a number after the +"
+                        ))?
+                        .parse()?,
+                ),
+                "-" => QueuePosition::RelativeAdd(
+                    v.get(1..)
+                        .ok_or(anyhow::anyhow!(
+                            "Invalid position string: '{v}'. Please add a number after the -"
+                        ))?
+                        .parse()?,
+                ),
+                _ => Self::Absolute(v.parse()?),
+            })
+        })
+    }
+}

--- a/src/tests/fixtures/mpd_client.rs
+++ b/src/tests/fixtures/mpd_client.rs
@@ -9,6 +9,7 @@ use itertools::Itertools;
 use rstest::fixture;
 
 use crate::mpd::{
+    QueuePosition,
     commands::{
         IdleEvent,
         ListFiles,
@@ -27,7 +28,7 @@ use crate::mpd::{
         volume::Bound,
     },
     errors::MpdError,
-    mpd_client::{Filter, MpdClient, QueueMoveTarget, SaveMode, SingleOrRange, Tag, ValueChange},
+    mpd_client::{Filter, MpdClient, SaveMode, SingleOrRange, Tag, ValueChange},
     proto_client::SocketClient,
 };
 
@@ -295,7 +296,7 @@ impl MpdClient for TestMpdClient {
         todo!("Not yet implemented")
     }
 
-    fn add(&mut self, _path: &str) -> MpdResult<()> {
+    fn add(&mut self, _path: &str, _position: Option<QueuePosition>) -> MpdResult<()> {
         todo!("Not yet implemented")
     }
 
@@ -423,11 +424,11 @@ impl MpdClient for TestMpdClient {
             .collect())
     }
 
-    fn move_in_queue(&mut self, _from: SingleOrRange, _to: QueueMoveTarget) -> MpdResult<()> {
+    fn move_in_queue(&mut self, _from: SingleOrRange, _to: QueuePosition) -> MpdResult<()> {
         todo!("Not yet implemented")
     }
 
-    fn move_id(&mut self, _id: u32, _to: QueueMoveTarget) -> MpdResult<()> {
+    fn move_id(&mut self, _id: u32, _to: QueuePosition) -> MpdResult<()> {
         todo!("Not yet implemented")
     }
 
@@ -440,11 +441,19 @@ impl MpdClient for TestMpdClient {
         }
     }
 
-    fn find_add(&mut self, _filter: &[Filter<'_>]) -> MpdResult<()> {
+    fn find_add(
+        &mut self,
+        _filter: &[Filter<'_>],
+        _position: Option<QueuePosition>,
+    ) -> MpdResult<()> {
         todo!("Not yet implemented")
     }
 
-    fn search_add(&mut self, _filter: &[Filter<'_>]) -> MpdResult<()> {
+    fn search_add(
+        &mut self,
+        _filter: &[Filter<'_>],
+        _position: Option<QueuePosition>,
+    ) -> MpdResult<()> {
         todo!("Not yet implemented")
     }
 

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -11,7 +11,7 @@ use crate::{
     MpdQueryResult,
     config::keys::{CommonAction, GlobalAction},
     context::AppContext,
-    mpd::{client::Client, commands::Song, mpd_client::MpdClient},
+    mpd::{QueuePosition, client::Client, commands::Song, mpd_client::MpdClient},
     shared::{
         key_event::KeyEvent,
         mouse_event::{MouseEvent, MouseEventKind},
@@ -40,8 +40,8 @@ where
         item: T,
     ) -> impl FnOnce(&mut Client<'_>) -> Result<Vec<Song>> + Send + 'static;
     fn prepare_preview(&mut self, context: &AppContext) -> Result<()>;
-    fn add(&self, item: &T, context: &AppContext, insert: bool) -> Result<()>;
-    fn add_all(&self, context: &AppContext, insert: bool) -> Result<()>;
+    fn add(&self, item: &T, context: &AppContext, position: Option<QueuePosition>) -> Result<()>;
+    fn add_all(&self, context: &AppContext, position: Option<QueuePosition>) -> Result<()>;
     fn open(&mut self, context: &AppContext) -> Result<()>;
     fn delete(&self, item: &T, index: usize, context: &AppContext) -> Result<()> {
         Ok(())
@@ -171,7 +171,7 @@ where
                         .current_mut()
                         .select_idx(idx_to_select, context.config.scrolloff);
                     if let Some(item) = self.stack().current().selected() {
-                        self.add(item, context, false)?;
+                        self.add(item, context, None)?;
                     }
 
                     self.prepare_preview(context);
@@ -315,19 +315,19 @@ where
             CommonAction::Add if !self.stack().current().marked().is_empty() => {
                 for idx in self.stack().current().marked() {
                     let item = &self.stack().current().items[*idx];
-                    self.add(item, context, false)?;
+                    self.add(item, context, None)?;
                 }
 
                 context.render()?;
             }
             CommonAction::Add => {
                 if let Some(item) = self.stack().current().selected() {
-                    self.add(item, context, false);
+                    self.add(item, context, None);
                 }
             }
             CommonAction::AddAll if !self.stack().current().items.is_empty() => {
                 log::debug!("add all");
-                self.add_all(context, false)?;
+                self.add_all(context, None)?;
             }
             CommonAction::AddAll => {}
             CommonAction::AddReplace if !self.stack().current().marked().is_empty() => {
@@ -337,7 +337,7 @@ where
                 });
                 for idx in self.stack().current().marked() {
                     let item = &self.stack().current().items[*idx];
-                    self.add(item, context, false)?;
+                    self.add(item, context, None)?;
                 }
 
                 context.render()?;
@@ -348,7 +348,7 @@ where
                     Ok(())
                 });
                 if let Some(item) = self.stack().current().selected() {
-                    self.add(item, context, false);
+                    self.add(item, context, None);
                 }
             }
             CommonAction::AddAllReplace if !self.stack().current().items.is_empty() => {
@@ -356,25 +356,25 @@ where
                     client.clear()?;
                     Ok(())
                 });
-                self.add_all(context, false)?;
+                self.add_all(context, None)?;
             }
             CommonAction::AddAllReplace => {}
             CommonAction::Insert if !self.stack().current().marked().is_empty() => {
                 for idx in self.stack().current().marked() {
                     let item = &self.stack().current().items[*idx];
-                    self.add(item, context, true)?;
+                    self.add(item, context, Some(QueuePosition::RelativeAdd(0)))?;
                 }
 
                 context.render()?;
             }
             CommonAction::Insert => {
                 if let Some(item) = self.stack().current().selected() {
-                    self.add(item, context, true);
+                    self.add(item, context, Some(QueuePosition::RelativeAdd(0)));
                 }
             }
             CommonAction::InsertAll if !self.stack().current().items.is_empty() => {
                 log::debug!("add all next");
-                self.add_all(context, true)?;
+                self.add_all(context, Some(QueuePosition::RelativeAdd(0)))?;
             }
             CommonAction::InsertAll => {}
             CommonAction::Delete if !self.stack().current().marked().is_empty() => {

--- a/src/ui/modals/add_random_modal.rs
+++ b/src/ui/modals/add_random_modal.rs
@@ -94,10 +94,12 @@ impl AddRandomModal<'_> {
         }
     }
 
-    fn add_random(tag: AddRandom, count: &str, ctx: &AppContext) -> Result<()> {
-        Ok(ctx
-            .work_sender
-            .send(WorkRequest::Command(Command::AddRandom { tag, count: count.parse()? }))?)
+    fn add_random(tag: AddRandom, count: &str, ctx: &AppContext, insert: bool) -> Result<()> {
+        Ok(ctx.work_sender.send(WorkRequest::Command(Command::AddRandom {
+            tag,
+            count: count.parse()?,
+            insert,
+        }))?)
     }
 }
 
@@ -181,7 +183,7 @@ impl Modal for AddRandomModal<'_> {
                     context.render()?;
                     return Ok(());
                 } else if let Some(CommonAction::Confirm) = action {
-                    Self::add_random(self.selected_tag, &self.count, context)?;
+                    Self::add_random(self.selected_tag, &self.count, context, false)?;
                     pop_modal!(context);
                     return Ok(());
                 }
@@ -278,7 +280,7 @@ impl Modal for AddRandomModal<'_> {
                     }
                     CommonAction::Confirm => {
                         if state.selected == 0 {
-                            Self::add_random(self.selected_tag, &self.count, context)?;
+                            Self::add_random(self.selected_tag, &self.count, context, false)?;
                         }
                         pop_modal!(context);
                     }
@@ -327,7 +329,7 @@ impl Modal for AddRandomModal<'_> {
             MouseEventKind::DoubleClick => {
                 match self.button_group.get_button_idx_at(event.into()) {
                     Some(0) => {
-                        Self::add_random(self.selected_tag, &self.count, context)?;
+                        Self::add_random(self.selected_tag, &self.count, context, false)?;
                         pop_modal!(context);
                     }
                     Some(_) => {

--- a/src/ui/modals/add_random_modal.rs
+++ b/src/ui/modals/add_random_modal.rs
@@ -94,12 +94,10 @@ impl AddRandomModal<'_> {
         }
     }
 
-    fn add_random(tag: AddRandom, count: &str, ctx: &AppContext, insert: bool) -> Result<()> {
-        Ok(ctx.work_sender.send(WorkRequest::Command(Command::AddRandom {
-            tag,
-            count: count.parse()?,
-            insert,
-        }))?)
+    fn add_random(tag: AddRandom, count: &str, ctx: &AppContext) -> Result<()> {
+        Ok(ctx
+            .work_sender
+            .send(WorkRequest::Command(Command::AddRandom { tag, count: count.parse()? }))?)
     }
 }
 
@@ -183,7 +181,7 @@ impl Modal for AddRandomModal<'_> {
                     context.render()?;
                     return Ok(());
                 } else if let Some(CommonAction::Confirm) = action {
-                    Self::add_random(self.selected_tag, &self.count, context, false)?;
+                    Self::add_random(self.selected_tag, &self.count, context)?;
                     pop_modal!(context);
                     return Ok(());
                 }
@@ -280,7 +278,7 @@ impl Modal for AddRandomModal<'_> {
                     }
                     CommonAction::Confirm => {
                         if state.selected == 0 {
-                            Self::add_random(self.selected_tag, &self.count, context, false)?;
+                            Self::add_random(self.selected_tag, &self.count, context)?;
                         }
                         pop_modal!(context);
                     }
@@ -329,7 +327,7 @@ impl Modal for AddRandomModal<'_> {
             MouseEventKind::DoubleClick => {
                 match self.button_group.get_button_idx_at(event.into()) {
                     Some(0) => {
-                        Self::add_random(self.selected_tag, &self.count, context, false)?;
+                        Self::add_random(self.selected_tag, &self.count, context)?;
                         pop_modal!(context);
                     }
                     Some(_) => {

--- a/src/ui/panes/albums.rs
+++ b/src/ui/panes/albums.rs
@@ -8,14 +8,18 @@ use crate::{
     config::{sort_mode::SortOptions, tabs::PaneType},
     context::AppContext,
     mpd::{
+        QueuePosition,
         client::Client,
         commands::Song,
         errors::MpdError,
         mpd_client::{Filter, MpdClient, Tag},
     },
     shared::{
-        ext::mpd_client::MpdClientExt, key_event::KeyEvent, macros::status_info,
-        mouse_event::MouseEvent, mpd_query::PreviewGroup,
+        ext::mpd_client::MpdClientExt,
+        key_event::KeyEvent,
+        macros::status_info,
+        mouse_event::MouseEvent,
+        mpd_query::PreviewGroup,
     },
     ui::{
         UiEvent,
@@ -60,7 +64,7 @@ impl AlbumsPane {
 
         match self.stack.path() {
             [_album] => {
-                self.add(current, context, false)?;
+                self.add(current, context, None)?;
                 let queue_len = context.queue.len();
                 if autoplay {
                     context.command(move |client| Ok(client.play_last(queue_len)?));
@@ -259,7 +263,12 @@ impl BrowserPane<DirOrSong> for AlbumsPane {
         self.open_or_play(false, context)
     }
 
-    fn add(&self, item: &DirOrSong, context: &AppContext, insert: bool) -> Result<()> {
+    fn add(
+        &self,
+        item: &DirOrSong,
+        context: &AppContext,
+        position: Option<QueuePosition>,
+    ) -> Result<()> {
         match self.stack.path() {
             [album] => {
                 let album = album.clone();
@@ -267,7 +276,7 @@ impl BrowserPane<DirOrSong> for AlbumsPane {
                 context.command(move |client| {
                     client.find_add(
                         &[Filter::new(Tag::File, &name), Filter::new(Tag::Album, album.as_str())],
-                        insert,
+                        position,
                     )?;
 
                     status_info!("'{name}' added to queue");
@@ -277,7 +286,7 @@ impl BrowserPane<DirOrSong> for AlbumsPane {
             [] => {
                 let name = item.dir_name_or_file_name().into_owned();
                 context.command(move |client| {
-                    client.find_add(&[Filter::new(Tag::Album, &name)], insert)?;
+                    client.find_add(&[Filter::new(Tag::Album, &name)], position)?;
 
                     status_info!("Album '{name}' added to queue");
                     Ok(())
@@ -289,19 +298,19 @@ impl BrowserPane<DirOrSong> for AlbumsPane {
         Ok(())
     }
 
-    fn add_all(&self, context: &AppContext, insert: bool) -> Result<()> {
+    fn add_all(&self, context: &AppContext, position: Option<QueuePosition>) -> Result<()> {
         match self.stack.path() {
             [album] => {
                 let album = album.clone();
                 context.command(move |client| {
-                    client.find_add(&[Filter::new(Tag::Album, album.as_str())], insert)?;
+                    client.find_add(&[Filter::new(Tag::Album, album.as_str())], position)?;
                     status_info!("Album '{}' added to queue", album);
                     Ok(())
                 });
             }
             [] => {
                 context.command(move |client| {
-                    client.add("/", insert)?; // add the whole library
+                    client.add("/", position)?; // add the whole library
                     status_info!("All albums added to queue");
                     Ok(())
                 });

--- a/src/ui/panes/albums.rs
+++ b/src/ui/panes/albums.rs
@@ -14,11 +14,8 @@ use crate::{
         mpd_client::{Filter, MpdClient, Tag},
     },
     shared::{
-        ext::mpd_client::MpdClientExt,
-        key_event::KeyEvent,
-        macros::status_info,
-        mouse_event::MouseEvent,
-        mpd_query::PreviewGroup,
+        ext::mpd_client::MpdClientExt, key_event::KeyEvent, macros::status_info,
+        mouse_event::MouseEvent, mpd_query::PreviewGroup,
     },
     ui::{
         UiEvent,
@@ -63,7 +60,7 @@ impl AlbumsPane {
 
         match self.stack.path() {
             [_album] => {
-                self.add(current, context)?;
+                self.add(current, context, false)?;
                 let queue_len = context.queue.len();
                 if autoplay {
                     context.command(move |client| Ok(client.play_last(queue_len)?));
@@ -262,16 +259,16 @@ impl BrowserPane<DirOrSong> for AlbumsPane {
         self.open_or_play(false, context)
     }
 
-    fn add(&self, item: &DirOrSong, context: &AppContext) -> Result<()> {
+    fn add(&self, item: &DirOrSong, context: &AppContext, insert: bool) -> Result<()> {
         match self.stack.path() {
             [album] => {
                 let album = album.clone();
                 let name = item.dir_name_or_file_name().into_owned();
                 context.command(move |client| {
-                    client.find_add(&[
-                        Filter::new(Tag::File, &name),
-                        Filter::new(Tag::Album, album.as_str()),
-                    ])?;
+                    client.find_add(
+                        &[Filter::new(Tag::File, &name), Filter::new(Tag::Album, album.as_str())],
+                        insert,
+                    )?;
 
                     status_info!("'{name}' added to queue");
                     Ok(())
@@ -280,7 +277,7 @@ impl BrowserPane<DirOrSong> for AlbumsPane {
             [] => {
                 let name = item.dir_name_or_file_name().into_owned();
                 context.command(move |client| {
-                    client.find_add(&[Filter::new(Tag::Album, &name)])?;
+                    client.find_add(&[Filter::new(Tag::Album, &name)], insert)?;
 
                     status_info!("Album '{name}' added to queue");
                     Ok(())
@@ -292,19 +289,19 @@ impl BrowserPane<DirOrSong> for AlbumsPane {
         Ok(())
     }
 
-    fn add_all(&self, context: &AppContext) -> Result<()> {
+    fn add_all(&self, context: &AppContext, insert: bool) -> Result<()> {
         match self.stack.path() {
             [album] => {
                 let album = album.clone();
                 context.command(move |client| {
-                    client.find_add(&[Filter::new(Tag::Album, album.as_str())])?;
+                    client.find_add(&[Filter::new(Tag::Album, album.as_str())], insert)?;
                     status_info!("Album '{}' added to queue", album);
                     Ok(())
                 });
             }
             [] => {
                 context.command(move |client| {
-                    client.add("/")?; // add the whole library
+                    client.add("/", insert)?; // add the whole library
                     status_info!("All albums added to queue");
                     Ok(())
                 });

--- a/src/ui/panes/directories.rs
+++ b/src/ui/panes/directories.rs
@@ -13,11 +13,8 @@ use crate::{
         mpd_client::{Filter, FilterKind, MpdClient, Tag},
     },
     shared::{
-        ext::mpd_client::MpdClientExt,
-        key_event::KeyEvent,
-        macros::status_info,
-        mouse_event::MouseEvent,
-        mpd_query::PreviewGroup,
+        ext::mpd_client::MpdClientExt, key_event::KeyEvent, macros::status_info,
+        mouse_event::MouseEvent, mpd_query::PreviewGroup,
     },
     ui::{
         UiEvent,
@@ -93,7 +90,7 @@ impl DirectoriesPane {
                 context.render()?;
             }
             t @ DirOrSong::Song(_) => {
-                self.add(t, context)?;
+                self.add(t, context, false)?;
                 let queue_len = context.queue.len();
                 if autoplay {
                     context.command(move |client| Ok(client.play_last(queue_len)?));
@@ -258,7 +255,7 @@ impl BrowserPane<DirOrSong> for DirectoriesPane {
         }
     }
 
-    fn add(&self, item: &DirOrSong, context: &AppContext) -> Result<()> {
+    fn add(&self, item: &DirOrSong, context: &AppContext, insert: bool) -> Result<()> {
         match item {
             DirOrSong::Dir { name: dirname, .. } => {
                 let mut next_path = self.stack.path().to_vec();
@@ -266,7 +263,7 @@ impl BrowserPane<DirOrSong> for DirectoriesPane {
                 let next_path = next_path.join(std::path::MAIN_SEPARATOR_STR).to_string();
 
                 context.command(move |client| {
-                    client.add(&next_path)?;
+                    client.add(&next_path, insert)?;
                     status_info!("Directory '{next_path}' added to queue");
                     Ok(())
                 });
@@ -278,7 +275,7 @@ impl BrowserPane<DirOrSong> for DirectoriesPane {
                 let title_text =
                     song.title_str(&context.config.theme.format_tag_separator).into_owned();
                 context.command(move |client| {
-                    client.add(&file)?;
+                    client.add(&file, insert)?;
                     if let Ok(Some(_song)) = client.find_one(&[Filter::new(Tag::File, &file)]) {
                         status_info!("'{}' by '{}' added to queue", title_text, artist_text);
                     }
@@ -292,10 +289,10 @@ impl BrowserPane<DirOrSong> for DirectoriesPane {
         Ok(())
     }
 
-    fn add_all(&self, context: &AppContext) -> Result<()> {
+    fn add_all(&self, context: &AppContext, insert: bool) -> Result<()> {
         let path = self.stack().path().join(std::path::MAIN_SEPARATOR_STR);
         context.command(move |client| {
-            client.add(&path)?;
+            client.add(&path, insert)?;
             status_info!("Directory '{path}' added to queue");
             Ok(())
         });

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -88,7 +88,7 @@ impl PlaylistsPane {
                 context.render()?;
             }
             DirOrSong::Song(_song) => {
-                self.add(selected, context)?;
+                self.add(selected, context, false)?;
                 let queue_len = context.queue.len();
                 if autoplay {
                     context.command(move |client| Ok(client.play_last(queue_len)?));
@@ -381,7 +381,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
         Ok(())
     }
 
-    fn add_all(&self, context: &AppContext) -> Result<()> {
+    fn add_all(&self, context: &AppContext, insert: bool) -> Result<()> {
         match self.stack().path() {
             [playlist] => {
                 let playlist = playlist.clone();
@@ -393,7 +393,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
             }
             [] => {
                 for playlist in &self.stack().current().items {
-                    self.add(playlist, context)?;
+                    self.add(playlist, context, insert)?;
                 }
                 status_info!("All playlists added to queue");
             }
@@ -403,7 +403,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
         Ok(())
     }
 
-    fn add(&self, item: &DirOrSong, context: &AppContext) -> Result<()> {
+    fn add(&self, item: &DirOrSong, context: &AppContext, insert: bool) -> Result<()> {
         match item {
             DirOrSong::Dir { name: d, .. } => {
                 let d = d.clone();
@@ -420,7 +420,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
                 let title_text =
                     s.title_str(&context.config.theme.format_tag_separator).into_owned();
                 context.command(move |client| {
-                    client.add(&file)?;
+                    client.add(&file, insert)?;
                     if let Ok(Some(_song)) = client.find_one(&[Filter::new(Tag::File, &file)]) {
                         status_info!("'{}' by '{}' added to queue", title_text, artist_text);
                     }

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -8,6 +8,7 @@ use crate::{
     config::tabs::PaneType,
     context::AppContext,
     mpd::{
+        QueuePosition,
         client::Client,
         commands::{Song, lsinfo::LsInfoEntry},
         mpd_client::{Filter, MpdClient, SingleOrRange, Tag},
@@ -88,7 +89,7 @@ impl PlaylistsPane {
                 context.render()?;
             }
             DirOrSong::Song(_song) => {
-                self.add(selected, context, false)?;
+                self.add(selected, context, None)?;
                 let queue_len = context.queue.len();
                 if autoplay {
                     context.command(move |client| Ok(client.play_last(queue_len)?));
@@ -381,7 +382,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
         Ok(())
     }
 
-    fn add_all(&self, context: &AppContext, insert: bool) -> Result<()> {
+    fn add_all(&self, context: &AppContext, position: Option<QueuePosition>) -> Result<()> {
         match self.stack().path() {
             [playlist] => {
                 let playlist = playlist.clone();
@@ -393,7 +394,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
             }
             [] => {
                 for playlist in &self.stack().current().items {
-                    self.add(playlist, context, insert)?;
+                    self.add(playlist, context, position.clone())?;
                 }
                 status_info!("All playlists added to queue");
             }
@@ -403,7 +404,12 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
         Ok(())
     }
 
-    fn add(&self, item: &DirOrSong, context: &AppContext, insert: bool) -> Result<()> {
+    fn add(
+        &self,
+        item: &DirOrSong,
+        context: &AppContext,
+        position: Option<QueuePosition>,
+    ) -> Result<()> {
         match item {
             DirOrSong::Dir { name: d, .. } => {
                 let d = d.clone();
@@ -420,7 +426,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
                 let title_text =
                     s.title_str(&context.config.theme.format_tag_separator).into_owned();
                 context.command(move |client| {
-                    client.add(&file, insert)?;
+                    client.add(&file, position)?;
                     if let Ok(Some(_song)) = client.find_one(&[Filter::new(Tag::File, &file)]) {
                         status_info!("'{}' by '{}' added to queue", title_text, artist_text);
                     }

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -769,6 +769,8 @@ impl Pane for QueuePane {
                 }
                 CommonAction::Add => {}
                 CommonAction::AddAll => {}
+                CommonAction::Insert => {}
+                CommonAction::InsertAll => {}
                 CommonAction::AddReplace => {}
                 CommonAction::AddAllReplace => {}
                 CommonAction::Delete => {}

--- a/src/ui/panes/search.rs
+++ b/src/ui/panes/search.rs
@@ -17,6 +17,7 @@ use crate::{
     context::AppContext,
     core::command::{create_env, run_external},
     mpd::{
+        QueuePosition,
         commands::Song,
         mpd_client::{Filter, FilterKind, MpdClient, Tag},
     },
@@ -75,12 +76,18 @@ impl SearchPane {
         }
     }
 
-    fn add_current(&mut self, autoplay: bool, context: &AppContext, insert: bool) -> Result<()> {
+    fn add_current(
+        &mut self,
+        autoplay: bool,
+        context: &AppContext,
+        position: Option<QueuePosition>,
+    ) -> Result<()> {
         if !self.songs_dir.marked().is_empty() {
             for idx in self.songs_dir.marked() {
                 let item = self.songs_dir.items[*idx].file.clone();
+                let position = position.clone();
                 context.command(move |client| {
-                    client.add(&item, insert)?;
+                    client.add(&item, position)?;
                     Ok(())
                 });
             }
@@ -90,7 +97,7 @@ impl SearchPane {
         } else if let Some(item) = self.songs_dir.selected() {
             let item = item.file.clone();
             context.command(move |client| {
-                client.add(&item, insert)?;
+                client.add(&item, position)?;
                 status_info!("Added '{item}' to queue");
                 Ok(())
             });
@@ -316,7 +323,7 @@ impl SearchPane {
         })
     }
 
-    fn search_add(&mut self, context: &AppContext, insert: bool) {
+    fn search_add(&mut self, context: &AppContext, position: Option<QueuePosition>) {
         let (filter_kind, case_sensitive) = self.filter_type();
         let filter = self.inputs.textbox_inputs.iter().filter_map(|input| match &input {
             Textbox { value, filter_key, .. } if !value.is_empty() => {
@@ -340,7 +347,7 @@ impl SearchPane {
                             Filter::new(std::mem::take(key), value).with_type(*kind)
                         })
                         .collect_vec(),
-                    insert,
+                    position,
                 )?;
                 Ok(())
             });
@@ -353,7 +360,7 @@ impl SearchPane {
                             Filter::new(std::mem::take(key), value).with_type(*kind)
                         })
                         .collect_vec(),
-                    insert,
+                    position,
                 )?;
                 Ok(())
             });
@@ -653,7 +660,7 @@ impl Pane for SearchPane {
                         }
                     }
                     Phase::BrowseResults { .. } => {
-                        self.add_current(false, context, false)?;
+                        self.add_current(false, context, None)?;
                     }
                 }
             }
@@ -691,7 +698,7 @@ impl Pane for SearchPane {
                     }
                 }
                 Phase::BrowseResults { .. } => {
-                    self.add_current(false, context, false)?;
+                    self.add_current(false, context, None)?;
                 }
             },
             MouseEventKind::MiddleClick if self.column_areas[1].contains(event.into()) => {
@@ -707,7 +714,7 @@ impl Pane for SearchPane {
                             if let Some(item) = self.songs_dir.selected() {
                                 let item = item.file.clone();
                                 context.command(move |client| {
-                                    client.add(&item, false)?;
+                                    client.add(&item, None)?;
                                     status_info!("Added '{item}' to queue");
                                     Ok(())
                                 });
@@ -871,7 +878,7 @@ impl Pane for SearchPane {
                         }
                         CommonAction::Add => {}
                         CommonAction::AddAll => {
-                            self.search_add(context, false);
+                            self.search_add(context, None);
 
                             status_info!("All found songs added to queue");
 
@@ -879,7 +886,7 @@ impl Pane for SearchPane {
                         }
                         CommonAction::Insert => {}
                         CommonAction::InsertAll => {
-                            self.search_add(context, true);
+                            self.search_add(context, Some(QueuePosition::RelativeAdd(0)));
 
                             status_info!("All found songs added to queue");
 
@@ -891,7 +898,7 @@ impl Pane for SearchPane {
                                 client.clear()?;
                                 Ok(())
                             });
-                            self.search_add(context, false);
+                            self.search_add(context, None);
 
                             status_info!("All found songs added to queue");
 
@@ -1008,7 +1015,7 @@ impl Pane for SearchPane {
 
                             context.render()?;
                         }
-                        CommonAction::Right => self.add_current(false, context, false)?,
+                        CommonAction::Right => self.add_current(false, context, None)?,
                         CommonAction::Left => {
                             self.phase = Phase::Search;
                             self.prepare_preview(context);
@@ -1060,21 +1067,21 @@ impl Pane for SearchPane {
                         CommonAction::Rename => {}
                         CommonAction::Close => {}
                         CommonAction::Confirm => {
-                            self.add_current(true, context, false)?;
+                            self.add_current(true, context, None)?;
 
                             context.render()?;
                         }
                         CommonAction::FocusInput => {}
-                        CommonAction::Add => self.add_current(false, context, false)?,
+                        CommonAction::Add => self.add_current(false, context, None)?,
                         CommonAction::AddAll => {
-                            self.search_add(context, false);
+                            self.search_add(context, None);
                             status_info!("All found songs added to queue");
 
                             context.render()?;
                         }
-                        CommonAction::Insert => self.add_current(false, context, false)?,
+                        CommonAction::Insert => self.add_current(false, context, None)?,
                         CommonAction::InsertAll => {
-                            self.search_add(context, true);
+                            self.search_add(context, None);
                             status_info!("All found songs added to queue");
 
                             context.render()?;
@@ -1084,14 +1091,14 @@ impl Pane for SearchPane {
                                 client.clear()?;
                                 Ok(())
                             });
-                            self.add_current(false, context, false)?;
+                            self.add_current(false, context, None)?;
                         }
                         CommonAction::AddAllReplace => {
                             context.command(|client| {
                                 client.clear()?;
                                 Ok(())
                             });
-                            self.search_add(context, false);
+                            self.search_add(context, None);
                             status_info!("All found songs added to queue");
 
                             context.render()?;


### PR DESCRIPTION
### Description
The added Insert and InsertAll commands allow adding songs directly after the current song, with mpd's POSITION argument on its API.

### Scope
This just changes what it needs to, it was done by adding the command and then being taken by the hand by the compiler and adding the explicit matches everywhere they were needed. Basic testing was done.

### Criticism
Since I don't know exactly how the queue view works, I didn't implement its Insert action, even though it would be interesting, since it is often needed to add a song already in the queue directly after the current track. Note it is still possible to do so manually by simply moving the track up. An implementation of this would probably add the song a second time instead of moving it.
