### PR TITLE
fix: Actually insert and not add playlists when using Insert

### DIFF
--- a/src/mpd/mpd_client.rs
+++ b/src/mpd/mpd_client.rs
@@ -169,7 +169,7 @@ pub trait MpdClient: Sized {
         playlist: &str,
         range: Option<SingleOrRange>,
     ) -> MpdResult<Vec<Song>>;
-    fn load_playlist(&mut self, name: &str) -> MpdResult<()>;
+    fn load_playlist(&mut self, name: &str, position: Option<QueuePosition>) -> MpdResult<()>;
     fn rename_playlist(&mut self, name: &str, new_name: &str) -> MpdResult<()>;
     fn delete_playlist(&mut self, name: &str) -> MpdResult<()>;
     fn delete_from_playlist(&mut self, playlist_name: &str, songs: &SingleOrRange)
@@ -675,8 +675,10 @@ impl MpdClient for Client<'_> {
         }
     }
 
-    fn load_playlist(&mut self, name: &str) -> MpdResult<()> {
-        self.send(&format!("load {}", name.quote_and_escape())).and_then(read_ok)
+    fn load_playlist(&mut self, name: &str, position: Option<QueuePosition>) -> MpdResult<()> {
+        let position_arg: String =
+            position.map_or(String::new(), |v| format!(" {}", v.as_mpd_str()));
+        self.send(&format!("load {} 0:{position_arg}", name.quote_and_escape())).and_then(read_ok)
     }
 
     fn rename_playlist(&mut self, name: &str, new_name: &str) -> MpdResult<()> {

--- a/src/tests/fixtures/mpd_client.rs
+++ b/src/tests/fixtures/mpd_client.rs
@@ -535,7 +535,7 @@ impl MpdClient for TestMpdClient {
         )
     }
 
-    fn load_playlist(&mut self, _name: &str) -> MpdResult<()> {
+    fn load_playlist(&mut self, _name: &str, _position: Option<QueuePosition>) -> MpdResult<()> {
         todo!("Not yet implemented")
     }
 

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -423,7 +423,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
             [playlist] => {
                 let playlist = playlist.clone();
                 context.command(move |client| {
-                    client.load_playlist(&playlist)?;
+                    client.load_playlist(&playlist, position)?;
                     status_info!("Playlist '{playlist}' added to queue");
                     Ok(())
                 });
@@ -450,7 +450,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
             DirOrSong::Dir { name: d, .. } => {
                 let d = d.clone();
                 context.command(move |client| {
-                    client.load_playlist(&d)?;
+                    client.load_playlist(&d, position)?;
                     status_info!("Playlist '{d}' added to queue");
                     Ok(())
                 });


### PR DESCRIPTION
- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [ ] ~Documentation has been updated (if needed)~

There has been no release since the Insert feature was added, making updating `CHANGELOG.md` superfluous.
