### PR TITLE
Add lyrics config option to show line timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ lists they are listed as multiple entries.
 - Added info modal to the playlist
 - Added initial partition support which allows you to connect to partition specified as a CLI argument
 - Added `listpartitions` CLI
-- Added `lyrics` config option for showing line timestamp
+- Added `lyrics` config option `timestamp` for showing line timestamp
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ lists they are listed as multiple entries.
 - Added info modal to the playlist
 - Added initial partition support which allows you to connect to partition specified as a CLI argument
 - Added `listpartitions` CLI
+- Added `lyrics` config option for showing line timestamp
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ lists they are listed as multiple entries.
 - Added info modal to the playlist
 - Added initial partition support which allows you to connect to partition specified as a CLI argument
 - Added `listpartitions` CLI
-
 - Added Start and End Boundaries to ProgressBar increasing its Customizability
 - Added components to the theme. Components are user-defined reusable parts of TUI.
 - Added `rewind_to_start_sec` config option. If elapsed time is past the configured value, the song will be rewound to start instead.

--- a/docs/src/content/docs/next/assets/example_theme.ron
+++ b/docs/src/content/docs/next/assets/example_theme.ron
@@ -155,5 +155,7 @@
             default: (kind: Property(Filename))
         ),
     ],
+    lyrics: (
+        show_timestamp: false
+    )
 )
-

--- a/docs/src/content/docs/next/assets/example_theme.ron
+++ b/docs/src/content/docs/next/assets/example_theme.ron
@@ -156,6 +156,6 @@
         ),
     ],
     lyrics: (
-        show_timestamp: false
+        timestamp: false
     )
 )

--- a/docs/src/content/docs/next/configuration/theme.mdx
+++ b/docs/src/content/docs/next/configuration/theme.mdx
@@ -289,3 +289,11 @@ Configuration of the header. Header is displayed at the top of the window. It ca
 player state and custom widgets. This property is described in its own page:
 
 <LinkCard title="header" description="Configuration of the window header" href={path("configuration/header/")} />
+
+### lyrics
+
+### lyrics.show_timestamp
+
+<ConfigValue name="lyrics.show_timestamp" type="boolean" default="false" />
+
+Sets the visibility of the timestamps in the lyrics pane.

--- a/docs/src/content/docs/next/configuration/theme.mdx
+++ b/docs/src/content/docs/next/configuration/theme.mdx
@@ -292,8 +292,8 @@ player state and custom widgets. This property is described in its own page:
 
 ### lyrics
 
-### lyrics.show_timestamp
+### lyrics.timestamp
 
-<ConfigValue name="lyrics.show_timestamp" type="boolean" default="false" />
+<ConfigValue name="lyrics.timestamp" type="boolean" default="false" />
 
 Sets the visibility of the timestamps in the lyrics pane.

