### PR TITLE
Changed logging path and fixed multiple user using rmpc issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -69,7 +69,7 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste the contents of `/tmp/rmpc.log` here
+      description: Please copy and paste the contents of `/tmp/rmpc_${UID}.log` here
       value: |
         <details>
           <summary>rmpc log</summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ lists they are listed as multiple entries.
 - `scrollbar` theme option now also accepts `None` as a valid value to hide all scrollbars in rmpc
 - `TogglePause` in both the keybind and CLI to issue play if the current state is stopped
 - Made lyrics index matching more lenient
+- Changed the logging path from `/tmp/rmpc.log` to `/tmp/rmpc_${UID}.log`
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ if you encounter an issue which is not yet solved in the current git version of 
 all information relevant to your issue.
 
 Sometimes you might be asked to provide `trace` level logs. You can obtain them by running rmpc
-with `RUST_LOG` environment variable set to trace. The log file is located at `/tmp/rmpc.log`.
+with `RUST_LOG` environment variable set to trace. The log file is located at `/tmp/rmpc_${UID}.log`.
 These logs can be very verbose so you might have to upload them somewhere and link them to the issue.
 ```bash
 RUST_LOG=trace rmpc

--- a/src/shared/logging.rs
+++ b/src/shared/logging.rs
@@ -4,6 +4,15 @@ use flexi_logger::{FileSpec, FlexiLoggerError, LoggerHandle};
 use super::events::Level;
 use crate::AppEvent;
 
+pub fn get_uid() -> Option<String> {
+    std::fs::read_to_string("/proc/self/status")
+        .ok()?
+        .lines()
+        .find(|line| line.starts_with("Uid:"))
+        .and_then(|line| line.split_whitespace().nth(1)) // first number is the real UID
+        .map(|s| s.to_string())
+}
+
 pub fn init(tx: Sender<AppEvent>) -> Result<LoggerHandle, FlexiLoggerError> {
     #[cfg(debug_assertions)]
     return init_debug(tx);
@@ -23,11 +32,12 @@ pub fn init_console() -> Result<LoggerHandle, FlexiLoggerError> {
 
 #[allow(dead_code)]
 fn init_release(tx: Sender<AppEvent>) -> Result<LoggerHandle, FlexiLoggerError> {
+    let uid = get_uid().unwrap_or_else(|| "unknown".to_string());
     flexi_logger::Logger::try_with_env_or_str("debug")?
         .log_to_file(
             FileSpec::default()
                 .directory(std::env::temp_dir())
-                .basename("rmpc")
+                .basename(format!("rmpc_{uid}"))
                 .suppress_timestamp(),
         )
         .add_writer("status_bar", Box::new(StatusBarWriter::new(tx)))
@@ -38,11 +48,12 @@ fn init_release(tx: Sender<AppEvent>) -> Result<LoggerHandle, FlexiLoggerError> 
 
 #[allow(dead_code)]
 fn init_debug(tx: Sender<AppEvent>) -> Result<LoggerHandle, FlexiLoggerError> {
+    let uid = get_uid().unwrap_or_else(|| "unknown".to_string());
     flexi_logger::Logger::try_with_env_or_str("debug")?
         .log_to_file_and_writer(
             FileSpec::default()
                 .directory(std::env::temp_dir())
-                .basename("rmpc")
+                .basename(format!("rmpc_{uid}"))
                 .suppress_timestamp(),
             Box::new(AppEventChannelWriter::new(tx.clone())),
         )


### PR DESCRIPTION
## Description
- The logs are now stored in  `/tmp/rmpc_${UID}.log`  rather than  `/tmp/rmpc.log` , which will not cause any permission issues as each user will have the file with their own UID

### Related issues
- Closes #414 

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
