### PR TITLE
feat: partial tui partitions impl

### DIFF
--- a/src/config/keys/actions.rs
+++ b/src/config/keys/actions.rs
@@ -16,6 +16,7 @@ pub enum GlobalAction {
     ShowCurrentSongInfo,
     ShowOutputs,
     ShowDecoders,
+    SwitchPartition,
     AddRandom,
     NextTrack,
     PreviousTrack,
@@ -57,6 +58,7 @@ pub enum GlobalActionFile {
     ShowCurrentSongInfo,
     ShowOutputs,
     ShowDecoders,
+    SwitchPartition,
     NextTrack,
     PreviousTrack,
     Stop,
@@ -134,6 +136,7 @@ impl From<GlobalActionFile> for GlobalAction {
             GlobalActionFile::AddRandom => GlobalAction::AddRandom,
             GlobalActionFile::ToggleSingleOnOff => GlobalAction::ToggleSingleOnOff,
             GlobalActionFile::ToggleConsumeOnOff => GlobalAction::ToggleConsumeOnOff,
+            GlobalActionFile::SwitchPartition => GlobalAction::SwitchPartition,
         }
     }
 }
@@ -177,6 +180,7 @@ impl ToDescription for GlobalAction {
             GlobalAction::AddRandom => "Add random songs to the queue".into(),
             GlobalAction::ToggleSingleOnOff => "Toggle single mode on or off, skipping oneshot".into(),
             GlobalAction::ToggleConsumeOnOff => "Toggle consume mode on or off, skipping oneshot".into(),
+            GlobalAction::SwitchPartition => "Switch to partition".into(),
         }
     }
 }

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -449,12 +449,12 @@ impl Pane for QueuePane {
             (ADD_TO_PLAYLIST, MpdQueryResult::AddToPlaylist { playlists, song_file }) => {
                 modal!(
                     context,
-                    SelectModal::new(context)
+                    SelectModal::builder()
+                        .context(context)
                         .options(playlists)
                         .confirm_label("Add")
                         .title("Select a playlist")
-                        .on_confirm(move |context, selected: &String, _idx| {
-                            let selected = selected.to_owned();
+                        .on_confirm(move |context, selected, _idx| {
                             let song_file = song_file.clone();
                             context.command(move |client| {
                                 if song_file.starts_with('/') {
@@ -471,6 +471,7 @@ impl Pane for QueuePane {
                             });
                             Ok(())
                         })
+                        .build()
                 );
             }
             _ => {}


### PR DESCRIPTION
## Description

This is a partial implementation and a subject to change (will change more likely than not). Thus no documentation at this point.

Adds `SwitchPartition` global action which displays a modal with existing partitions and allows you to switch between them. Cannot create a partition in TUI yet.