--- a/src/config/theme/lyrics.rs
+++ b/src/config/theme/lyrics.rs
@@ -1,20 +1,17 @@
-use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Clone)]
 pub struct LyricsConfig {
-    pub show_timestamp: bool,
+    pub timestamp: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct LyricsConfigFile {
-    pub(super) show_timestamp: bool,
+    pub(super) timestamp: bool,
 }
 
-impl TryFrom<LyricsConfigFile> for LyricsConfig {
-    type Error = anyhow::Error;
-
-    fn try_from(value: LyricsConfigFile) -> Result<Self> {
-        Ok(LyricsConfig { show_timestamp: value.show_timestamp })
+impl From<LyricsConfigFile> for LyricsConfig {
+    fn from(value: LyricsConfigFile) -> Self {
+        LyricsConfig { timestamp: value.timestamp }
     }
 }

--- a/src/config/theme/lyrics.rs
+++ b/src/config/theme/lyrics.rs
@@ -6,19 +6,15 @@ pub struct LyricsConfig {
     pub show_timestamp: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct LyricsConfigFile {
     pub(super) show_timestamp: bool,
 }
 
-impl Default for LyricsConfigFile {
-    fn default() -> Self {
-        Self { show_timestamp: false }
-    }
-}
+impl TryFrom<LyricsConfigFile> for LyricsConfig {
+    type Error = anyhow::Error;
 
-impl LyricsConfigFile {
-    pub(super) fn into_config(self) -> Result<LyricsConfig> {
-        Ok(LyricsConfig { show_timestamp: self.show_timestamp })
+    fn try_from(value: LyricsConfigFile) -> Result<Self> {
+        Ok(LyricsConfig { show_timestamp: value.show_timestamp })
     }
 }

--- a/src/config/theme/lyrics.rs
+++ b/src/config/theme/lyrics.rs
@@ -1,0 +1,24 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Clone)]
+pub struct LyricsConfig {
+    pub show_timestamp: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LyricsConfigFile {
+    pub(super) show_timestamp: bool,
+}
+
+impl Default for LyricsConfigFile {
+    fn default() -> Self {
+        Self { show_timestamp: false }
+    }
+}
+
+impl LyricsConfigFile {
+    pub(super) fn into_config(self) -> Result<LyricsConfig> {
+        Ok(LyricsConfig { show_timestamp: self.show_timestamp })
+    }
+}

--- a/src/config/theme/lyrics.rs
+++ b/src/config/theme/lyrics.rs
@@ -7,6 +7,7 @@ pub struct LyricsConfig {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct LyricsConfigFile {
+    #[serde(default)]
     pub(super) timestamp: bool,
 }
 

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -280,7 +280,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
                 .preview_metadata_group_style
                 .to_config_or(None, None)?,
             level_styles: value.level_styles.try_into()?,
-            lyrics: value.lyrics.into_config()?,
+            lyrics: value.lyrics.try_into()?,
         })
     }
 }

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -280,7 +280,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
                 .preview_metadata_group_style
                 .to_config_or(None, None)?,
             level_styles: value.level_styles.try_into()?,
-            lyrics: value.lyrics.try_into()?,
+            lyrics: value.lyrics.into(),
         })
     }
 }

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -6,6 +6,7 @@ use ratatui::style::{Color, Style};
 
 use self::{
     header::{HeaderConfig, HeaderConfigFile},
+    lyrics::{LyricsConfig, LyricsConfigFile},
     progress_bar::{ProgressBarConfig, ProgressBarConfigFile},
     queue_table::{QueueTableColumns, QueueTableColumnsFile},
     scrollbar::ScrollbarConfig,
@@ -14,6 +15,7 @@ use self::{
 
 mod header;
 pub mod level_styles;
+mod lyrics;
 mod progress_bar;
 pub mod properties;
 mod queue_table;
@@ -62,6 +64,7 @@ pub struct UiConfig {
     pub layout: SizedPaneOrSplit,
     pub format_tag_separator: String,
     pub level_styles: LevelStyles,
+    pub lyrics: LyricsConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -101,6 +104,8 @@ pub struct UiConfigFile {
     pub(super) format_tag_separator: String,
     #[serde(default)]
     pub(super) level_styles: LevelStylesFile,
+    #[serde(default)]
+    pub(super) lyrics: LyricsConfigFile,
 }
 
 impl Default for UiConfigFile {
@@ -168,6 +173,7 @@ impl Default for UiConfigFile {
                 modifiers: Some(Modifiers::Bold),
             },
             level_styles: LevelStylesFile::default(),
+            lyrics: LyricsConfigFile::default(),
         }
     }
 }
@@ -274,6 +280,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
                 .preview_metadata_group_style
                 .to_config_or(None, None)?,
             level_styles: value.level_styles.try_into()?,
+            lyrics: value.lyrics.into_config()?,
         })
     }
 }

