### PR TITLE
feat: initial partition support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ lists they are listed as multiple entries.
 - Add `level_styles` config option for various status message levels
 - Add filtering to the keybinds modal
 - Added info modal to the playlist
+- Added initial partition support which allows you to connect to partition specified as a CLI argument
+- Added `listpartitions` CLI
 
 ### Changed
 

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -24,6 +24,22 @@ pub struct Args {
     #[arg(short, long)]
     /// Override the MPD password
     pub password: Option<String>,
+
+    #[command(flatten)]
+    pub partition: Partition,
+}
+
+#[derive(Debug, clap::Args)]
+#[group(required = false, multiple = true)]
+pub struct Partition {
+    /// Partition to connect to at startup
+    #[clap(long)]
+    pub partition: Option<String>,
+
+    /// Automatically create the partition if it does not exist. Requires
+    /// partition to be set.
+    #[clap(long, requires = "partition")]
+    pub autocreate: bool,
 }
 
 #[derive(ValueEnum, IntoStaticStr, strum::Display, Clone, Copy, Debug, PartialEq)]
@@ -229,6 +245,8 @@ pub enum Command {
     },
     /// List currently mounted storages
     ListMounts,
+    /// List the currently existing partitions
+    ListPartitions,
     /// Manipulate and query song stickers
     Sticker {
         #[command(subcommand)]

--- a/src/core/command.rs
+++ b/src/core/command.rs
@@ -314,6 +314,10 @@ impl Command {
                 println!("{}", serde_json::ser::to_string(&client.list_mounts()?)?);
                 Ok(())
             })),
+            Command::ListPartitions => Ok(Box::new(|client| {
+                println!("{}", serde_json::ser::to_string(&client.list_partitions()?.0)?);
+                Ok(())
+            })),
             Command::AlbumArt { output } => Ok(Box::new(move |client| {
                 let Some(song) = client.get_current_song()? else {
                     std::process::exit(3);

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,8 @@ fn main() -> Result<()> {
                 std::mem::take(&mut config.address),
                 std::mem::take(&mut config.password),
                 "main",
+                args.partition.partition,
+                args.partition.autocreate,
             )?;
             client.set_read_timeout(None)?;
             (cmd.execute(&config)?)(&mut client)?;
@@ -222,9 +224,14 @@ fn main() -> Result<()> {
             }
             event_tx.send(AppEvent::RequestRender).context("Failed to render first frame")?;
 
-            let mut client =
-                Client::init(config.address.clone(), config.password.clone(), "command")
-                    .context("Failed to connect to MPD")?;
+            let mut client = Client::init(
+                config.address.clone(),
+                config.password.clone(),
+                "command",
+                args.partition.partition,
+                args.partition.autocreate,
+            )
+            .context("Failed to connect to MPD")?;
             client.set_read_timeout(Some(config.mpd_read_timeout))?;
             client.set_write_timeout(Some(config.mpd_write_timeout))?;
 

--- a/src/mpd/mpd_client.rs
+++ b/src/mpd/mpd_client.rs
@@ -216,6 +216,13 @@ pub trait MpdClient: Sized {
     // Searches the sticker database for stickers with the specified name, below
     // the specified directory (URI).
     fn find_stickers(&mut self, uri: &str, name: &str) -> MpdResult<StickersWithFile>;
+
+    // Partitions
+    fn switch_to_partition(&mut self, name: &str) -> MpdResult<()>;
+    fn new_partition(&mut self, name: &str) -> MpdResult<()>;
+    fn delete_partition(&mut self, name: &str) -> MpdResult<()>;
+    fn list_partitions(&mut self) -> MpdResult<MpdList>;
+    fn move_output(&mut self, output_name: &str) -> MpdResult<()>;
 }
 
 fn read_response<T: Default + FromMpd, S: SocketClient>(
@@ -890,6 +897,26 @@ impl MpdClient for Client<'_> {
             key.quote_and_escape()
         ))
         .and_then(read_response)
+    }
+
+    fn switch_to_partition(&mut self, name: &str) -> MpdResult<()> {
+        self.send(&format!("partition {}", name.quote_and_escape())).and_then(read_ok)
+    }
+
+    fn new_partition(&mut self, name: &str) -> MpdResult<()> {
+        self.send(&format!("newpartition {}", name.quote_and_escape())).and_then(read_ok)
+    }
+
+    fn list_partitions(&mut self) -> MpdResult<MpdList> {
+        self.send("listpartitions").and_then(read_response)
+    }
+
+    fn delete_partition(&mut self, name: &str) -> MpdResult<()> {
+        self.send(&format!("delpartition {}", name.quote_and_escape())).and_then(read_ok)
+    }
+
+    fn move_output(&mut self, output_name: &str) -> MpdResult<()> {
+        self.send(&format!("moveoutput {}", output_name.quote_and_escape())).and_then(read_ok)
     }
 }
 

--- a/src/tests/fixtures/mpd_client.rs
+++ b/src/tests/fixtures/mpd_client.rs
@@ -636,6 +636,26 @@ impl MpdClient for TestMpdClient {
     ) -> MpdResult<crate::mpd::commands::stickers::StickersWithFile> {
         todo!("Not yet implemented")
     }
+
+    fn switch_to_partition(&mut self, _name: &str) -> MpdResult<()> {
+        todo!("Not yet implemented")
+    }
+
+    fn new_partition(&mut self, _name: &str) -> MpdResult<()> {
+        todo!("Not yet implemented")
+    }
+
+    fn delete_partition(&mut self, _name: &str) -> MpdResult<()> {
+        todo!("Not yet implemented")
+    }
+
+    fn list_partitions(&mut self) -> MpdResult<MpdList> {
+        todo!("Not yet implemented")
+    }
+
+    fn move_output(&mut self, _output_name: &str) -> MpdResult<()> {
+        todo!("Not yet implemented")
+    }
 }
 
 impl SocketClient for TestMpdClient {


### PR DESCRIPTION
this introduces `listpartitions` command and `--partition` + `--autocreate` arguments to the CLI which allows you to connect to a specified MPD partition

they should work for both the tui and CLI
