### PR TITLE
feat: multiple tag resolution strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ lists they are listed as multiple entries.
 - Added components to the theme. Components are user-defined reusable parts of TUI.
 - Added `rewind_to_start_sec` config option. If elapsed time is past the configured value, the song will be rewound to start instead.
 - Added `reflect_changes_to_playlist` config option. This makes changes to the queue reflect to the stored playlist if any.
+- Added `mutliple_tag_resolution_strategy` to choose which tag value to display when multiple values are present
 
 ### Changed
 

--- a/docs/src/content/docs/next/configuration/theme.mdx
+++ b/docs/src/content/docs/next/configuration/theme.mdx
@@ -257,6 +257,14 @@ Style for all tabs except the active one.
 Use this to separate entries when a song has multiple values for a tag. For example, a song with
 two values for `artist` and `|` as a separator will show `artist1 | artist2`. Default is `|`.
 
+### mutliple_tag_resolution_strategy
+
+<ConfigValue name="mutliple_tag_resolution_strategy" type={["All", "First", "Last", "Nth(<number>)"]} />
+
+What strategy to choose when a song has multiple values for a tag. `All` uses #format_tag_separator to join
+all values to one. `First` and `Last` choose the first and last value respectively and `Nth` chooses exactly
+which one to take. Last value is used when index given to `Nth` is larger than the count of available values.
+
 ### song_table_format
 
 <ConfigValue

--- a/src/mpd/commands/metadata_tag.rs
+++ b/src/mpd/commands/metadata_tag.rs
@@ -37,6 +37,16 @@ pub trait MetadataTagExt<'s> {
 }
 
 impl MetadataTag {
+    pub fn first(&self) -> &str {
+        match self {
+            MetadataTag::Single(v) => v.as_str(),
+            MetadataTag::Multiple(items) => items
+                .first()
+                .map(|s| s.as_str())
+                .expect("Multiple tags to contain at least one value"),
+        }
+    }
+
     pub fn last(&self) -> &str {
         match self {
             MetadataTag::Single(v) => v.as_str(),
@@ -44,6 +54,17 @@ impl MetadataTag {
                 .last()
                 .map(|s| s.as_str())
                 .expect("Multiple tags to contain at least one value"),
+        }
+    }
+
+    pub fn nth(&self, idx: usize) -> &str {
+        match self {
+            MetadataTag::Single(v) => v.as_str(),
+            MetadataTag::Multiple(items) => {
+                if idx >= items.len() { items.last() } else { items.get(idx) }
+                    .map(|s| s.as_str())
+                    .expect("Multiple tags to contain at least one value")
+            }
         }
     }
 

--- a/src/ui/dir_or_song.rs
+++ b/src/ui/dir_or_song.rs
@@ -3,7 +3,10 @@ use std::{borrow::Cow, cmp::Ordering};
 use unicase::UniCase;
 
 use crate::{
-    config::sort_mode::{SortMode, SortOptions},
+    config::{
+        sort_mode::{SortMode, SortOptions},
+        theme::TagResolutionStrategy,
+    },
     mpd::commands::{Song, lsinfo::LsInfoEntry},
 };
 
@@ -122,7 +125,7 @@ impl Ord for DirOrSongCustomSort<'_, '_> {
                 }
                 (DirOrSong::Song(song), DirOrSong::Dir { name, .. }) => {
                     for prop in items {
-                        let s = song.format(prop, "");
+                        let s = song.format(prop, "", TagResolutionStrategy::All);
                         if let Some(s) = s {
                             let result = UniCase::new(s.as_ref()).cmp(&UniCase::new(name));
                             if result != Ordering::Equal {
@@ -134,7 +137,7 @@ impl Ord for DirOrSongCustomSort<'_, '_> {
                 }
                 (DirOrSong::Dir { name, .. }, DirOrSong::Song(song)) => {
                     for prop in items {
-                        let s = song.format(prop, "");
+                        let s = song.format(prop, "", TagResolutionStrategy::All);
                         if let Some(s) = s {
                             let result = UniCase::new(name.as_str()).cmp(&UniCase::new(s.as_ref()));
                             if result != Ordering::Equal {

--- a/src/ui/dirstack/mod.rs
+++ b/src/ui/dirstack/mod.rs
@@ -74,8 +74,12 @@ impl DirStackItem for DirOrSong {
                         .into_iter()
                         .chain(config.theme.browser_song_format.0.iter().map(|prop| {
                             Span::from(
-                                prop.as_string(Some(s), &config.theme.format_tag_separator)
-                                    .unwrap_or_default(),
+                                prop.as_string(
+                                    Some(s),
+                                    &config.theme.format_tag_separator,
+                                    config.theme.mutliple_tag_resolution_strategy,
+                                )
+                                .unwrap_or_default(),
                             )
                         }));
                 Line::from(spans.collect_vec())

--- a/src/ui/panes/property.rs
+++ b/src/ui/panes/property.rs
@@ -37,7 +37,12 @@ impl Pane for PropertyPane<'_> {
         let song = context.find_current_song_in_queue().map(|(_, song)| song);
 
         let line = Line::from(self.content.iter().fold(Vec::new(), |mut acc, val| {
-            match val.as_span(song, context, &context.config.theme.format_tag_separator) {
+            match val.as_span(
+                song,
+                context,
+                &context.config.theme.format_tag_separator,
+                context.config.theme.mutliple_tag_resolution_strategy,
+            ) {
                 Some(Either::Left(span)) => acc.push(span),
                 Some(Either::Right(ref mut spans)) => acc.append(spans),
                 None => {}

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -175,6 +175,7 @@ impl Pane for QueuePane {
                             max_len,
                             &config.theme.symbols,
                             &config.theme.format_tag_separator,
+                            config.theme.mutliple_tag_resolution_strategy,
                         )
                         .unwrap_or_default()
                         .alignment(formats[i].alignment.into());

--- a/src/ui/widgets/header.rs
+++ b/src/ui/widgets/header.rs
@@ -64,7 +64,12 @@ impl<'a> PropertyTemplates<'a> {
         config: &Config,
     ) -> Line<'a> {
         Line::from(self.0.iter().fold(Vec::new(), |mut acc, val| {
-            match val.as_span(song, context, &config.theme.format_tag_separator) {
+            match val.as_span(
+                song,
+                context,
+                &config.theme.format_tag_separator,
+                config.theme.mutliple_tag_resolution_strategy,
+            ) {
                 Some(Either::Left(span)) => acc.push(span),
                 Some(Either::Right(ref mut spans)) => acc.append(spans),
                 None => {}


### PR DESCRIPTION
## Description

Finally getting to make a change for myself :smile:, When multiple values for a single tag are present, use `mutliple_tag_resolution_strategy` to determine which one to display. Defaults to `All`.

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
