### PR TITLE
Add existence check of config_path on config watcher

### DIFF
--- a/src/core/config_watcher.rs
+++ b/src/core/config_watcher.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, time::Duration};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use crossbeam::channel::Sender;
 use notify_debouncer_full::{
     DebounceEventResult,
@@ -24,10 +24,7 @@ pub(crate) fn init(
     event_tx: Sender<AppEvent>,
 ) -> Result<Debouncer<RecommendedWatcher, RecommendedCache>> {
     if !config_path.exists() {
-        return Err(anyhow::Error::msg(format!(
-            "Config path {} does not exist",
-            config_path.display()
-        )));
+        bail!("Config path {} does not exist", config_path.display());
     }
 
     let config_file_name = config_path

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,9 +277,6 @@ fn main() -> Result<()> {
             )
             .context("Failed to create app context")?;
 
-            let enable_mouse = context.config.enable_mouse;
-            let terminal = ui::setup_terminal(enable_mouse).context("Failed to setup terminal")?;
-
             core::client::init(
                 client_rx.clone(),
                 event_tx.clone(),
@@ -306,7 +303,7 @@ fn main() -> Result<()> {
                     context.config.theme_name.as_ref().map(|n| format!("{n}.ron",)),
                     event_tx.clone(),
                 )
-                .inspect_err(|_| status_warn!("Failed to initialize config watcher")),
+                .inspect_err(|e| log::warn!("Failed to initialize config watcher: {e}")),
             );
 
             let enable_mouse = context.config.enable_mouse;


### PR DESCRIPTION
## Description
Adds better error messages and logs, check if config_path exist before watching and delay terminal initialization. 

### Related issues
Closes #418 

### Checklist

- [X] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [ ] Documentation has been updated (if needed)
- [x] Changelog has been updated
