### PR TITLE
fix: allow playlists with no preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ lists they are listed as multiple entries.
 - Filter overlapping song table when `show_song_table_header` was set to false
 - Remove extra space at the start of every lyrics line in case the lrc file had space between timestamp and content
 - Styles for `Group` not working in the queue table
+- Allow playlist with no metadata for preview. Happens in entries from http for example.
 
 ## [0.8.0] - 2025-02-16
 

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -576,9 +576,8 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
                                 .context(anyhow!("File '{}' was listed but not found", song.file))?
                                 .0
                                 .first()
-                                .context("Expected to find exactly one song for preview")?
                             {
-                                LsInfoEntry::File(song) => Some(song.to_preview(
+                                Some(LsInfoEntry::File(song)) => Some(song.to_preview(
                                     config.theme.preview_label_style,
                                     config.theme.preview_metadata_group_style,
                                 )),


### PR DESCRIPTION
## Description

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
