### PR TITLE
feat: playlist info modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,14 @@ lists they are listed as multiple entries.
 - Added `Block` AlbumArt Support
 - Add `level_styles` config option for various status message levels
 - Add filtering to the keybinds modal
+- Added info modal to the playlist
 
 ### Changed
 
 - **Breaking**: Songs are no longer sorted by their `browser_song_format`. The new `browser_song_sort` is used instead
 - **Breaking**: Some tags can now be arrays of values instead of a single value if multiple values are in the given id3 tag when listing song metadata via cli.
 - **Breaking**: For CLI which return song info: `last-modified` and `added` are no longer in songs' metadata, they are at the top level object instead now
+- **Breaking**: `ShowInfo` queue action has been moved to `navigation`. It is now more general and works in playlists as well.
 - The first lyrics will now only be highlighted once reached
 - `Filename` property no longer includes file extension, use `FileExtension` if you want to keep it
 - Migrate to Rust 2024 and raise MSRV to 1.85

--- a/docs/src/content/docs/next/assets/example_config.ron
+++ b/docs/src/content/docs/next/assets/example_config.ron
@@ -89,6 +89,7 @@
             "<Esc>":     Close,
             "K":         MoveUp,
             "D":         Delete,
+            "B":         ShowInfo,
         },
         queue: {
             "D":       DeleteAll,
@@ -96,7 +97,6 @@
             "<C-s>":   Save,
             "a":       AddToPlaylist,
             "d":       Delete,
-            "i":       ShowInfo,
             "C":       JumpToCurrent,
             "X":       Shuffle,
         },

--- a/docs/src/content/docs/next/configuration/keybinds.mdx
+++ b/docs/src/content/docs/next/configuration/keybinds.mdx
@@ -134,6 +134,7 @@ list and controlling search mode.
 |                 | AddAllReplace   | Replace current queue with all items                                                                                               |
 |                 | Insert          | Insert item after current (playing) item                                                                                           |
 |                 | InsertAll       | Insert all items after current (playing) item                                                                                      |
+|       `B`       | ShowInfo        | Show info about the item under cursor in a modal popup                                                                             |
 
 ### Queue
 
@@ -146,6 +147,5 @@ Keybinds specific to the queue pane.
 |   `Enter`   | Play          | Play song under cursor                                        |
 |     `a`     | AddToPlaylist | Add song under cursor to an existing playlist                 |
 |     `d`     | Delete        | Remove song under curor from the queue                        |
-|     `i`     | ShowInfo      | Show metadata of the song under cursor in a modal popup       |
 |     `C`     | JumpToCurrent | Moves the cursor in Queue table to the currently playing song |
 |     `X`     | Shuffle       | Shuffles the whole queue or selected range(s)                 |

--- a/src/config/keys/actions.rs
+++ b/src/config/keys/actions.rs
@@ -300,9 +300,9 @@ pub enum QueueActions {
     Play,
     Save,
     AddToPlaylist,
-    ShowInfo,
     JumpToCurrent,
     Shuffle,
+    Unused,
 }
 
 impl From<QueueActionsFile> for QueueActions {
@@ -313,7 +313,7 @@ impl From<QueueActionsFile> for QueueActions {
             QueueActionsFile::Play => QueueActions::Play,
             QueueActionsFile::Save => QueueActions::Save,
             QueueActionsFile::AddToPlaylist => QueueActions::AddToPlaylist,
-            QueueActionsFile::ShowInfo => QueueActions::ShowInfo,
+            QueueActionsFile::ShowInfo => QueueActions::Unused,
             QueueActionsFile::JumpToCurrent => QueueActions::JumpToCurrent,
             QueueActionsFile::Shuffle => QueueActions::Shuffle,
         }
@@ -328,7 +328,7 @@ impl ToDescription for QueueActions {
             QueueActions::Play => "Play song under cursor",
             QueueActions::Save => "Save current queue as a new playlist",
             QueueActions::AddToPlaylist => "Add song under cursor to an existing playlist",
-            QueueActions::ShowInfo => "Show metadata of the song under cursor in a modal popup",
+            QueueActions::Unused => "unused",
             QueueActions::JumpToCurrent => {
                 "Moves the cursor in Queue table to the currently playing song"
             }
@@ -376,6 +376,7 @@ pub enum CommonActionFile {
     AddAllReplace,
     Insert,
     InsertAll,
+    ShowInfo,
 }
 
 #[derive(Debug, Display, PartialEq, Eq, Hash, Clone, Copy, EnumDiscriminants)]
@@ -413,6 +414,7 @@ pub enum CommonAction {
     AddAllReplace,
     Insert,
     InsertAll,
+    ShowInfo,
 }
 
 impl ToDescription for CommonAction {
@@ -460,6 +462,7 @@ impl ToDescription for CommonAction {
             CommonAction::AddAllReplace => "Replace current queue with all items",
             CommonAction::Insert => "Add item after current song",
             CommonAction::InsertAll => "Add all items after current song",
+            CommonAction::ShowInfo => "Show info about item under cursor in a modal popup",
         }.into()
     }
 }
@@ -499,6 +502,7 @@ impl From<CommonActionFile> for CommonAction {
             CommonActionFile::AddAllReplace => CommonAction::AddAllReplace,
             CommonActionFile::Insert => CommonAction::Insert,
             CommonActionFile::InsertAll => CommonAction::InsertAll,
+            CommonActionFile::ShowInfo => CommonAction::ShowInfo,
         }
     }
 }

