### PR TITLE
fix: Actually insert and not add with Insert in search pane

### DIFF
--- a/src/ui/panes/search.rs
+++ b/src/ui/panes/search.rs
@@ -1078,9 +1078,11 @@ impl Pane for SearchPane {
 
                             context.render()?;
                         }
-                        CommonAction::Insert => self.add_current(false, context, None)?,
+                        CommonAction::Insert => {
+                            self.add_current(false, context, Some(QueuePosition::RelativeAdd(0)))?;
+                        }
                         CommonAction::InsertAll => {
-                            self.search_add(context, None);
+                            self.search_add(context, Some(QueuePosition::RelativeAdd(0)));
                             status_info!("All found songs added to queue");
 
                             context.render()?;


### PR DESCRIPTION
Somehow this one didn't make it into #422 (fix: Actually insert and not add playlists when using Insert)

Basically just fixing two places where I didn't replace with the correct action when making mpc_client's add commands take a position arg and not an insert one.

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)

No docs or changelog changes needed.