### PR TITLE
feat: support playlists in directories pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ lists they are listed as multiple entries.
 - Added new `Cava` pane
 - Added `mpd_idle_read_timeout_ms`
 - Added FAQ section to the docs
+- Directories pane now displays playlists located in your music directory. Also added `show_playlists_in_browser`
+to hide them.
 
 ### Changed
 

--- a/docs/src/content/docs/next/assets/example_config.ron
+++ b/docs/src/content/docs/next/assets/example_config.ron
@@ -18,7 +18,7 @@
     reflect_changes_to_playlist: false,
     select_current_song_on_change: false,
     browser_song_sort: [Disc, Track, Artist, Title],
-    directories_sort: SortFormat(group_directories_first: true, reverse: false),
+    directories_sort: SortFormat(group_by_type: true, reverse: false),
     album_art: (
         method: Auto,
         max_size_px: (width: 1200, height: 1200),

--- a/docs/src/content/docs/next/assets/example_theme.ron
+++ b/docs/src/content/docs/next/assets/example_theme.ron
@@ -26,10 +26,12 @@
     symbols: (
         song: "S",
         dir: "D",
+        playlist: "P",
         marker: "M",
         ellipsis: "...",
         song_style: None,
         dir_style: None,
+        playlist_style: None,
     ),
     level_styles: (
         info: (fg: "blue", bg: "black"),

--- a/docs/src/content/docs/next/assets/themes/catppuccin-macchiato/theme.ron
+++ b/docs/src/content/docs/next/assets/themes/catppuccin-macchiato/theme.ron
@@ -5,7 +5,7 @@
     default_album_art_path: None,
     draw_borders: false,
     show_song_table_header: false,
-    symbols: (song: "🎵", dir: "📁", marker: "\u{e0b0}"),
+    symbols: (song: "🎵", dir: "📁", playlist: "🎼", marker: "\u{e0b0}"),
     layout: Split(
         direction: Vertical,
         panes: [

--- a/docs/src/content/docs/next/assets/themes/default/theme.ron
+++ b/docs/src/content/docs/next/assets/themes/default/theme.ron
@@ -22,7 +22,7 @@
     current_item_style: (fg: "black", bg: "blue", modifiers: "Bold"),
     borders_style: (fg: "blue"),
     highlight_border_style: (fg: "blue"),
-    symbols: (song: "S", dir: "D", marker: "M", ellipsis: "..."),
+    symbols: (song: "S", dir: "D", playlist: "P", marker: "M", ellipsis: "..."),
     progress_bar: (
         symbols: ["[", "-", ">", " ", "]"],
         track_style: (fg: "#1e2030"),

--- a/docs/src/content/docs/next/assets/themes/nord/theme.ron
+++ b/docs/src/content/docs/next/assets/themes/nord/theme.ron
@@ -22,7 +22,7 @@
     current_item_style: (fg: "#2e3440", bg: "#81a1c1", modifiers: "Bold"),
     borders_style: (fg: "#81a1c1", modifiers: "Bold"),
     highlight_border_style: (fg: "#81a1c1"),
-    symbols: (song: "󰝚 ", dir: " ", marker: "* ", ellipsis: "..."),
+    symbols: (song: "󰝚 ", dir: " ", playlist: "🗒", marker: "* ", ellipsis: "..."),
     progress_bar: (
         symbols: ["█", "█", "█", "█", "█"],
         track_style: (fg: "#3b4252"),

--- a/docs/src/content/docs/next/assets/themes/nord/theme.ron
+++ b/docs/src/content/docs/next/assets/themes/nord/theme.ron
@@ -22,7 +22,7 @@
     current_item_style: (fg: "#2e3440", bg: "#81a1c1", modifiers: "Bold"),
     borders_style: (fg: "#81a1c1", modifiers: "Bold"),
     highlight_border_style: (fg: "#81a1c1"),
-    symbols: (song: "󰝚 ", dir: " ", playlist: "󰲸", marker: "* ", ellipsis: "..."),
+    symbols: (song: "󰝚 ", dir: " ", playlist: "󰲸 ", marker: "* ", ellipsis: "..."),
     progress_bar: (
         symbols: ["█", "█", "█", "█", "█"],
         track_style: (fg: "#3b4252"),

--- a/docs/src/content/docs/next/assets/themes/nord/theme.ron
+++ b/docs/src/content/docs/next/assets/themes/nord/theme.ron
@@ -22,7 +22,7 @@
     current_item_style: (fg: "#2e3440", bg: "#81a1c1", modifiers: "Bold"),
     borders_style: (fg: "#81a1c1", modifiers: "Bold"),
     highlight_border_style: (fg: "#81a1c1"),
-    symbols: (song: "󰝚 ", dir: " ", playlist: "🗒", marker: "* ", ellipsis: "..."),
+    symbols: (song: "󰝚 ", dir: " ", playlist: "󰲸", marker: "* ", ellipsis: "..."),
     progress_bar: (
         symbols: ["█", "█", "█", "█", "█"],
         track_style: (fg: "#3b4252"),

--- a/docs/src/content/docs/next/configuration/index.mdx
+++ b/docs/src/content/docs/next/configuration/index.mdx
@@ -265,14 +265,28 @@ Defaults to `[Disc, Track, Artist, Title]` which means the songs are first sorte
 
 <ConfigValue name="directories_sort" type={["ModifiedTime(..)", "Format(..)", "SongFormat(..)"]} />
 
-Determines how the entries are sorted in the directories pane. All of the properties below take additional config options:
-`group_directories_first` and `reverse` which make directories grouped before entries and reverse the ordering respectively.
+Determines how the entries are sorted in the directories pane. All of the properties below take
+additional config options: `group_by_type` and `reverse` which groups the entries by directories,
+songs and playlists and reverse the ordering respectively.
 
 - `Format` - Songs are sorted by their displayed format.
 - `SortFormat` - Similar to `Format` but songs are sorted by <a href={path("configuration/#browser_song_sort")}>browser_song_sort</a>.
 - `ModifiedTime` - Entries are sorted by their last modified time.
 
-Defaults to `SortFormat(group_directories_first: true, reverse: false)`.
+Defaults to `SortFormat(group_by_type: true, reverse: false)`.
+
+### show_playlists_in_browser
+
+<ConfigValue name="show_playlists_in_browser" type={["All", "None", "NonRoot"]} />
+
+Whether to show playlists in browser or not. Possible values:
+
+- `All` - Show all playlists
+- `None` - Do not show playlists
+- `NonRoot` - Show playlists everywhere except the root directory. This option exists because MPD
+  lists all of its playlists as being inside the root directory.
+
+Defaults to `NonRoot`.
 
 ### reflect_changes_to_playlist
 

--- a/docs/src/content/docs/next/themes/nord.mdx
+++ b/docs/src/content/docs/next/themes/nord.mdx
@@ -22,6 +22,6 @@ The space below the cover art is for synced lyrics (.lrc).
 
 ## Config
 
-<Code code={theme1} lang="rust" title="nord.ron" />
+<Code code={theme1} lang="rust" title="theme.ron" />
 
 <Code code={theme2} lang="rust" title="config.ron" />

--- a/docs/src/content/docs/next/themes/nord.mdx
+++ b/docs/src/content/docs/next/themes/nord.mdx
@@ -8,7 +8,7 @@ sidebar:
 import { Image } from "astro:assets";
 import { Code } from "@astrojs/starlight/components";
 import img1 from "../assets/themes/nord/nord.png";
-import theme1 from "../assets/themes/nord/nord.ron?raw";
+import theme1 from "../assets/themes/nord/theme.ron?raw";
 import theme2 from "../assets/themes/nord/config.ron?raw";
 
 You must add the tab section to your `config.ron`.

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -87,6 +87,10 @@ pub fn default_song_sort() -> Vec<SongPropertyFile> {
     ]
 }
 
+pub fn playlist_symbol() -> String {
+    "P".to_owned()
+}
+
 pub fn default_tag_separator() -> String {
     " | ".to_string()
 }

--- a/src/config/sort_mode.rs
+++ b/src/config/sort_mode.rs
@@ -12,13 +12,13 @@ pub enum SortMode {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SortOptions {
     pub mode: SortMode,
-    pub group_directories_first: bool,
+    pub group_by_type: bool,
     pub reverse: bool,
 }
 
 impl Default for SortOptions {
     fn default() -> Self {
-        Self { mode: SortMode::default(), group_directories_first: true, reverse: false }
+        Self { mode: SortMode::default(), group_by_type: true, reverse: false }
     }
 }
 
@@ -34,19 +34,19 @@ impl Default for SortMode {
 pub enum SortModeFile {
     Format {
         #[serde(default = "defaults::bool::<true>")]
-        group_directories_first: bool,
+        group_by_type: bool,
         #[serde(default = "defaults::bool::<false>")]
         reverse: bool,
     },
     SortFormat {
         #[serde(default = "defaults::bool::<true>")]
-        group_directories_first: bool,
+        group_by_type: bool,
         #[serde(default = "defaults::bool::<false>")]
         reverse: bool,
     },
     ModifiedTime {
         #[serde(default = "defaults::bool::<true>")]
-        group_directories_first: bool,
+        group_by_type: bool,
         #[serde(default = "defaults::bool::<false>")]
         reverse: bool,
     },
@@ -54,6 +54,6 @@ pub enum SortModeFile {
 
 impl Default for SortModeFile {
     fn default() -> Self {
-        Self::SortFormat { group_directories_first: true, reverse: false }
+        Self::SortFormat { group_by_type: true, reverse: false }
     }
 }

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -171,10 +171,12 @@ impl Default for UiConfigFile {
             symbols: SymbolsFile {
                 song: "S".to_owned(),
                 dir: "D".to_owned(),
+                playlist: defaults::playlist_symbol(),
                 marker: "M".to_owned(),
                 ellipsis: Some("...".to_owned()),
                 song_style: None,
                 dir_style: None,
+                playlist_style: None,
             },
             song_table_format: QueueTableColumnsFile::default(),
             browser_song_format: SongFormatFile::default(),
@@ -216,20 +218,25 @@ pub struct TabBar {
 pub struct SymbolsFile {
     pub(super) song: String,
     pub(super) dir: String,
+    #[serde(default = "defaults::playlist_symbol")]
+    pub(super) playlist: String,
     pub(super) marker: String,
     pub(super) ellipsis: Option<String>,
     pub(super) song_style: Option<StyleFile>,
     pub(super) dir_style: Option<StyleFile>,
+    pub(super) playlist_style: Option<StyleFile>,
 }
 
 #[derive(Debug, Default, Clone)]
 pub struct SymbolsConfig {
     pub song: String,
     pub dir: String,
+    pub playlist: String,
     pub marker: String,
     pub ellipsis: String,
     pub song_style: Option<Style>,
     pub dir_style: Option<Style>,
+    pub playlist_style: Option<Style>,
 }
 
 impl From<SymbolsFile> for SymbolsConfig {
@@ -237,6 +244,7 @@ impl From<SymbolsFile> for SymbolsConfig {
         Self {
             song: value.song,
             dir: value.dir,
+            playlist: value.playlist,
             marker: value.marker,
             ellipsis: value.ellipsis.unwrap_or_else(|| "...".to_string()),
             song_style: value
@@ -246,6 +254,11 @@ impl From<SymbolsFile> for SymbolsConfig {
                 .unwrap_or_default(),
             dir_style: value
                 .dir_style
+                .map(|s| s.to_config_or(None, None))
+                .transpose()
+                .unwrap_or_default(),
+            playlist_style: value
+                .playlist_style
                 .map(|s| s.to_config_or(None, None))
                 .transpose()
                 .unwrap_or_default(),

--- a/src/core/command.rs
+++ b/src/core/command.rs
@@ -220,10 +220,10 @@ impl Command {
                                     .trim_start_matches(&dir)
                                     .trim_start_matches('/')
                                     .trim_end_matches('/'),
-                                position.clone(),
+                                position,
                             )?;
                         } else {
-                            client.add(&file.to_string_lossy(), position.clone())?;
+                            client.add(&file.to_string_lossy(), position)?;
                         }
                     }
 
@@ -232,7 +232,7 @@ impl Command {
             }
             Command::Add { files, position, .. } => Ok(Box::new(move |client| {
                 for file in &files {
-                    client.add(&file.to_string_lossy(), position.clone())?;
+                    client.add(&file.to_string_lossy(), position)?;
                 }
 
                 Ok(())

--- a/src/mpd/queue_position.rs
+++ b/src/mpd/queue_position.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[allow(dead_code)]
 pub enum QueuePosition {
     /// relative to the currently playing song; e.g. +0 moves to right after the

--- a/src/ui/dir_or_song.rs
+++ b/src/ui/dir_or_song.rs
@@ -108,7 +108,7 @@ impl DirOrSong {
 
 impl Ord for DirOrSongCustomSort<'_, '_> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // If grouping is enabled, we group first group dirs, then songs and then
+        // If grouping is enabled, we group dirs first, then songs and then
         // playlists
         if self.opts.group_by_type {
             let type_order = match (self.dir_or_song, other.dir_or_song) {

--- a/src/ui/dirstack/mod.rs
+++ b/src/ui/dirstack/mod.rs
@@ -62,12 +62,19 @@ impl DirStackItem for DirOrSong {
         };
 
         let mut value = match self {
-            DirOrSong::Dir { name, .. } => Line::from(vec![
+            DirOrSong::Dir { name, playlist: is_playlist, .. } => Line::from(vec![
                 marker_span,
-                Span::styled(
-                    config.theme.symbols.dir.clone(),
-                    config.theme.symbols.dir_style.unwrap_or_default(),
-                ),
+                if *is_playlist {
+                    Span::styled(
+                        config.theme.symbols.playlist.clone(),
+                        config.theme.symbols.playlist_style.unwrap_or_default(),
+                    )
+                } else {
+                    Span::styled(
+                        config.theme.symbols.dir.clone(),
+                        config.theme.symbols.dir_style.unwrap_or_default(),
+                    )
+                },
                 Span::from(" "),
                 Span::from(if name.is_empty() {
                     Cow::Borrowed("Untitled")

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -430,7 +430,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
             }
             [] => {
                 for playlist in &self.stack().current().items {
-                    self.add(playlist, context, position.clone())?;
+                    self.add(playlist, context, position)?;
                 }
                 status_info!("All playlists added to queue");
             }

--- a/src/ui/panes/playlists/tests.rs
+++ b/src/ui/panes/playlists/tests.rs
@@ -520,7 +520,12 @@ fn song(name: &str) -> Song {
 }
 
 fn dir(name: &str) -> DirOrSong {
-    DirOrSong::Dir { name: name.to_string(), full_path: name.to_string(), last_modified: *NOW }
+    DirOrSong::Dir {
+        name: name.to_string(),
+        full_path: name.to_string(),
+        last_modified: *NOW,
+        playlist: false,
+    }
 }
 
 #[fixture]

--- a/src/ui/panes/search.rs
+++ b/src/ui/panes/search.rs
@@ -85,7 +85,6 @@ impl SearchPane {
         if !self.songs_dir.marked().is_empty() {
             for idx in self.songs_dir.marked() {
                 let item = self.songs_dir.items[*idx].file.clone();
-                let position = position.clone();
                 context.command(move |client| {
                     client.add(&item, position)?;
                     Ok(())


### PR DESCRIPTION
## Description

Introduces support for playlists in the directories pane. A new option to control the behavior
is also created.

Note: `group_directories_first` on `directories_sort` was changed to `group_by_type`. This is a
small breaking change in case you were on the git version.

### Related issues

https://github.com/mierak/rmpc/issues/433

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
