### PR TITLE
feat: add block album_art support

### DIFF
--- a/src/config/album_art.rs
+++ b/src/config/album_art.rs
@@ -63,6 +63,7 @@ pub enum ImageMethodFile {
     UeberzugX11,
     Iterm2,
     Sixel,
+    Block,
     None,
     #[default]
     Auto,
@@ -76,6 +77,7 @@ pub enum ImageMethod {
     Iterm2,
     Sixel,
     None,
+    Block,
     #[default]
     Unsupported,
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -418,6 +418,7 @@ impl ConfigFile {
             }
             ImageMethodFile::UeberzugX11 => ImageMethod::Unsupported,
             ImageMethodFile::Sixel => ImageMethod::Sixel,
+            ImageMethodFile::Block => ImageMethod::Block,
             ImageMethodFile::None => ImageMethod::None,
             ImageMethodFile::Auto => match image::determine_image_support(is_tmux)? {
                 ImageProtocol::Kitty => ImageMethod::Kitty,
@@ -425,6 +426,7 @@ impl ConfigFile {
                 ImageProtocol::UeberzugX11 => ImageMethod::UeberzugX11,
                 ImageProtocol::Iterm2 => ImageMethod::Iterm2,
                 ImageProtocol::Sixel => ImageMethod::Sixel,
+                ImageProtocol::Block => ImageMethod::Block,
                 ImageProtocol::None => ImageMethod::Unsupported,
             },
         };
@@ -440,7 +442,8 @@ impl ConfigFile {
             | ImageMethod::UeberzugWayland
             | ImageMethod::UeberzugX11
             | ImageMethod::Iterm2
-            | ImageMethod::Sixel => {
+            | ImageMethod::Sixel
+            | ImageMethod::Block => {
                 log::debug!(resolved:? = config.album_art.method, requested:? = album_art_method, is_tmux; "Image method resolved");
             }
         }

--- a/src/shared/ansi_colors.rs
+++ b/src/shared/ansi_colors.rs
@@ -1,0 +1,250 @@
+// ansi_colours – true-colour ↔ ANSI terminal palette converter
+// Copyright 2018 by Michał Nazarewicz <mina86@mina86.com>
+//
+// ansi_colours is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation; either version 3 of the License, or (at
+// your option) any later version.
+//
+// ansi_colours is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
+// General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with ansi_colours.  If not, see <http://www.gnu.org/licenses/>.
+/// The ANSI colour palette.
+#[rustfmt::skip]
+#[allow(clippy::unreadable_literal)]
+pub static ANSI_COLOURS: [u32; 256] = [
+    // The 16 system colours as used by default by xterm.  Taken
+    // from XTerm-col.ad distributed with xterm source code.
+    0x000000, 0xcd0000, 0x00cd00, 0xcdcd00,
+    0x0000ee, 0xcd00cd, 0x00cdcd, 0xe5e5e5,
+    0x7f7f7f, 0xff0000, 0x00ff00, 0xffff00,
+    0x5c5cff, 0xff00ff, 0x00ffff, 0xffffff,
+
+    // 6×6×6 cube.  One each axis, the six indices map to [0, 95, 135, 175,
+    // 215, 255] RGB component values.
+    0x000000, 0x00005f, 0x000087, 0x0000af,
+    0x0000d7, 0x0000ff, 0x005f00, 0x005f5f,
+    0x005f87, 0x005faf, 0x005fd7, 0x005fff,
+    0x008700, 0x00875f, 0x008787, 0x0087af,
+    0x0087d7, 0x0087ff, 0x00af00, 0x00af5f,
+    0x00af87, 0x00afaf, 0x00afd7, 0x00afff,
+    0x00d700, 0x00d75f, 0x00d787, 0x00d7af,
+    0x00d7d7, 0x00d7ff, 0x00ff00, 0x00ff5f,
+    0x00ff87, 0x00ffaf, 0x00ffd7, 0x00ffff,
+    0x5f0000, 0x5f005f, 0x5f0087, 0x5f00af,
+    0x5f00d7, 0x5f00ff, 0x5f5f00, 0x5f5f5f,
+    0x5f5f87, 0x5f5faf, 0x5f5fd7, 0x5f5fff,
+    0x5f8700, 0x5f875f, 0x5f8787, 0x5f87af,
+    0x5f87d7, 0x5f87ff, 0x5faf00, 0x5faf5f,
+    0x5faf87, 0x5fafaf, 0x5fafd7, 0x5fafff,
+    0x5fd700, 0x5fd75f, 0x5fd787, 0x5fd7af,
+    0x5fd7d7, 0x5fd7ff, 0x5fff00, 0x5fff5f,
+    0x5fff87, 0x5fffaf, 0x5fffd7, 0x5fffff,
+    0x870000, 0x87005f, 0x870087, 0x8700af,
+    0x8700d7, 0x8700ff, 0x875f00, 0x875f5f,
+    0x875f87, 0x875faf, 0x875fd7, 0x875fff,
+    0x878700, 0x87875f, 0x878787, 0x8787af,
+    0x8787d7, 0x8787ff, 0x87af00, 0x87af5f,
+    0x87af87, 0x87afaf, 0x87afd7, 0x87afff,
+    0x87d700, 0x87d75f, 0x87d787, 0x87d7af,
+    0x87d7d7, 0x87d7ff, 0x87ff00, 0x87ff5f,
+    0x87ff87, 0x87ffaf, 0x87ffd7, 0x87ffff,
+    0xaf0000, 0xaf005f, 0xaf0087, 0xaf00af,
+    0xaf00d7, 0xaf00ff, 0xaf5f00, 0xaf5f5f,
+    0xaf5f87, 0xaf5faf, 0xaf5fd7, 0xaf5fff,
+    0xaf8700, 0xaf875f, 0xaf8787, 0xaf87af,
+    0xaf87d7, 0xaf87ff, 0xafaf00, 0xafaf5f,
+    0xafaf87, 0xafafaf, 0xafafd7, 0xafafff,
+    0xafd700, 0xafd75f, 0xafd787, 0xafd7af,
+    0xafd7d7, 0xafd7ff, 0xafff00, 0xafff5f,
+    0xafff87, 0xafffaf, 0xafffd7, 0xafffff,
+    0xd70000, 0xd7005f, 0xd70087, 0xd700af,
+    0xd700d7, 0xd700ff, 0xd75f00, 0xd75f5f,
+    0xd75f87, 0xd75faf, 0xd75fd7, 0xd75fff,
+    0xd78700, 0xd7875f, 0xd78787, 0xd787af,
+    0xd787d7, 0xd787ff, 0xd7af00, 0xd7af5f,
+    0xd7af87, 0xd7afaf, 0xd7afd7, 0xd7afff,
+    0xd7d700, 0xd7d75f, 0xd7d787, 0xd7d7af,
+    0xd7d7d7, 0xd7d7ff, 0xd7ff00, 0xd7ff5f,
+    0xd7ff87, 0xd7ffaf, 0xd7ffd7, 0xd7ffff,
+    0xff0000, 0xff005f, 0xff0087, 0xff00af,
+    0xff00d7, 0xff00ff, 0xff5f00, 0xff5f5f,
+    0xff5f87, 0xff5faf, 0xff5fd7, 0xff5fff,
+    0xff8700, 0xff875f, 0xff8787, 0xff87af,
+    0xff87d7, 0xff87ff, 0xffaf00, 0xffaf5f,
+    0xffaf87, 0xffafaf, 0xffafd7, 0xffafff,
+    0xffd700, 0xffd75f, 0xffd787, 0xffd7af,
+    0xffd7d7, 0xffd7ff, 0xffff00, 0xffff5f,
+    0xffff87, 0xffffaf, 0xffffd7, 0xffffff,
+
+    // Greyscale ramp.  This is calculated as (index - 232) * 10 + 8
+    // repeated for each RGB component.
+    0x080808, 0x121212, 0x1c1c1c, 0x262626,
+    0x303030, 0x3a3a3a, 0x444444, 0x4e4e4e,
+    0x585858, 0x626262, 0x6c6c6c, 0x767676,
+    0x808080, 0x8a8a8a, 0x949494, 0x9e9e9e,
+    0xa8a8a8, 0xb2b2b2, 0xbcbcbc, 0xc6c6c6,
+    0xd0d0d0, 0xdadada, 0xe4e4e4, 0xeeeeee,
+];
+
+/// A lookup table for approximations of shades of grey.  Values chosen to get
+/// smallest possible ΔE*₀₀.
+///
+/// Calculating the mapping has several corner cases.  The greyscale ramp starts
+/// at rgb(8, 8, 8) but ends at rgb(238, 238, 238) resulting in asymmetric
+/// distance to the extreme values.  Shades of grey are present in the greyscale
+/// ramp as well as the 6×6×6 colour cube making it necessary to consider
+/// multiple cases. And that all on top of ANSI palette using linear indexes in
+/// gamma encoded colour space.
+///
+/// Not to have to deal with all that, the colours are simply precalculated.
+/// This way we know we always get the best possible match.  This also makes
+/// conversion for grey colours blazing fast.
+///
+/// There’s a unit test that verifies that those are the best indexes.
+#[rustfmt::skip]
+pub static ANSI256_FROM_GREY: [u8; 256] = [
+     16,  16,  16,  16,  16, 232, 232, 232,
+    232, 232, 232, 232, 232, 232, 233, 233,
+    233, 233, 233, 233, 233, 233, 233, 233,
+    234, 234, 234, 234, 234, 234, 234, 234,
+    234, 234, 235, 235, 235, 235, 235, 235,
+    235, 235, 235, 235, 236, 236, 236, 236,
+    236, 236, 236, 236, 236, 236, 237, 237,
+    237, 237, 237, 237, 237, 237, 237, 237,
+    238, 238, 238, 238, 238, 238, 238, 238,
+    238, 238, 239, 239, 239, 239, 239, 239,
+    239, 239, 239, 239, 240, 240, 240, 240,
+    240, 240, 240, 240,  59,  59,  59,  59,
+     59, 241, 241, 241, 241, 241, 241, 241,
+    242, 242, 242, 242, 242, 242, 242, 242,
+    242, 242, 243, 243, 243, 243, 243, 243,
+    243, 243, 243, 244, 244, 244, 244, 244,
+    244, 244, 244, 244, 102, 102, 102, 102,
+    102, 245, 245, 245, 245, 245, 245, 246,
+    246, 246, 246, 246, 246, 246, 246, 246,
+    246, 247, 247, 247, 247, 247, 247, 247,
+    247, 247, 247, 248, 248, 248, 248, 248,
+    248, 248, 248, 248, 145, 145, 145, 145,
+    145, 249, 249, 249, 249, 249, 249, 250,
+    250, 250, 250, 250, 250, 250, 250, 250,
+    250, 251, 251, 251, 251, 251, 251, 251,
+    251, 251, 251, 252, 252, 252, 252, 252,
+    252, 252, 252, 252, 188, 188, 188, 188,
+    188, 253, 253, 253, 253, 253, 253, 254,
+    254, 254, 254, 254, 254, 254, 254, 254,
+    254, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 231,
+    231, 231, 231, 231, 231, 231, 231, 231,
+];
+
+#[allow(clippy::cast_possible_truncation)]
+fn to_triple(rgb: u32) -> (u8, u8, u8) {
+    ((rgb >> 16) as u8, (rgb >> 8) as u8, rgb as u8)
+}
+
+/// Returns index of a colour in 256-colour ANSI palette approximating given
+/// sRGB colour.
+#[inline]
+pub fn ansi256_from_rgb(rgb: (u8, u8, u8)) -> u8 {
+    let rgb = to_u32(rgb.0, rgb.1, rgb.2);
+    let (r, g, b) = to_triple(rgb);
+
+    let grey_index = ANSI256_FROM_GREY[luminance(r, g, b) as usize];
+    let grey_distance = distance((r, g, b), ANSI_COLOURS[grey_index as usize]);
+    let (cube_index, cube_rgb) = cube_index(r, g, b);
+    if distance((r, g, b), cube_rgb) < grey_distance { cube_index } else { grey_index }
+}
+
+fn cube_index(r: u8, g: u8, b: u8) -> (u8, u32) {
+    let r = cube_index_red(r);
+    let g = cube_index_green(g);
+    let b = cube_index_blue(b);
+    (r.0 + g.0 + b.0, r.1 + g.1 + b.1)
+}
+
+#[rustfmt::skip]
+#[allow(clippy::many_single_char_names)]
+fn cube_thresholds(v: u8, a: u8, b: u8, c: u8, d: u8, e: u8) -> (u8, u32) {
+    if      v < a { (0,   0) }
+    else if v < b { (1,  95) }
+    else if v < c { (2, 135) }
+    else if v < d { (3, 175) }
+    else if v < e { (4, 215) }
+    else          { (5, 255) }
+}
+
+// The next three functions approximate a pure colour by an entry in the 6×6×6
+// cube.  E.g. cube_index_red(r) approximates an rgb(r, 0, 0) colour.  This was
+// motivated by ΔE*₀₀ being most variable in dark colours so I felt it’s more
+// important to better approximate dark colours than light colours.
+
+fn cube_index_red(v: u8) -> (u8, u32) {
+    let (i, v) = cube_thresholds(v, 38, 115, 155, 196, 235);
+    (i * 36 + 16, v << 16)
+}
+
+fn cube_index_green(v: u8) -> (u8, u32) {
+    let (i, v) = cube_thresholds(v, 36, 116, 154, 195, 235);
+    (i * 6, v << 8)
+}
+
+fn cube_index_blue(v: u8) -> (u8, u32) {
+    cube_thresholds(v, 35, 115, 155, 195, 235)
+}
+
+/// Returns luminance of given sRGB colour.  The calculation favours speed over
+/// precision and so doesn’t correctly account for sRGB’s gamma correction.
+#[allow(clippy::many_single_char_names, clippy::unreadable_literal, clippy::cast_lossless)]
+fn luminance(r: u8, g: u8, b: u8) -> u8 {
+    // The following weighted average is as fast as naive arithmetic mean and at
+    // the same time noticeably more precise.  The coefficients are the second
+    // row of the RGB->XYZ conversion matrix (i.e. values for calculating Y from
+    // linear RGB) which I’ve calculated so that denominator is 2^24 to simplify
+    // division.
+    let v = 3567664u32 * (r as u32) + 11998547u32 * (g as u32) + 1211005u32 * (b as u32);
+    // Round to nearest rather than truncating when dividing.
+    ((v + (1u32 << 23)) >> 24) as u8
+
+    // Approximating sRGB gamma correction with a simple γ=2 improves the
+    // precision considerably but is also five times slower than the above
+    // (and probably slower still on architectures lacking MMS or FPU).
+    //
+    //     return sqrtf((float)r * (float)r * 0.2126729f +
+    //                  (float)g * (float)g * 0.7151521f +
+    //                  (float)b * (float)b * 0.0721750);
+    //
+    // Doing proper gamma correction results in further improvement but is
+    // also 20 times slower, so we’re opting out from doing that.
+}
+
+/// Calculates distance between two colours.  Tries to balance speed and
+/// perceptual correctness.  It’s not a proper metric but two properties this
+/// function provides are: d(x, x) = 0 and d(x, y) < d(x, z) implies x being
+/// closer to y than to z.
+#[allow(clippy::many_single_char_names, clippy::unreadable_literal, clippy::cast_sign_loss)]
+fn distance((xr, xg, xb): (u8, u8, u8), y: u32) -> u32 {
+    let (yr, yg, yb) = to_triple(y);
+    // See <https://www.compuphase.com/cmetric.htm> though we’re doing a few
+    // things to avoid some of the calculations.  We can do that since we only
+    // care about some properties of the metric.
+
+    let r_sum = i32::from(xr) + i32::from(yr);
+
+    let r = i32::from(xr) - i32::from(yr);
+    let g = i32::from(xg) - i32::from(yg);
+    let b = i32::from(xb) - i32::from(yb);
+
+    let d = (1024 + r_sum) * r * r + 2048 * g * g + (1534 - r_sum) * b * b;
+
+    d as u32
+}
+
+#[inline]
+fn to_u32(r: u8, g: u8, b: u8) -> u32 {
+    ((r as u32) << 16) | ((g as u32) << 8) | (b as u32)
+}

--- a/src/shared/image.rs
+++ b/src/shared/image.rs
@@ -23,6 +23,7 @@ pub enum ImageProtocol {
     UeberzugX11,
     Iterm2,
     Sixel,
+    Block,
     #[default]
     None,
 }

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,3 +1,4 @@
+pub mod ansi_colors;
 pub mod dependencies;
 pub mod env;
 pub mod events;

--- a/src/ui/image/block.rs
+++ b/src/ui/image/block.rs
@@ -1,0 +1,198 @@
+use super::{AlbumArtConfig, Backend, ImageBackendRequest, clear_area};
+use crate::shared::ansi_colors::ansi256_from_rgb;
+use crate::{
+    config::{
+        Size,
+        album_art::{HorizontalAlign, VerticalAlign},
+    },
+    shared::{
+        image::{AlignedArea, resize_image},
+        macros::{status_error, try_cont},
+    },
+    try_skip,
+    ui::image::{EncodeRequest, facade::IS_SHOWING, recv_data},
+};
+use anyhow::{Result, bail};
+use crossbeam::channel::{Sender, unbounded};
+use crossterm::style::{ResetColor, SetBackgroundColor, SetForegroundColor};
+use crossterm::{
+    cursor::{MoveTo, RestorePosition, SavePosition},
+    queue,
+    style::{Color, Colors, Print},
+};
+use image::{DynamicImage, GenericImageView, Rgba};
+use ratatui::layout::Rect;
+use std::io::Write;
+use std::sync::{Arc, atomic::Ordering};
+
+#[derive(Debug)]
+pub struct Block {
+    sender: Sender<ImageBackendRequest>,
+    colors: Colors,
+    handle: std::thread::JoinHandle<()>,
+}
+
+impl Backend for Block {
+    fn hide(&mut self, size: Rect) -> anyhow::Result<()> {
+        clear_area(&mut std::io::stdout().lock(), self.colors, size)
+    }
+
+    fn show(&mut self, data: Arc<Vec<u8>>, area: Rect) -> Result<()> {
+        Ok(self.sender.send(ImageBackendRequest::Encode(EncodeRequest { area, data }))?)
+    }
+
+    fn set_config(&self, config: AlbumArtConfig) -> Result<()> {
+        Ok(self.sender.send(ImageBackendRequest::SetConfig(config))?)
+    }
+
+    fn cleanup(self: Box<Self>, _area: Rect) -> Result<()> {
+        self.sender.send(ImageBackendRequest::Stop)?;
+        self.handle.join().expect("block thread to end gracefully");
+        Ok(())
+    }
+}
+
+const LOSS_FACTOR: usize = 2;
+const MAX_WIDTH: u16 = 180;
+const PRINT_BLOCK: &str = "\u{2580}";
+
+#[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+impl Block {
+    pub(super) fn new(config: AlbumArtConfig) -> Self {
+        let (sender, receiver) = unbounded::<ImageBackendRequest>();
+        let colors = config.colors;
+
+        let handle = std::thread::Builder::new()
+            .name("block".to_string())
+            .spawn(move || {
+                let mut config = config;
+                let mut pending_req = None;
+                'outer: loop {
+                    let EncodeRequest { data, area } =
+                        match recv_data(&mut pending_req, &mut config, &receiver) {
+                            Ok(Some(msg)) => msg,
+                            Ok(None) => break,
+                            Err(err) => {
+                                log::error!("Error receiving ImageBackendRequest message: {err}");
+                                break;
+                            }
+                        };
+
+                    // consume all pending messages, skipping older encode requests
+                    for msg in receiver.try_iter() {
+                        match msg {
+                            ImageBackendRequest::Stop => break 'outer,
+                            ImageBackendRequest::SetConfig(cfg) => config = cfg,
+                            ImageBackendRequest::Encode(req) => {
+                                pending_req = Some(req);
+                                log::debug!(
+                                    "Skipping image because another one is waiting in the queue"
+                                );
+                                continue 'outer;
+                            }
+                        }
+                    }
+
+                    let mut w = std::io::stdout().lock();
+                    if !IS_SHOWING.load(Ordering::Relaxed) {
+                        log::trace!(
+                            "Not showing image because its not supposed to be displayed anymore"
+                        );
+                        continue;
+                    }
+                    try_cont!(
+                        clear_area(&mut w, config.colors, area),
+                        "Failed to clear image area"
+                    );
+
+                    let (img, resized_area) = try_cont!(
+                        encode(&data, area, config.max_size, config.halign, config.valign),
+                        "Failed to encode"
+                    );
+
+                    try_skip!(
+                        display(&mut w, &img, resized_area),
+                        "Failed to clear sixel image area"
+                    );
+                }
+            })
+            .expect("block thread to be spawned");
+
+        Self { sender, colors, handle }
+    }
+}
+
+fn encode(
+    data: &[u8],
+    area: Rect,
+    max_size: Size,
+    halign: HorizontalAlign,
+    valign: VerticalAlign,
+) -> Result<(DynamicImage, AlignedArea)> {
+    match resize_image(data, area, max_size, halign, valign) {
+        Ok(resized) => {
+            if resized.1.size_px.width > MAX_WIDTH {
+                status_error!(
+                    "Image Size too big. Should be less than {} for compatibility reasons.",
+                    MAX_WIDTH
+                );
+                bail!("Bailing on block image render.");
+            }
+            return Ok(resized);
+        }
+        Err(err) => bail!("Failed to resize image, err: {}", err),
+    }
+}
+
+fn display(
+    w: &mut impl Write,
+    img: &DynamicImage,
+    resized_area: AlignedArea,
+) -> std::io::Result<()> {
+    queue!(w, SavePosition)?;
+    queue!(w, MoveTo(resized_area.area.x, resized_area.area.y))?;
+
+    let (i_height, i_width) = img.dimensions();
+    let img_buffer = img.to_rgba8();
+
+    for y in (0..i_height).step_by(LOSS_FACTOR * 2) {
+        for x in (0..i_width).step_by(LOSS_FACTOR) {
+            let top = match img_buffer.get_pixel_checked(x, y) {
+                Some(rgb) => rgb,
+                None => &image::Rgba([0, 0, 0, 255]),
+            };
+            let bottom = match img_buffer.get_pixel_checked(x, y + 1) {
+                Some(rgb) => rgb,
+                None => &image::Rgba([0, 0, 0, 255]),
+            };
+            let fg = color_from_pixel(*top);
+            let bg = color_from_pixel(*bottom);
+            queue!(w, SetForegroundColor(fg), SetBackgroundColor(bg), Print(PRINT_BLOCK))?;
+        }
+        if y != i_height - 1 {
+            queue!(w, ResetColor, Print("\r\n"))?;
+        }
+    }
+
+    w.flush()?;
+    queue!(w, RestorePosition)?;
+    Ok(())
+}
+
+fn color_from_pixel(pixel: Rgba<u8>) -> Color {
+    let rgb = (pixel[0], pixel[1], pixel[2]);
+
+    if truecolor_available() {
+        Color::Rgb { r: rgb.0, g: rgb.1, b: rgb.2 }
+    } else {
+        Color::AnsiValue(ansi256_from_rgb(rgb))
+    }
+}
+
+fn truecolor_available() -> bool {
+    if let Ok(value) = std::env::var("COLORTERM") {
+        value.contains("truecolor") || value.contains("24bit")
+    } else {
+        false
+    }
+}

--- a/src/ui/image/facade.rs
+++ b/src/ui/image/facade.rs
@@ -8,6 +8,7 @@ use ratatui::layout::Rect;
 
 use super::{
     Backend,
+    block::Block,
     iterm2::Iterm2,
     kitty::Kitty,
     sixel::Sixel,
@@ -34,6 +35,7 @@ enum ImageState {
     Ueberzug(Ueberzug),
     Iterm2(Iterm2),
     Sixel(Sixel),
+    Block(Block),
     #[default]
     None,
 }
@@ -46,6 +48,7 @@ impl AlbumArtFacade {
             ImageProtocol::UeberzugX11 => ImageState::Ueberzug(Ueberzug::new(Layer::X11)),
             ImageProtocol::Iterm2 => ImageState::Iterm2(Iterm2::new(config.into())),
             ImageProtocol::Sixel => ImageState::Sixel(Sixel::new(config.into())),
+            ImageProtocol::Block => ImageState::Block(Block::new(config.into())),
             ImageProtocol::None => ImageState::None,
         };
         Self {
@@ -77,6 +80,7 @@ impl AlbumArtFacade {
             ImageState::Ueberzug(ueberzug) => ueberzug.show(data, self.last_size),
             ImageState::Iterm2(iterm2) => iterm2.show(data, self.last_size),
             ImageState::Sixel(s) => s.show(data, self.last_size),
+            ImageState::Block(s) => s.show(data, self.last_size),
             ImageState::None => Ok(()),
         }
     }
@@ -93,6 +97,7 @@ impl AlbumArtFacade {
             ImageState::Ueberzug(ueberzug) => ueberzug.show(data, self.last_size),
             ImageState::Iterm2(iterm2) => iterm2.show(data, self.last_size),
             ImageState::Sixel(s) => s.show(data, self.last_size),
+            ImageState::Block(s) => s.show(data, self.last_size),
             ImageState::None => Ok(()),
         }
     }
@@ -104,6 +109,7 @@ impl AlbumArtFacade {
             ImageState::Ueberzug(ueberzug) => ueberzug.hide(self.last_size)?,
             ImageState::Iterm2(iterm2) => iterm2.hide(self.last_size)?,
             ImageState::Sixel(s) => s.hide(self.last_size)?,
+            ImageState::Block(s) => s.hide(self.last_size)?,
             ImageState::None => {}
         }
         Ok(())
@@ -117,6 +123,7 @@ impl AlbumArtFacade {
             ImageState::Ueberzug(ueberzug) => Box::new(ueberzug).cleanup(self.last_size),
             ImageState::Iterm2(iterm2) => Box::new(iterm2).cleanup(self.last_size),
             ImageState::Sixel(s) => Box::new(s).cleanup(self.last_size),
+            ImageState::Block(s) => Box::new(s).cleanup(self.last_size),
             ImageState::None => Ok(()),
         }
     }
