### PR TITLE
fix: typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ lists they are listed as multiple entries.
 - Added components to the theme. Components are user-defined reusable parts of TUI.
 - Added `rewind_to_start_sec` config option. If elapsed time is past the configured value, the song will be rewound to start instead.
 - Added `reflect_changes_to_playlist` config option. This makes changes to the queue reflect to the stored playlist if any.
-- Added `mutliple_tag_resolution_strategy` to choose which tag value to display when multiple values are present
+- Added `multiple_tag_resolution_strategy` to choose which tag value to display when multiple values are present
 - Added `maps_three_symbols` test for progress bar. This will help avoid any errors while changing progress bar code in future
 - Added `PopConfigErrorModal` so theat the config error modals are automatically removed when the config reloads and is found correct
 - Added style configuration for dir and song symbols in browsers
@@ -109,9 +109,9 @@ lists they are listed as multiple entries.
 - `remote` command to cli which allows for IPC with running rmpc instances
 - Example script to automatically download lyrics from [https://lrclib.net/](https://lrclib.net/)
 - Added `max_fps` to config
-- Introduced `StateV2` property as a replacement for `State`. It has additional config properties compared to its predecesor.
+- Introduced `StateV2` property as a replacement for `State`. It has additional config properties compared to its predecessor.
 - Introduced `RandomV2`, `ConsumeV2`, `RepeatV2` and `SingleV2` properties as a replacement for their respective earlier versions.
-They have additional config properties compared to their predecesors.
+They have additional config properties compared to their predecessors.
 - `borders` configuration in the tabs configuration
 - A new `Property` pane
 
@@ -136,7 +136,7 @@ They have additional config properties compared to their predecesors.
 - Properly escape strings in mpd protocol
 - Preview for songs outside of the music database not working in playlists
 - AddToPlaylist not working for local songs
-- rmpc waiting potentionally forever for MPD's response
+- rmpc waiting potentially forever for MPD's response
 - Adding songs which do not belong to any album not working in `Artists` and `AlbumArtists` panes not working
 - Songs metadata not being sorted in preview column
 - Prevent album art rendering when modal is open
@@ -282,7 +282,7 @@ They have additional config properties compared to their predecesors.
 
 ### Fixed
 
-- Fixed filename property behavior in proprty formatters
+- Fixed filename property behavior in property formatters
 - Added missing text color to default theme
 
 ### Removed
@@ -326,7 +326,7 @@ They have additional config properties compared to their predecesors.
 - Implement command mode/cli
 - Added outputs config modal/cli
 - Added get volume, status info, song info commands
-- Added inital youtube playback support
+- Added initial youtube playback support
 - Introduced worker queue
 
 ### Fixed

--- a/docs/src/content/docs/next/configuration/cava.mdx
+++ b/docs/src/content/docs/next/configuration/cava.mdx
@@ -37,7 +37,7 @@ After that you need to setup Cava, MPD and rmpc to talk to each other.
 2.  Configure rmpc and by extension Cava. This goes in your `config.ron`. The most important bit here is
     the input, this has to reflect your `mpd.conf` from step one. These settings are passed directly to cava
     so please refer to its [documentation](https://github.com/karlstav/cava/blob/master/example_files/config)
-    for more info. Most of these options do not have to be provided and have sensisble defaults.
+    for more info. Most of these options do not have to be provided and have sensible defaults.
 
     ```rust
     cava: (

--- a/docs/src/content/docs/next/configuration/index.mdx
+++ b/docs/src/content/docs/next/configuration/index.mdx
@@ -80,7 +80,7 @@ How long to wait for write to MPD socket to finish before giving up and reconnec
 <ConfigValue name="mpd_write_timeout_ms" optional type="number" />
 
 By default the client will wait forever for data from MPD to appear while being idle. This makes it timeout after the
-specified tiemout and try again. Defaults to None.
+specified timeout and try again. Defaults to None.
 
 :::caution
 Do not set this option. Only reason to use this is if you are experiencing connection issues and rmpc hanging after a disconnect.

--- a/docs/src/content/docs/next/configuration/layout.mdx
+++ b/docs/src/content/docs/next/configuration/layout.mdx
@@ -36,7 +36,7 @@ For example you cannot display album art in the base layout and in the queue tab
 
 <ConfigValue name="components" type="other" customText="Map<string, Pane | Split | Component>" />
 
-Components are reuseable blocks of panes. They can be used to define some part of UI once and reuse it in multiple tabs, layout
+Components are reusable blocks of panes. They can be used to define some part of UI once and reuse it in multiple tabs, layout
 and even included in other components without having to copy the definition to each tab separately. They can also be used to
 restructure your `layout` and `tabs` to make them more readable.
 

--- a/docs/src/content/docs/next/configuration/theme.mdx
+++ b/docs/src/content/docs/next/configuration/theme.mdx
@@ -275,9 +275,9 @@ Style for all tabs except the active one.
 Use this to separate entries when a song has multiple values for a tag. For example, a song with
 two values for `artist` and `|` as a separator will show `artist1 | artist2`. Default is `|`.
 
-### mutliple_tag_resolution_strategy
+### multiple_tag_resolution_strategy
 
-<ConfigValue name="mutliple_tag_resolution_strategy" type={["All", "First", "Last", "Nth(<number>)"]} />
+<ConfigValue name="multiple_tag_resolution_strategy" type={["All", "First", "Last", "Nth(<number>)"]} />
 
 What strategy to choose when a song has multiple values for a tag. `All` uses #format_tag_separator to join
 all values to one. `First` and `Last` choose the first and last value respectively and `Nth` chooses exactly

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -70,7 +70,7 @@ pub struct UiConfig {
     pub layout: SizedPaneOrSplit,
     pub components: HashMap<String, SizedPaneOrSplit>,
     pub format_tag_separator: String,
-    pub mutliple_tag_resolution_strategy: TagResolutionStrategy,
+    pub multiple_tag_resolution_strategy: TagResolutionStrategy,
     pub level_styles: LevelStyles,
     pub lyrics: LyricsConfig,
     pub cava: CavaTheme,
@@ -114,7 +114,7 @@ pub struct UiConfigFile {
     #[serde(default = "defaults::default_tag_separator")]
     pub(super) format_tag_separator: String,
     #[serde(default)]
-    pub(super) mutliple_tag_resolution_strategy: TagResolutionStrategy,
+    pub(super) multiple_tag_resolution_strategy: TagResolutionStrategy,
     #[serde(default)]
     pub(super) level_styles: LevelStylesFile,
     #[serde(default)]
@@ -179,7 +179,7 @@ impl Default for UiConfigFile {
             song_table_format: QueueTableColumnsFile::default(),
             browser_song_format: SongFormatFile::default(),
             format_tag_separator: " | ".to_owned(),
-            mutliple_tag_resolution_strategy: TagResolutionStrategy::default(),
+            multiple_tag_resolution_strategy: TagResolutionStrategy::default(),
             preview_label_style: StyleFile {
                 fg: Some("yellow".to_string()),
                 bg: None,
@@ -344,7 +344,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
             background_color: bg_color,
             draw_borders: value.draw_borders,
             format_tag_separator: value.format_tag_separator,
-            mutliple_tag_resolution_strategy: value.mutliple_tag_resolution_strategy,
+            multiple_tag_resolution_strategy: value.multiple_tag_resolution_strategy,
             modal_background_color: StringColor(value.modal_background_color)
                 .to_color()?
                 .or(bg_color),

--- a/src/config/theme/properties.rs
+++ b/src/config/theme/properties.rs
@@ -510,8 +510,8 @@ impl TryFrom<SongFormatFile> for SongFormat {
     type Error = anyhow::Error;
 
     fn try_from(value: SongFormatFile) -> Result<Self, Self::Error> {
-        let properites: Vec<_> = value.0.into_iter().map(|v| v.try_into()).try_collect()?;
-        Ok(SongFormat(properites))
+        let properties: Vec<_> = value.0.into_iter().map(|v| v.try_into()).try_collect()?;
+        Ok(SongFormat(properties))
     }
 }
 

--- a/src/core/event_loop.rs
+++ b/src/core/event_loop.rs
@@ -106,7 +106,7 @@ fn main_task<B: Backend + std::io::Write>(
         if let Some(event) = event {
             match event {
                 AppEvent::ConfigChanged { config: mut new_config, keep_old_theme } => {
-                    // Techical limitation. Keep the old image backend because it was not rechecked
+                    // Technical limitation. Keep the old image backend because it was not rechecked
                     // anyway. Sending the escape sequences to determine image support would mess up
                     // the terminal output at this point.
                     new_config.album_art.method = context.config.album_art.method;

--- a/src/core/scheduler/mod.rs
+++ b/src/core/scheduler/mod.rs
@@ -209,7 +209,7 @@ where
     }
 }
 
-/// Cancels the taks when dropped
+/// Cancels the task when dropped
 pub(crate) struct TaskGuard<T> {
     id: Id,
     job_tx: Sender<SchedulerCommand<T>>,

--- a/src/core/socket.rs
+++ b/src/core/socket.rs
@@ -54,7 +54,7 @@ pub(crate) fn init(
 pub struct SocketGuard(PathBuf);
 impl Drop for SocketGuard {
     fn drop(&mut self) {
-        // Ingore, the app is exiting, theres nothing else we can do
+        // Ignore, the app is exiting, theres nothing else we can do
         _ = std::fs::remove_file(&self.0);
     }
 }

--- a/src/mpd/mpd_client.rs
+++ b/src/mpd/mpd_client.rs
@@ -188,7 +188,7 @@ pub trait MpdClient: Sized {
     ) -> MpdResult<()>;
     fn save_queue_as_playlist(&mut self, name: &str, mode: Option<SaveMode>) -> MpdResult<()>;
     /// This function first invokes [`Self::albumart`].
-    /// If no album art is fonud it invokes [`Self::read_picture`].
+    /// If no album art is found it invokes [`Self::read_picture`].
     /// If no art is still found, but no errors were encountered, None is
     /// returned.
     fn find_album_art(&mut self, path: &str) -> MpdResult<Option<Vec<u8>>>;
@@ -874,7 +874,7 @@ impl MpdClient for Client<'_> {
                         result.push(v);
                     }
                     Err(error) => {
-                        log::warn!(error:?, uri; "Tried to find stickers but unexpected error occured");
+                        log::warn!(error:?, uri; "Tried to find stickers but unexpected error occurred");
                         result.push(Stickers::default());
                         list_ended_with_err = true;
                         break;

--- a/src/mpd/proto_client.rs
+++ b/src/mpd/proto_client.rs
@@ -241,7 +241,7 @@ impl<'cmd, 'client, C: SocketClient> ProtoClient<'cmd, 'client, C> {
                 Err(e.into())
             }
             Err(e) => {
-                log::error!(err:? = e; "Encountered unexpected error whe reading a response line from MPD");
+                log::error!(err:? = e; "Encountered unexpected error when reading a response line from MPD");
                 Err(e.into())
             }
         }?;

--- a/src/mpd/proto_client.rs
+++ b/src/mpd/proto_client.rs
@@ -168,7 +168,7 @@ impl<'cmd, 'client, C: SocketClient> ProtoClient<'cmd, 'client, C> {
             match self.read_bin_inner(&mut buf) {
                 Ok(Some(response)) => {
                     if buf.len() >= response.size_total as usize || response.bytes_read == 0 {
-                        trace!( len = buf.len();"Finshed reading binary response");
+                        trace!( len = buf.len();"Finished reading binary response");
                         break;
                     }
                 }

--- a/src/shared/ext.rs
+++ b/src/shared/ext.rs
@@ -16,7 +16,7 @@ pub mod error {
         fn to_status(&self) -> String {
             match self {
                 MpdError::Parse(e) => format!("Failed to parse: {e}"),
-                MpdError::UnknownCode(e) => format!("Unkown code: {e}"),
+                MpdError::UnknownCode(e) => format!("Unknown code: {e}"),
                 MpdError::Generic(e) => format!("Generic error: {e}"),
                 MpdError::ClientClosed => "Client closed".to_string(),
                 MpdError::Mpd(e) => format!("MPD Error: {e}"),
@@ -24,7 +24,7 @@ pub mod error {
                     format!("Expected Value but got '{e}'")
                 }
                 MpdError::UnsupportedMpdVersion(e) => {
-                    format!("Unsuported MPD version: {e}")
+                    format!("Unsupported MPD version: {e}")
                 }
                 MpdError::TimedOut(_) => "Request to MPD timed out".to_string(),
             }

--- a/src/shared/image.rs
+++ b/src/shared/image.rs
@@ -270,7 +270,7 @@ pub fn create_aligned_area(
 
 pub fn resize_image(
     image_data: &[u8],
-    availabe_area: Rect,
+    available_area: Rect,
     max_size_px: Size,
     halign: HorizontalAlign,
     valign: VerticalAlign,
@@ -282,7 +282,7 @@ pub fn resize_image(
         .context("Unable to decode image")?;
 
     let result_area = create_aligned_area(
-        availabe_area,
+        available_area,
         (image.width(), image.height()),
         max_size_px,
         halign,

--- a/src/shared/ipc/commands/set.rs
+++ b/src/shared/ipc/commands/set.rs
@@ -9,7 +9,7 @@ use crate::{
     shared::ipc::SocketCommandExecute,
 };
 
-// Enum values only exist for the short time and are not contstructed often, so
+// Enum values only exist for the short time and are not constructed often, so
 // the large difference should be negligible
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/shared/lrc/index.rs
+++ b/src/shared/lrc/index.rs
@@ -147,7 +147,7 @@ impl LrcIndex {
                         // Lrc matching by length was not found, but there are lrc without length
                         Some(without_length[0])
                     } else {
-                        // Lrc with matching lenght was not found and there are no lrc without
+                        // Lrc with matching length was not found and there are no lrc without
                         // length. Return the closest match by length.
                         with_length
                             .iter()
@@ -161,7 +161,7 @@ impl LrcIndex {
                             .copied()
                     }
                 } else {
-                    // Song does not have a lenght information, not sure if this can ever happen,
+                    // Song does not have a length information, not sure if this can ever happen,
                     // but better safe than sorry. Return the first result rather than nothing.
                     Some(results[0])
                 }

--- a/src/shared/mouse_event.rs
+++ b/src/shared/mouse_event.rs
@@ -7,7 +7,7 @@ use crossterm::event::{
 };
 use ratatui::layout::Position;
 
-// maybe make the timout configurable?
+// maybe make the timeout configurable?
 const DOUBLE_CLICK_TIMEOUT: Duration = Duration::from_millis(500);
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/src/ui/dirstack/mod.rs
+++ b/src/ui/dirstack/mod.rs
@@ -90,7 +90,7 @@ impl DirStackItem for DirOrSong {
                         prop.as_string(
                             Some(s),
                             &config.theme.format_tag_separator,
-                            config.theme.mutliple_tag_resolution_strategy,
+                            config.theme.multiple_tag_resolution_strategy,
                         )
                         .unwrap_or_default(),
                     )

--- a/src/ui/dirstack/state.rs
+++ b/src/ui/dirstack/state.rs
@@ -213,21 +213,21 @@ impl<T: ScrollingState> DirState<T> {
     }
 
     fn apply_scrolloff(&mut self, scrolloff: usize) {
-        let vieport_len = self.viewport_len.unwrap_or_default();
+        let viewport_len = self.viewport_len.unwrap_or_default();
         let offset = self.inner.offset();
         let idx = self.get_selected().unwrap_or_default();
         let content_len = self.content_len.unwrap_or_default();
-        let max_offset = content_len.saturating_sub(vieport_len);
+        let max_offset = content_len.saturating_sub(viewport_len);
 
         // Always place cursor in the middle of the screen when scrolloff is too
         // big
-        if scrolloff.saturating_mul(2) >= vieport_len {
-            self.inner.set_offset(idx.saturating_sub(vieport_len / 2).min(max_offset));
+        if scrolloff.saturating_mul(2) >= viewport_len {
+            self.inner.set_offset(idx.saturating_sub(viewport_len / 2).min(max_offset));
             return;
         }
 
         let scrolloff_start_down =
-            (offset.saturating_add(vieport_len)).saturating_sub(scrolloff.saturating_add(1));
+            (offset.saturating_add(viewport_len)).saturating_sub(scrolloff.saturating_add(1));
         if idx > scrolloff_start_down {
             let new_offset =
                 (offset.saturating_add(idx.saturating_sub(scrolloff_start_down))).min(max_offset);
@@ -288,7 +288,7 @@ impl<T: ScrollingState> DirState<T> {
 
     pub fn invert_marked(&mut self) {
         let Some(content_len) = self.content_len else {
-            log::warn!("Failed to invert marked items because content lenght is None");
+            log::warn!("Failed to invert marked items because content length is None");
             return;
         };
         let all = (0..content_len).collect::<BTreeSet<usize>>();

--- a/src/ui/image/kitty.rs
+++ b/src/ui/image/kitty.rs
@@ -198,7 +198,7 @@ fn create_data_to_transfer(
 
         let frames: Vec<AnimationFrame> = frames
             .map_ok(|frame| {
-                let delay = frame.delay().numer_denom_ms();
+                let delay = frame.delay().number_denom_ms();
 
                 AnimationFrame {
                     delay: delay.0 / delay.1,
@@ -222,10 +222,10 @@ fn create_data_to_transfer(
 
         let mut e = flate2::write::ZlibEncoder::new(Vec::new(), compression);
         e.write_all(image.to_rgba8().as_raw())
-            .context("Error occured when writing image bytes to zlib encoder")?;
+            .context("Error occurred when writing image bytes to zlib encoder")?;
 
         let content = base64::engine::general_purpose::STANDARD
-            .encode(e.finish().context("Error occured when flushing image bytes to zlib encoder")?);
+            .encode(e.finish().context("Error occurred when flushing image bytes to zlib encoder")?);
 
         log::debug!(input_bytes = image_data.len(), compressed_bytes = content.len(), duration:? = start_time.elapsed(); "Image data compression finished");
         Ok(Data::ImageData(ImageData {

--- a/src/ui/image/kitty.rs
+++ b/src/ui/image/kitty.rs
@@ -224,8 +224,9 @@ fn create_data_to_transfer(
         e.write_all(image.to_rgba8().as_raw())
             .context("Error occurred when writing image bytes to zlib encoder")?;
 
-        let content = base64::engine::general_purpose::STANDARD
-            .encode(e.finish().context("Error occurred when flushing image bytes to zlib encoder")?);
+        let content = base64::engine::general_purpose::STANDARD.encode(
+            e.finish().context("Error occurred when flushing image bytes to zlib encoder")?,
+        );
 
         log::debug!(input_bytes = image_data.len(), compressed_bytes = content.len(), duration:? = start_time.elapsed(); "Image data compression finished");
         Ok(Data::ImageData(ImageData {

--- a/src/ui/image/kitty.rs
+++ b/src/ui/image/kitty.rs
@@ -198,7 +198,7 @@ fn create_data_to_transfer(
 
         let frames: Vec<AnimationFrame> = frames
             .map_ok(|frame| {
-                let delay = frame.delay().number_denom_ms();
+                let delay = frame.delay().numer_denom_ms();
 
                 AnimationFrame {
                     delay: delay.0 / delay.1,

--- a/src/ui/image/ueberzug.rs
+++ b/src/ui/image/ueberzug.rs
@@ -34,7 +34,7 @@ struct UeberzugDaemon {
 }
 
 const IDENTIFIER: &str = "rmpc-albumart";
-const PID_FILE_TIMOUT: Duration = Duration::from_secs(5);
+const PID_FILE_TIMEOUT: Duration = Duration::from_secs(5);
 const UEBERZUG_ALBUM_ART_PATH: &str = "/tmp/rmpc/albumart";
 const UEBERZUG_ALBUM_ART_DIR: &str = "/tmp/rmpc";
 
@@ -200,7 +200,7 @@ impl UeberzugDaemon {
     }
 
     #[allow(clippy::cast_sign_loss)]
-    fn is_deamon_running(pid: Pid) -> bool {
+    fn is_daemon_running(pid: Pid) -> bool {
         let mut system = System::new();
         let infopid = sysinfo::Pid::from_u32(pid.0 as u32);
         system.refresh_processes_specifics(
@@ -234,7 +234,7 @@ impl UeberzugDaemon {
             self.ueberzug_process = Some(child);
             return Ok(pid);
         };
-        if Self::is_deamon_running(pid) {
+        if Self::is_daemon_running(pid) {
             Ok(pid)
         } else {
             let (pid, child) = self.spawn_daemon()?;
@@ -247,7 +247,7 @@ impl UeberzugDaemon {
         let start = std::time::Instant::now();
 
         while let Err(err) = std::fs::read_to_string(&self.pid_file) {
-            if err.kind() == ErrorKind::NotFound && start.elapsed() < PID_FILE_TIMOUT {
+            if err.kind() == ErrorKind::NotFound && start.elapsed() < PID_FILE_TIMEOUT {
                 std::thread::sleep(Duration::from_millis(100));
             } else {
                 return Err(err.into());

--- a/src/ui/panes/property.rs
+++ b/src/ui/panes/property.rs
@@ -41,7 +41,7 @@ impl Pane for PropertyPane<'_> {
                 song,
                 context,
                 &context.config.theme.format_tag_separator,
-                context.config.theme.mutliple_tag_resolution_strategy,
+                context.config.theme.multiple_tag_resolution_strategy,
             ) {
                 Some(Either::Left(span)) => acc.push(span),
                 Some(Either::Right(ref mut spans)) => acc.append(spans),

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -175,7 +175,7 @@ impl Pane for QueuePane {
                             max_len,
                             &config.theme.symbols,
                             &config.theme.format_tag_separator,
-                            config.theme.mutliple_tag_resolution_strategy,
+                            config.theme.multiple_tag_resolution_strategy,
                         )
                         .unwrap_or_default()
                         .alignment(formats[i].alignment.into());
@@ -274,7 +274,7 @@ impl Pane for QueuePane {
         ])
         .areas(queue_area);
 
-        // Aplly empty margin on left and right
+        // Apply empty margin on left and right
         let table_block_area = table_block_area.shrink_horizontally(1);
         let header_area = header_area.shrink_horizontally(1);
         // Make scrollbar not overlap header/table separator if separator is visible

--- a/src/ui/widgets/header.rs
+++ b/src/ui/widgets/header.rs
@@ -68,7 +68,7 @@ impl<'a> PropertyTemplates<'a> {
                 song,
                 context,
                 &config.theme.format_tag_separator,
-                config.theme.mutliple_tag_resolution_strategy,
+                config.theme.multiple_tag_resolution_strategy,
             ) {
                 Some(Either::Left(span)) => acc.push(span),
                 Some(Either::Right(ref mut spans)) => acc.append(spans),

--- a/src/ui/widgets/input.rs
+++ b/src/ui/widgets/input.rs
@@ -34,7 +34,7 @@ impl Widget for Input<'_> {
             if self.focused { self.focused_style } else { self.unfocused_style };
 
         let label = Paragraph::new(self.label).wrap(Wrap { trim: false }).style(self.label_style);
-        let mut input = Paragraph::new(self.trimed_text(input_area)).style(self.input_style);
+        let mut input = Paragraph::new(self.trimmed_text(input_area)).style(self.input_style);
 
         if !self.borderless {
             input = input.block(
@@ -57,7 +57,7 @@ impl Widget for Input<'_> {
 
 #[allow(unused)]
 impl<'a> Input<'a> {
-    fn trimed_text(&self, input_area: ratatui::layout::Rect) -> Cow<'a, str> {
+    fn trimmed_text(&self, input_area: ratatui::layout::Rect) -> Cow<'a, str> {
         if self.text.is_empty() && !self.focused {
             return Cow::Borrowed(self.placeholder.unwrap_or(""));
         }

--- a/src/ui/widgets/scan_status.rs
+++ b/src/ui/widgets/scan_status.rs
@@ -13,7 +13,7 @@ impl ScanStatus {
         Self { update_start }
     }
 
-    /// get updating symbol, this symbol rotates in set inverval if the db is
+    /// get updating symbol, this symbol rotates in set interval if the db is
     /// scanning
     pub fn get_str(&mut self) -> Option<&str> {
         let start = self.update_start?;


### PR DESCRIPTION
## Description
Here is a `pull request` addressing the typos noted in #450 as well as other misspelling

_note:_ I will keep this `pull request` in `Draft` until I have addressed all typos I can find

### Related issues
#450

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [ ] Changelog has been updated


### Important to note:
this `pull request` is fixing typos found in the changelog and configuration options name

which means breaking change for people already using those options
this is a necessary fix to avoid more affected users once the typos are present in a versioned release

If you wish to delay or edit this `pull request`, feel free to do so. And please let me know why so I can help further.