### PR TITLE
feat(outputs): Add plugin field to Output struct

### DIFF
--- a/src/mpd/commands/outputs.rs
+++ b/src/mpd/commands/outputs.rs
@@ -12,6 +12,7 @@ pub struct Output {
     pub id: u32,
     pub name: String,
     pub enabled: bool,
+    pub plugin: String,
 }
 
 impl FromMpd for Outputs {
@@ -41,6 +42,7 @@ impl FromMpd for Output {
                 "1" => self.enabled = true,
                 _ => return Ok(LineHandled::No { value }),
             },
+            "plugin" => self.plugin = value,
             _ => return Ok(LineHandled::No { value }),
         }
         Ok(LineHandled::Yes)


### PR DESCRIPTION
Add plugin field to track the output plugin type used by MPD audio
outputs. This adds the "plugin" attribute to the output object
generated by `rmpc outputs`.

Example:

```cmdline
john@saturn:~/ > rmpc outputs
[{"id":0,"name":"Snapserver","enabled":true,"plugin":"fifo"}]
```