### PR TITLE
Add lyrics style to theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ lists they are listed as multiple entries.
 - Added info modal to the playlist
 - Added initial partition support which allows you to connect to partition specified as a CLI argument
 - Added `listpartitions` CLI
+- Added `lyrics` config option for lyrics pane lines
 
 ### Changed
 

--- a/docs/src/content/docs/next/configuration/theme.mdx
+++ b/docs/src/content/docs/next/configuration/theme.mdx
@@ -289,3 +289,19 @@ Configuration of the header. Header is displayed at the top of the window. It ca
 player state and custom widgets. This property is described in its own page:
 
 <LinkCard title="header" description="Configuration of the window header" href={path("configuration/header/")} />
+
+### lyrics
+
+Configures the styles of the lyrics pane.
+
+### lyrics.active_line_style
+
+<ConfigValue name="active_line_style" type="other" customText="<style>" />
+
+Styles Currently active line
+
+### lyrics.line_style
+
+<ConfigValue name="line_style" type="other" customText="<style>" />
+
+Styles for each line of the lyrics

--- a/src/config/theme/lyrics.rs
+++ b/src/config/theme/lyrics.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use ratatui::style::{Color, Style};
 use serde::{Deserialize, Serialize};
 
-use super::{Modifiers, StyleFile, style::ToConfigOr};
+use super::{StyleFile, style::ToConfigOr};
 
 #[derive(Debug, Default, Clone)]
 pub struct LyricsConfig {
@@ -12,24 +12,13 @@ pub struct LyricsConfig {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LyricsConfigFile {
-    pub(super) active_line_style: Option<StyleFile>,
-    pub(super) line_style: Option<StyleFile>,
+    pub(super) active_line_style: StyleFile,
+    pub(super) line_style: StyleFile,
 }
 
 impl Default for LyricsConfigFile {
     fn default() -> Self {
-        Self {
-            active_line_style: Some(StyleFile {
-                fg: Some("blue".to_string()),
-                bg: None,
-                modifiers: Some(Modifiers::Bold),
-            }),
-            line_style: Some(StyleFile {
-                fg: Some("white".to_string()),
-                bg: None,
-                modifiers: Some(Modifiers::Dim),
-            }),
-        }
+        Self { active_line_style: StyleFile::default(), line_style: StyleFile::default() }
     }
 }
 

--- a/src/config/theme/lyrics.rs
+++ b/src/config/theme/lyrics.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+use ratatui::style::{Color, Style};
+use serde::{Deserialize, Serialize};
+
+use super::{Modifiers, StyleFile, style::ToConfigOr};
+
+#[derive(Debug, Default, Clone)]
+pub struct LyricsConfig {
+    pub active_line_style: Style,
+    pub line_style: Style,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LyricsConfigFile {
+    pub(super) active_line_style: Option<StyleFile>,
+    pub(super) line_style: Option<StyleFile>,
+}
+
+impl Default for LyricsConfigFile {
+    fn default() -> Self {
+        Self {
+            active_line_style: Some(StyleFile {
+                fg: Some("blue".to_string()),
+                bg: None,
+                modifiers: Some(Modifiers::Bold),
+            }),
+            line_style: Some(StyleFile {
+                fg: Some("white".to_string()),
+                bg: None,
+                modifiers: Some(Modifiers::Dim),
+            }),
+        }
+    }
+}
+
+impl LyricsConfigFile {
+    pub(super) fn into_config(self) -> Result<LyricsConfig> {
+        Ok(LyricsConfig {
+            active_line_style: self.active_line_style.to_config_or(Some(Color::Blue), None)?,
+            line_style: self.line_style.to_config_or(Some(Color::White), None)?,
+        })
+    }
+}

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -6,6 +6,7 @@ use ratatui::style::{Color, Style};
 
 use self::{
     header::{HeaderConfig, HeaderConfigFile},
+    lyrics::{LyricsConfig, LyricsConfigFile},
     progress_bar::{ProgressBarConfig, ProgressBarConfigFile},
     queue_table::{QueueTableColumns, QueueTableColumnsFile},
     scrollbar::ScrollbarConfig,
@@ -14,6 +15,7 @@ use self::{
 
 mod header;
 pub mod level_styles;
+mod lyrics;
 mod progress_bar;
 pub mod properties;
 mod queue_table;
@@ -62,6 +64,7 @@ pub struct UiConfig {
     pub layout: SizedPaneOrSplit,
     pub format_tag_separator: String,
     pub level_styles: LevelStyles,
+    pub lyrics: LyricsConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -101,6 +104,7 @@ pub struct UiConfigFile {
     pub(super) format_tag_separator: String,
     #[serde(default)]
     pub(super) level_styles: LevelStylesFile,
+    pub(super) lyrics: LyricsConfigFile,
 }
 
 impl Default for UiConfigFile {
@@ -168,6 +172,7 @@ impl Default for UiConfigFile {
                 modifiers: Some(Modifiers::Bold),
             },
             level_styles: LevelStylesFile::default(),
+            lyrics: LyricsConfigFile::default(),
         }
     }
 }
@@ -274,6 +279,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
                 .preview_metadata_group_style
                 .to_config_or(None, None)?,
             level_styles: value.level_styles.try_into()?,
+            lyrics: value.lyrics.into_config()?,
         })
     }
 }

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -104,6 +104,7 @@ pub struct UiConfigFile {
     pub(super) format_tag_separator: String,
     #[serde(default)]
     pub(super) level_styles: LevelStylesFile,
+    #[serde(default)]
     pub(super) lyrics: LyricsConfigFile,
 }
 