--- a/src/ui/panes/lyrics.rs
+++ b/src/ui/panes/lyrics.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use anyhow::Result;
 use ratatui::{
     Frame,
@@ -66,19 +64,16 @@ impl Pane for LyricsPane {
         let Some(current_line) = lrc.lines.get(current_line_idx) else {
             return Ok(());
         };
-        for (index, l) in
-            textwrap::wrap(&current_line.content, area.width as usize).into_iter().enumerate()
-        {
+        let formatted_line = if timestamp && !current_line.content.is_empty() {
+            &format!("[{}] {}", current_line.time.to_string(), current_line.content)
+        } else {
+            &current_line.content
+        };
+        for l in textwrap::wrap(formatted_line, area.width as usize) {
             let Some(area) = areas.get(current_area) else {
                 break;
             };
-            let text = Text::from(if index == 0 && timestamp && !l.is_empty() {
-                Cow::Owned(format!("[{}] {}", current_line.time.to_string(), l))
-            } else {
-                l
-            })
-            .centered()
-            .style(middle_style);
+            let text = Text::from(l.clone()).centered().style(middle_style);
             frame.render_widget(text, *area);
             current_area += 1;
         }
@@ -90,22 +85,19 @@ impl Pane for LyricsPane {
             let Some(line) = lrc.lines.get(before_lyrics_cursor) else {
                 break;
             };
-            for (index, l) in
-                textwrap::wrap(&line.content, area.width as usize).into_iter().enumerate().rev()
-            {
+            let formatted_line = if timestamp && !line.content.is_empty() {
+                &format!("[{}] {}", line.time.to_string(), line.content)
+            } else {
+                &line.content
+            };
+            for l in textwrap::wrap(formatted_line, area.width as usize).iter().rev() {
                 if before_area_cursor == 0 {
                     break;
                 }
                 let Some(area) = areas.get(before_area_cursor - 1) else {
                     break;
                 };
-                let text = Text::from(if index == 0 && timestamp && !l.is_empty() {
-                    Cow::Owned(format!("[{}] {}", line.time.to_string(), l))
-                } else {
-                    l
-                })
-                .centered()
-                .style(default_style);
+                let text = Text::from(l.clone()).centered().style(default_style);
 
                 frame.render_widget(text, *area);
                 before_area_cursor -= 1;
@@ -122,19 +114,16 @@ impl Pane for LyricsPane {
             let Some(line) = lrc.lines.get(after_lyrics_cursor) else {
                 break;
             };
-            for (index, l) in
-                textwrap::wrap(&line.content, area.width as usize).into_iter().enumerate()
-            {
+            let formatted_line = if timestamp && !line.content.is_empty() {
+                &format!("[{}] {}", line.time.to_string(), line.content)
+            } else {
+                &line.content
+            };
+            for l in textwrap::wrap(formatted_line, area.width as usize) {
                 let Some(area) = areas.get(after_area_cursor + 1) else {
                     break;
                 };
-                let text = Text::from(if index == 0 && timestamp && !l.is_empty() {
-                    Cow::Owned(format!("[{}] {}", line.time.to_string(), l))
-                } else {
-                    l
-                })
-                .centered()
-                .style(default_style);
+                let text = Text::from(l.clone()).centered().style(default_style);
                 frame.render_widget(text, *area);
                 after_area_cursor += 1;
             }

--- a/src/ui/panes/lyrics.rs
+++ b/src/ui/panes/lyrics.rs
@@ -60,7 +60,7 @@ impl Pane for LyricsPane {
             default_style
         };
 
-        let show_timestamp = context.config.theme.lyrics.show_timestamp;
+        let timestamp = context.config.theme.lyrics.timestamp;
 
         let mut current_area = middle_row as usize;
         let Some(current_line) = lrc.lines.get(current_line_idx) else {
@@ -72,7 +72,7 @@ impl Pane for LyricsPane {
             let Some(area) = areas.get(current_area) else {
                 break;
             };
-            let text = Text::from(if index == 0 && show_timestamp && !l.is_empty() {
+            let text = Text::from(if index == 0 && timestamp && !l.is_empty() {
                 Cow::Owned(format!("[{}] {}", current_line.time.to_string(), l))
             } else {
                 l
@@ -93,13 +93,13 @@ impl Pane for LyricsPane {
             for (index, l) in
                 textwrap::wrap(&line.content, area.width as usize).into_iter().enumerate().rev()
             {
-                let Some(area) = areas.get(before_area_cursor - 1) else {
-                    break;
-                };
                 if before_area_cursor == 0 {
                     break;
                 }
-                let text = Text::from(if index == 0 && show_timestamp && !l.is_empty() {
+                let Some(area) = areas.get(before_area_cursor - 1) else {
+                    break;
+                };
+                let text = Text::from(if index == 0 && timestamp && !l.is_empty() {
                     Cow::Owned(format!("[{}] {}", line.time.to_string(), l))
                 } else {
                     l
@@ -128,7 +128,7 @@ impl Pane for LyricsPane {
                 let Some(area) = areas.get(after_area_cursor + 1) else {
                     break;
                 };
-                let text = Text::from(if index == 0 && show_timestamp && !l.is_empty() {
+                let text = Text::from(if index == 0 && timestamp && !l.is_empty() {
                     Cow::Owned(format!("[{}] {}", line.time.to_string(), l))
                 } else {
                     l

--- a/src/ui/panes/lyrics.rs
+++ b/src/ui/panes/lyrics.rs
@@ -64,8 +64,10 @@ impl Pane for LyricsPane {
         let Some(current_line) = lrc.lines.get(current_line_idx) else {
             return Ok(());
         };
-        for l in textwrap::wrap(&current_line.content, area.width as usize) {
-            let content = if show_timestamp && !l.is_empty() {
+        for (index, l) in
+            textwrap::wrap(&current_line.content, area.width as usize).into_iter().enumerate()
+        {
+            let content = if index == 0 && show_timestamp && !l.is_empty() {
                 format!("[{}] {}", current_line.time.to_string(), l)
             } else {
                 l.to_string()
@@ -85,8 +87,10 @@ impl Pane for LyricsPane {
             let Some(line) = lrc.lines.get(before_lyrics_cursor) else {
                 break;
             };
-            for l in textwrap::wrap(&line.content, area.width as usize).iter().rev() {
-                let content = if show_timestamp && !l.is_empty() {
+            for (index, l) in
+                textwrap::wrap(&line.content, area.width as usize).into_iter().enumerate().rev()
+            {
+                let content = if index == 0 && show_timestamp && !l.is_empty() {
                     format!("[{}] {}", line.time.to_string(), l)
                 } else {
                     l.to_string()
@@ -113,8 +117,10 @@ impl Pane for LyricsPane {
             let Some(line) = lrc.lines.get(after_lyrics_cursor) else {
                 break;
             };
-            for l in textwrap::wrap(&line.content, area.width as usize) {
-                let content = if show_timestamp && !l.is_empty() {
+            for (index, l) in
+                textwrap::wrap(&line.content, area.width as usize).into_iter().enumerate()
+            {
+                let content = if index == 0 && show_timestamp && !l.is_empty() {
                     format!("[{}] {}", line.time.to_string(), l)
                 } else {
                     l.to_string()

--- a/src/ui/panes/lyrics.rs
+++ b/src/ui/panes/lyrics.rs
@@ -73,7 +73,7 @@ impl Pane for LyricsPane {
             let Some(area) = areas.get(current_area) else {
                 break;
             };
-            let text = Text::from(l.clone()).centered().style(middle_style);
+            let text = Text::from(l).centered().style(middle_style);
             frame.render_widget(text, *area);
             current_area += 1;
         }
@@ -123,7 +123,7 @@ impl Pane for LyricsPane {
                 let Some(area) = areas.get(after_area_cursor + 1) else {
                     break;
                 };
-                let text = Text::from(l.clone()).centered().style(default_style);
+                let text = Text::from(l).centered().style(default_style);
                 frame.render_widget(text, *area);
                 after_area_cursor += 1;
             }


### PR DESCRIPTION
## Description

adds lyrics.show_timestamp to add the timestamp of each line
it ignores empty lines

![image](https://github.com/user-attachments/assets/f9e49f6d-69eb-420f-9f24-46cee7e18373)


### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
