### PR TITLE
feat: Improve cava visualization

### DIFF
--- a/docs/src/content/docs/next/configuration/cava.mdx
+++ b/docs/src/content/docs/next/configuration/cava.mdx
@@ -75,7 +75,7 @@ carefully as the example does not work copy/paste out of the box.
 cava: (
     // symbols that will be used to draw the bar in the visualiser, in ascending order of
     // fill fraction
-    bar_symbol: "▁▂▃▄▅▆▇█",
+    bar_symbols: ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"],
 
     bg_color: "black", // background color, defaults to rmpc's bg color if not provided
 

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -30,8 +30,8 @@ pub fn usize<const V: usize>() -> usize {
     V
 }
 
-pub fn default_bar_symbol() -> String {
-    "▁▂▃▄▅▆▇█".to_string()
+pub fn default_bar_symbols() -> Vec<char> {
+    "▁▂▃▄▅▆▇█".chars().collect()
 }
 
 pub fn default_progress_update_interval_ms() -> Option<u64> {

--- a/src/config/theme/cava.rs
+++ b/src/config/theme/cava.rs
@@ -17,8 +17,8 @@ use crate::shared::ext::vec::VecExt;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CavaThemeFile {
-    #[serde(default = "defaults::default_bar_symbol")]
-    pub bar_symbol: String,
+    #[serde(default = "defaults::default_bar_symbols")]
+    pub bar_symbols: Vec<char>,
     #[serde(default)]
     pub bg_color: Option<String>,
     #[serde(default)]
@@ -28,7 +28,7 @@ pub struct CavaThemeFile {
 impl Default for CavaThemeFile {
     fn default() -> Self {
         Self {
-            bar_symbol: "▁▂▃▄▅▆▇█".into(),
+            bar_symbols: "▁▂▃▄▅▆▇█".chars().collect(),
             bg_color: Some("black".to_owned()),
             bar_color: CavaColorFile::Single("blue".into()),
         }
@@ -37,7 +37,8 @@ impl Default for CavaThemeFile {
 
 #[derive(Debug, Clone)]
 pub struct CavaTheme {
-    pub bar_symbol: String,
+    pub bar_symbols: Vec<char>,
+    pub bar_symbols_count: usize,
     pub bg_color: CrosstermColor,
     pub bar_color: CavaColor,
 }
@@ -45,7 +46,8 @@ pub struct CavaTheme {
 impl Default for CavaTheme {
     fn default() -> Self {
         Self {
-            bar_symbol: "▁▂▃▄▅▆▇█".into(),
+            bar_symbols_count: 8,
+            bar_symbols: "▁▂▃▄▅▆▇█".chars().collect(),
             bg_color: CrosstermColor::Black,
             bar_color: CavaColor::Single(CrosstermColor::Blue),
         }
@@ -86,7 +88,8 @@ fn lerp_u8(a: u8, b: u8, t: f64) -> u8 {
 impl CavaThemeFile {
     pub fn into_config(self, default_bg_color: Option<RatatuiColor>) -> Result<CavaTheme> {
         Ok(CavaTheme {
-            bar_symbol: self.bar_symbol,
+            bar_symbols_count: self.bar_symbols.len(),
+            bar_symbols: self.bar_symbols,
             bg_color: self
                 .bg_color
                 .map(|c| -> Result<RatatuiColor> {

--- a/src/ui/panes/cava.rs
+++ b/src/ui/panes/cava.rs
@@ -120,8 +120,8 @@ impl CavaPane {
                 if fill_amount < 0.01 {
                     queue!(writer, PrintStyledContent(' '.on(theme.bg_color)))?;
                 } else {
-                    let char_index = (fill_amount * theme.bar_symbol.chars().count() as f32).floor() as usize;
-                    let fill_char = theme.bar_symbol.chars().nth(char_index).unwrap_or(' ');
+                    let char_index = (fill_amount * theme.bar_symbols_count as f32).floor() as usize;
+                    let fill_char = theme.bar_symbols.get(char_index).unwrap_or(&' ');
                     queue!(
                         writer,
                         PrintStyledContent(


### PR DESCRIPTION
## Description

This pull request improves the rendering of cava in rmpc using the partially filled unicode blocks (▁▂▃▄▅▆▇█), which creates a smoother-looking visualization.

The `cava.bar_symbol` theme option has been changed to accept multiple characters, which are selected based on how full the grid cell must be.

Example of the new look of Cava:
![image](https://github.com/user-attachments/assets/5e8a14fe-8881-47db-8038-2c399d8e6620)

I'm having trouble getting the nightly toolchain working on my computer (Rust and Gentoo sometimes have trouble getting along unfortunately), so I have not yet been able to format the code correctly.

### Checklist

- [x] All tests passed
- [ ] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [ ] Changelog has been updated