--- a/src/ui/panes/lyrics.rs
+++ b/src/ui/panes/lyrics.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
-    style::Style,
     text::Text,
 };
 
@@ -43,10 +42,11 @@ impl Pane for LyricsPane {
         let areas = Layout::vertical((0..rows).map(|_| Constraint::Length(1))).split(area);
         let middle_row = rows / 2;
 
+        let default_style = context.config.theme.lyrics.line_style;
         let middle_style = if first_line_reached {
-            context.config.theme.highlighted_item_style
+            context.config.theme.lyrics.active_line_style
         } else {
-            Style::default().fg(context.config.theme.text_color.unwrap_or_default())
+            default_style
         };
 
         let mut current_area = middle_row as usize;
@@ -54,10 +54,11 @@ impl Pane for LyricsPane {
             return Ok(());
         };
         for line in textwrap::wrap(&current_line.content, area.width as usize) {
+            let p = Text::from(line).centered().style(middle_style);
             let Some(area) = areas.get(current_area) else {
                 break;
             };
-            frame.render_widget(Text::from(line).centered().style(middle_style), *area);
+            frame.render_widget(p, *area);
             current_area += 1;
         }
 
@@ -69,9 +70,7 @@ impl Pane for LyricsPane {
                 break;
             };
             for l in textwrap::wrap(&line.content, area.width as usize).iter().rev() {
-                let p = Text::from(l.clone()).centered().style(
-                    Style::default().fg(context.config.theme.text_color.unwrap_or_default()),
-                );
+                let p = Text::from(l.clone()).centered().style(default_style);
                 if before_area_cursor == 0 {
                     break;
                 }
@@ -94,9 +93,7 @@ impl Pane for LyricsPane {
                 break;
             };
             for l in textwrap::wrap(&line.content, area.width as usize) {
-                let p = Text::from(l).centered().style(
-                    Style::default().fg(context.config.theme.text_color.unwrap_or_default()),
-                );
+                let p = Text::from(l).centered().style(default_style);
                 let Some(area) = areas.get(after_area_cursor + 1) else {
                     break;
                 };


### PR DESCRIPTION
hello, i tried to add lyrics styles to the theme folder, for now only two properties which are active_line_style and line_style
it seems everything is working properly
although i couldn't figure out how to get `rmpc theme` to add the new config part to the output
also i couldn't find a way to add default modifers

but now you can do something like this:

![image](https://github.com/user-attachments/assets/e4229a26-9171-4aad-8a06-df48e05044b3)