--- a/src/config/keys/mod.rs
+++ b/src/config/keys/mod.rs
@@ -10,7 +10,6 @@ pub use actions::{
     CommonAction,
     DirectoriesActions,
     GlobalAction,
-    PlaylistsActions,
     QueueActions,
     SearchActions,
 };
@@ -37,7 +36,6 @@ pub struct KeyConfig {
     pub albums: HashMap<Key, AlbumsActions>,
     pub artists: HashMap<Key, ArtistsActions>,
     pub directories: HashMap<Key, DirectoriesActions>,
-    pub playlists: HashMap<Key, PlaylistsActions>,
     pub search: HashMap<Key, SearchActions>,
     #[cfg(debug_assertions)]
     pub logs: HashMap<Key, LogsActions>,
@@ -50,11 +48,6 @@ pub struct KeyConfigFile {
     pub global: HashMap<Key, GlobalActionFile>,
     #[serde(default)]
     pub navigation: HashMap<Key, CommonActionFile>,
-    // pub albums: HashMap<AlbumsActions, Vec<Key>>,
-    // pub artists: HashMap<ArtistsActions, Vec<Key>>,
-    // pub directories: HashMap<DirectoriesActions, Vec<Key>>,
-    // pub playlists: HashMap<PlaylistsActions, Vec<Key>>,
-    // pub search: HashMap<SearchActions, Vec<Key>>,
     #[cfg(debug_assertions)]
     #[serde(default)]
     pub logs: HashMap<Key, LogsActionsFile>,
@@ -142,6 +135,7 @@ impl Default for KeyConfigFile {
                 (Key { key: K::Esc,       modifiers: M::NONE    }, C::Close),
                 (Key { key: K::Enter,     modifiers: M::NONE    }, C::Confirm),
                 (Key { key: K::Char('i'), modifiers: M::NONE    }, C::FocusInput),
+                (Key { key: K::Char('B'), modifiers: M::SHIFT   }, C::ShowInfo),
             ]),
             // albums: HashMap::from([
             // ]),
@@ -162,7 +156,6 @@ impl Default for KeyConfigFile {
                 (Key { key: K::Enter,     modifiers: M::NONE    }, Q::Play),
                 (Key { key: K::Char('s'), modifiers: M::CONTROL }, Q::Save),
                 (Key { key: K::Char('a'), modifiers: M::NONE    }, Q::AddToPlaylist),
-                (Key { key: K::Char('i'), modifiers: M::NONE    }, Q::ShowInfo),
                 (Key { key: K::Char('C'), modifiers: M::SHIFT   }, Q::JumpToCurrent),
                 (Key { key: K::Char('X'), modifiers: M::SHIFT   }, Q::Shuffle),
             ]),