@@ -131,6 +138,7 @@ impl AlbumArtFacade {
             ImageState::Ueberzug(ueberzug) => ueberzug.set_config(config.into())?,
             ImageState::Iterm2(iterm2) => iterm2.set_config(config.into())?,
             ImageState::Sixel(sixel) => sixel.set_config(config.into())?,
+            ImageState::Block(block) => block.set_config(config.into())?,
             ImageState::None => {}
         }
         Ok(())
@@ -145,6 +153,7 @@ impl From<ImageMethod> for ImageProtocol {
             ImageMethod::UeberzugX11 => ImageProtocol::UeberzugX11,
             ImageMethod::Iterm2 => ImageProtocol::Iterm2,
             ImageMethod::Sixel => ImageProtocol::Sixel,
+            ImageMethod::Block => ImageProtocol::Block,
             ImageMethod::None | ImageMethod::Unsupported => ImageProtocol::None,
         }
     }

--- a/src/ui/image/mod.rs
+++ b/src/ui/image/mod.rs
@@ -23,6 +23,7 @@ pub mod iterm2;
 pub mod kitty;
 pub mod sixel;
 pub mod ueberzug;
+pub mod block;
 
 #[allow(unused)]
 trait Backend {


### PR DESCRIPTION
Add block album_art.
Copied over ideas from [viu](https://github.com/atanunq/viu) to add block print support. Should work everywhere.
Tested on Alacritty.

It was annoying that Alacritty didn't have image support. This atleast gives it some image rendering to default to.

<img width="2492" alt="Screenshot 2025-05-28 at 5 37 31 PM" src="https://github.com/user-attachments/assets/48ec1779-8654-4235-bca4-2ed54848524f" />
