### PR TITLE
Fix: Lyrics files with ']' in the metadata fields not getting indexed and title not getting matched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ lists they are listed as multiple entries.
 ### Fixed
 
 - Lyrics with fractions of seconds which weren't to 2s.f. being parsed incorrectly
+- Lyrics with metadata fields containing ']' not being indexed
 - Album art staying on the old one when in tmux and not visible
 - Fixed catpuccin theme not being up to date in the docs
 - Handle invalid utf8 characters

--- a/src/shared/lrc/index.rs
+++ b/src/shared/lrc/index.rs
@@ -70,7 +70,7 @@ impl LrcIndex {
     pub fn find_lrc_for_song(&self, song: &Song) -> Result<Option<Lrc>> {
         match (
             song.metadata.get("artist"),
-            song.metadata.get("artist"),
+            song.metadata.get("title"),
             song.metadata.get("album"),
             song.duration,
         ) {

--- a/src/shared/lrc/index.rs
+++ b/src/shared/lrc/index.rs
@@ -134,11 +134,8 @@ impl LrcIndexEntry {
             let metadata = buf
                 .trim()
                 .strip_prefix('[')
+                .and_then(|s| s.strip_suffix(']'))
                 .with_context(|| format!("Invalid lrc line format: '{buf}'"))?;
-            if !metadata.ends_with(']') {
-                break;
-            }
-            let metadata = &metadata[..metadata.len() - 1];
 
             match metadata.chars().next() {
                 Some(c) if c.is_numeric() => {

--- a/src/shared/lrc/index.rs
+++ b/src/shared/lrc/index.rs
@@ -81,7 +81,7 @@ impl LrcIndex {
                 match lrc_opt {
                     None => log::trace!("No Lyrics found for {:?}", song.metadata),
                     Some(lrc) => log::trace!("Lyrics found at {:?}", lrc.path),
-                };
+                }
                 lrc_opt
             }
             _ => None,

--- a/src/shared/lrc/index.rs
+++ b/src/shared/lrc/index.rs
@@ -131,11 +131,14 @@ impl LrcIndexEntry {
                 continue;
             }
 
-            let metadata = buf
+            let (metadata, rest) = buf
                 .trim()
                 .strip_prefix('[')
-                .and_then(|s| s.strip_suffix(']'))
+                .and_then(|s| s.rsplit_once(']'))
                 .with_context(|| format!("Invalid lrc line format: '{buf}'"))?;
+            if !rest.is_empty() {
+                break;
+            }
 
             match metadata.chars().next() {
                 Some(c) if c.is_numeric() => {


### PR DESCRIPTION
I've noticed that titles that include a closing bracket (like "some song title [Explicit]") didn't get indexed.
During debugging this, I found that the artist metadata field is passed twice to the find_lrc function.

This PR fixes this.

I had some more issues trying to get my .lrc files to be read/matched, though they might be too specific/uncommon to bother fixing:
- Files that start with [BOMs](https://de.wikipedia.org/wiki/Byte_Order_Mark) fail to be parsed
- Length mismatches, which made me wonder if matching the length is truly nessesary
- Some .lrc files missing an album metadata field, resulting in them not getting indexed