@@ -175,14 +168,9 @@ impl From<KeyConfigFile> for KeyConfig {
         KeyConfig {
             global: value.global.into_iter().map(|(k, v)| (k, v.into())).collect(),
             navigation: value.navigation.into_iter().map(|(k, v)| (k, v.into())).collect(),
-            // albums: invert_map(value.albums),
-            // artists: invert_map(value.artists),
-            // directories: invert_map(value.directories),
-            // playlists: invert_map(value.playlists),
             albums: HashMap::new(),
             artists: HashMap::new(),
             directories: HashMap::new(),
-            playlists: HashMap::new(),
             search: HashMap::new(),
             #[cfg(debug_assertions)]
             logs: value.logs.into_iter().map(|(k, v)| (k, v.into())).collect(),
@@ -247,7 +235,6 @@ mod tests {
             albums: HashMap::from([]),
             artists: HashMap::from([]),
             directories: HashMap::from([]),
-            playlists: HashMap::from([]),
             search: HashMap::from([]),
             navigation: HashMap::from([(Key { key: KeyCode::Char('a'), modifiers: KeyModifiers::CONTROL }, CommonAction::Up),
                                        (Key { key: KeyCode::Char('b'), modifiers: KeyModifiers::SHIFT }, CommonAction::Up)]),

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -43,6 +43,9 @@ where
     fn add(&self, item: &T, context: &AppContext, position: Option<QueuePosition>) -> Result<()>;
     fn add_all(&self, context: &AppContext, position: Option<QueuePosition>) -> Result<()>;
     fn open(&mut self, context: &AppContext) -> Result<()>;
+    fn show_info(&self, item: &T, context: &AppContext) -> Result<()> {
+        Ok(())
+    }
     fn delete(&self, item: &T, index: usize, context: &AppContext) -> Result<()> {
         Ok(())
     }
@@ -401,6 +404,11 @@ where
             CommonAction::Confirm if self.stack().current().marked().is_empty() => {
                 self.open(context)?;
                 context.render()?;
+            }
+            CommonAction::ShowInfo => {
+                if let Some(item) = self.stack().current().selected() {
+                    self.show_info(item, context);
+                }
             }
             CommonAction::Confirm => {}
             CommonAction::PaneDown => {}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,10 +10,10 @@ use itertools::Itertools;
 use modals::{
     add_random_modal::AddRandomModal,
     decoders::DecodersModal,
+    info_list_modal::InfoListModal,
     input_modal::InputModal,
     keybinds::KeybindsModal,
     outputs::OutputsModal,
-    song_info::SongInfoModal,
 };
 use panes::{PaneContainer, Panes, pane_call};
 use ratatui::{
@@ -427,7 +427,14 @@ impl<'ui> Ui<'ui> {
                 }
                 GlobalAction::ShowCurrentSongInfo => {
                     if let Some((_, current_song)) = context.find_current_song_in_queue() {
-                        modal!(context, SongInfoModal::new(current_song.clone()));
+                        modal!(
+                            context,
+                            InfoListModal::builder()
+                                .items(current_song)
+                                .title("Song info")
+                                .column_widths(&[30, 70])
+                                .build()
+                        );
                     } else {
                         status_info!("No song is currently playing");
                     }

--- a/src/ui/modals/info_list_modal.rs
+++ b/src/ui/modals/info_list_modal.rs
@@ -1,4 +1,7 @@
+use std::time::Duration;
+
 use anyhow::Result;
+use bon::bon;
 use itertools::Itertools;
 use ratatui::{
     Frame,
@@ -15,6 +18,7 @@ use crate::{
     context::AppContext,
     mpd::commands::Song,
     shared::{
+        ext::duration::DurationExt,
         key_event::KeyEvent,
         macros::pop_modal,
         mouse_event::{MouseEvent, MouseEventKind},
@@ -23,17 +27,42 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub struct SongInfoModal {
+pub struct InfoListModal {
     scrolling_state: DirState<TableState>,
     table_area: Rect,
-    song: Song,
+    items: KeyValues,
+    column_widths: &'static [u16],
+    title: &'static str,
+    size: (u16, u16),
 }
 
-impl SongInfoModal {
-    pub fn new(song: Song) -> Self {
+#[derive(Debug)]
+struct KeyValues(Vec<KeyValue>);
+#[derive(Debug)]
+struct KeyValue {
+    key: String,
+    value: String,
+}
+
+#[bon]
+impl InfoListModal {
+    #[builder]
+    pub fn new(
+        items: impl Into<KeyValues>,
+        title: &'static str,
+        column_widths: &'static [u16],
+        size: Option<(u16, u16)>,
+    ) -> Self {
         let mut scrolling_state = DirState::default();
         scrolling_state.select(Some(0), 0);
-        Self { scrolling_state, song, table_area: Rect::default() }
+        Self {
+            scrolling_state,
+            items: items.into(),
+            table_area: Rect::default(),
+            title,
+            column_widths,
+            size: size.unwrap_or((80, 80)),
+        }
     }
 
     #[allow(clippy::cast_possible_truncation)]
@@ -60,9 +89,9 @@ impl SongInfoModal {
     }
 }
 
-impl Modal for SongInfoModal {
+impl Modal for InfoListModal {
     fn render(&mut self, frame: &mut Frame, app: &mut AppContext) -> Result<()> {
-        let popup_area = frame.area().centered(80, 80);
+        let popup_area = frame.area().centered(self.size.0, self.size.1);
         frame.render_widget(Clear, popup_area);
         if let Some(bg_color) = app.config.theme.modal_background_color {
             frame.render_widget(Block::default().style(Style::default().bg(bg_color)), popup_area);
@@ -73,9 +102,8 @@ impl Modal for SongInfoModal {
             .border_set(border::ROUNDED)
             .border_style(app.config.as_border_style())
             .title_alignment(ratatui::prelude::Alignment::Center)
-            .title("Song info");
+            .title(self.title);
 
-        let (key_col_width, val_col_width) = (30, 70);
         let margin = Margin { horizontal: 1, vertical: 0 };
         let [header_area, table_area] =
             Layout::vertical([Constraint::Length(2), Constraint::Percentage(100)])
@@ -83,86 +111,39 @@ impl Modal for SongInfoModal {
         let header_area = header_area.inner(margin);
         let table_area = table_area.inner(margin);
 
-        let [tag_area, mut value_area] = Layout::horizontal([
-            Constraint::Percentage(key_col_width),
-            Constraint::Percentage(val_col_width),
-        ])
-        .areas(table_area);
-        value_area.width = value_area.width.saturating_sub(1); // account for the column spacing
+        let column_constraints =
+            self.column_widths.iter().map(|w| Constraint::Percentage(*w)).collect_vec();
+        let column_areas = Layout::horizontal(&column_constraints).spacing(1).split(table_area);
 
-        let Self { song, .. } = self;
-        let mut rows = Vec::new();
-
-        rows.extend(SongInfoModal::row("File", tag_area.width, &song.file, value_area.width));
-        let file_name = song.file_name().unwrap_or_default();
-        if !file_name.is_empty() {
-            rows.extend(SongInfoModal::row(
-                "Filename",
-                tag_area.width,
-                &file_name,
-                value_area.width,
-            ));
-        }
-
-        if let Some(title) = song.metadata.get("title") {
-            rows.extend(title.iter().flat_map(|item| {
-                SongInfoModal::row("Title", tag_area.width, item, value_area.width)
-            }));
-        }
-
-        if let Some(artist) = song.metadata.get("artist") {
-            rows.extend(artist.iter().flat_map(|item| {
-                SongInfoModal::row("Artist", tag_area.width, item, value_area.width)
-            }));
-        }
-
-        if let Some(album) = song.metadata.get("album") {
-            rows.extend(album.iter().flat_map(|item| {
-                SongInfoModal::row("Album", tag_area.width, item, value_area.width)
-            }));
-        }
-
-        let duration = song.duration.as_ref().map(|d| d.as_secs().to_string()).unwrap_or_default();
-        if !duration.is_empty() {
-            rows.extend(SongInfoModal::row(
-                "Duration",
-                tag_area.width,
-                &duration,
-                value_area.width,
-            ));
-        }
-
-        rows.extend(
-            song.metadata
-                .iter()
-                .filter(|(key, _)| {
-                    !["title", "album", "artist", "duration"].contains(&(*key).as_str())
-                })
-                .flat_map(|(k, v)| {
-                    v.iter().flat_map(|item| {
-                        SongInfoModal::row(k, tag_area.width, item, value_area.width)
-                    })
-                }),
-        );
+        let rows = self
+            .items
+            .0
+            .iter()
+            .flat_map(|item| {
+                InfoListModal::row(
+                    &item.key,
+                    column_areas[0].width,
+                    &item.value,
+                    column_areas[1].width,
+                )
+            })
+            .collect_vec();
 
         self.scrolling_state.set_content_len(Some(rows.len()));
         self.scrolling_state.set_viewport_len(Some(table_area.height.into()));
 
-        let header_table = Table::new(vec![Row::new([Cell::from("Tag"), Cell::from("Value")])], [
-            Constraint::Percentage(key_col_width),
-            Constraint::Percentage(val_col_width),
-        ])
+        let header_table = Table::new(
+            vec![Row::new([Cell::from("Tag"), Cell::from("Value")])],
+            &column_constraints,
+        )
         .column_spacing(1)
         .block(
             Block::default().borders(Borders::BOTTOM).border_style(app.config.as_border_style()),
         );
-        let table = Table::new(rows, [
-            Constraint::Percentage(key_col_width),
-            Constraint::Percentage(val_col_width),
-        ])
-        .column_spacing(1)
-        .style(app.config.as_text_style())
-        .row_highlight_style(app.config.theme.current_item_style);
+        let table = Table::new(rows, &column_constraints)
+            .column_spacing(1)
+            .style(app.config.as_text_style())
+            .row_highlight_style(app.config.theme.current_item_style);
 
         self.table_area = table_area;
 
@@ -251,5 +232,92 @@ impl Modal for SongInfoModal {
         }
 
         Ok(())
+    }
+}
+
+impl From<Vec<Song>> for KeyValues {
+    fn from(value: Vec<Song>) -> Self {
+        let mut result = Vec::new();
+
+        let total_duration: Duration = value.iter().filter_map(|v| v.duration).sum();
+        let total_artists = value
+            .iter()
+            .filter_map(|v| v.metadata.get("artist"))
+            .flat_map(|tag| tag.iter())
+            .unique()
+            .count();
+        let total_albums = value
+            .iter()
+            .filter_map(|v| v.metadata.get("album"))
+            .flat_map(|tag| tag.iter())
+            .unique()
+            .count();
+        let total_genres = value
+            .iter()
+            .filter_map(|v| v.metadata.get("genre"))
+            .flat_map(|tag| tag.iter())
+            .unique()
+            .count();
+
+        result.push(KeyValue { key: "Songs".to_owned(), value: value.len().to_string() });
+        result
+            .push(KeyValue { key: "Total duration".to_owned(), value: total_duration.to_string() });
+        result.push(KeyValue { key: "Artists".to_owned(), value: total_artists.to_string() });
+        result.push(KeyValue { key: "Albums".to_owned(), value: total_albums.to_string() });
+        result.push(KeyValue { key: "Genres".to_owned(), value: total_genres.to_string() });
+        KeyValues(result)
+    }
+}
+
+impl From<&Song> for KeyValues {
+    fn from(song: &Song) -> Self {
+        let mut result = Vec::new();
+        result.push(KeyValue { key: "File".to_owned(), value: song.file.clone() });
+        let file_name = song.file_name().unwrap_or_default();
+        if !file_name.is_empty() {
+            result.push(KeyValue { key: "Filename".to_owned(), value: file_name.into_owned() });
+        }
+
+        if let Some(title) = song.metadata.get("title") {
+            result.extend(
+                title
+                    .iter()
+                    .map(|item| KeyValue { key: "Title".to_owned(), value: item.to_owned() }),
+            );
+        }
+
+        if let Some(artist) = song.metadata.get("artist") {
+            result.extend(
+                artist
+                    .iter()
+                    .map(|item| KeyValue { key: "Artist".to_owned(), value: item.to_owned() }),
+            );
+        }
+
+        if let Some(album) = song.metadata.get("album") {
+            result.extend(
+                album
+                    .iter()
+                    .map(|item| KeyValue { key: "Album".to_owned(), value: item.to_owned() }),
+            );
+        }
+
+        let duration = song.duration.as_ref().map(|d| d.as_secs().to_string()).unwrap_or_default();
+        if !duration.is_empty() {
+            result.push(KeyValue { key: "Duration".to_owned(), value: duration });
+        }
+
+        result.extend(
+            song.metadata
+                .iter()
+                .filter(|(key, _)| {
+                    !["title", "album", "artist", "duration"].contains(&(*key).as_str())
+                })
+                .flat_map(|(k, v)| {
+                    v.iter().map(|item| KeyValue { key: k.to_owned(), value: item.to_owned() })
+                }),
+        );
+
+        KeyValues(result)
     }
 }

--- a/src/ui/modals/mod.rs
+++ b/src/ui/modals/mod.rs
@@ -14,12 +14,12 @@ use crate::{
 pub mod add_random_modal;
 pub mod confirm_modal;
 pub mod decoders;
+pub mod info_list_modal;
 pub mod info_modal;
 pub mod input_modal;
 pub mod keybinds;
 pub mod outputs;
 pub mod select_modal;
-pub mod song_info;
 
 #[allow(unused)]
 pub(crate) trait Modal: std::fmt::Debug {

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -34,9 +34,9 @@ use crate::{
         dirstack::DirState,
         modals::{
             confirm_modal::ConfirmModal,
+            info_list_modal::InfoListModal,
             input_modal::InputModal,
             select_modal::SelectModal,
-            song_info::SongInfoModal,
         },
     },
 };
@@ -617,15 +617,6 @@ impl Pane for QueuePane {
                             });
                     }
                 }
-                QueueActions::ShowInfo => {
-                    if let Some(selected_song) =
-                        self.scrolling_state.get_selected().and_then(|idx| context.queue.get(idx))
-                    {
-                        modal!(context, SongInfoModal::new(selected_song.clone()));
-                    } else {
-                        status_error!("No song selected");
-                    }
-                }
                 QueueActions::Shuffle if !self.scrolling_state.marked.is_empty() => {
                     for range in self.scrolling_state.marked.ranges().rev() {
                         context.command(move |client| {
@@ -642,6 +633,7 @@ impl Pane for QueuePane {
                     });
                     status_info!("Shuffled the queue");
                 }
+                QueueActions::Unused => {}
             }
         } else if let Some(action) = event.as_common_action(context) {
             match action {
@@ -872,6 +864,22 @@ impl Pane for QueuePane {
                             client.add(&file, Some(QueuePosition::RelativeAdd(0)))?;
                             Ok(())
                         });
+                    }
+                }
+                CommonAction::ShowInfo => {
+                    if let Some(selected_song) =
+                        self.scrolling_state.get_selected().and_then(|idx| context.queue.get(idx))
+                    {
+                        modal!(
+                            context,
+                            InfoListModal::builder()
+                                .items(selected_song)
+                                .title("Song info")
+                                .column_widths(&[30, 70])
+                                .build()
+                        );
+                    } else {
+                        status_error!("No song selected");
                     }
                 }
                 CommonAction::InsertAll => {}

--- a/src/ui/panes/search.rs
+++ b/src/ui/panes/search.rs
@@ -916,6 +916,7 @@ impl Pane for SearchPane {
                         CommonAction::PaneUp => {}
                         CommonAction::PaneRight => {}
                         CommonAction::PaneLeft => {}
+                        CommonAction::ShowInfo => {}
                     }
                 }
             }
@@ -1106,6 +1107,7 @@ impl Pane for SearchPane {
                         CommonAction::PaneUp => {}
                         CommonAction::PaneRight => {}
                         CommonAction::PaneLeft => {}
+                        CommonAction::ShowInfo => {}
                     }
                 }
             }


### PR DESCRIPTION
fixes #381

This introduces a breaking change by moving `ShowInfo` from queue actions to navigation.

This is because the implementation is now more general and ready to be expanded in the other panes. The default keybind is now `B` because `i` and `I` are already taken.
