### PR TITLE
fix: incorrect warning when using addyt from cli

### DIFF
--- a/docs/src/content/docs/next/reference/cli-command-mode.mdx
+++ b/docs/src/content/docs/next/reference/cli-command-mode.mdx
@@ -24,46 +24,56 @@ You can also get help for a specific command by running the command with `--help
 Usage: rmpc [OPTIONS] [COMMAND]
 
 Commands:
-  config         Prints the default config. Can be used to bootstrap your config file
-  theme          Prints the default theme. Can be used to bootstrap your theme file
-  lyricsindex    Index the lyrics dir and display result, meant only for debugging purposes
-  update         Scan MPD's music directory for updates
-  rescan         Scan MPD's music directory for updates. Also rescans unmodified files
-  albumart       Saves the current album art to a file. Exit codes: * 0: Success * 1: Error * 2: No album art found * 3: No song playing
-  debuginfo      Prints information about optional runtime dependencies
-  version        Prints the rmpc version
-  play           Plays song at the position in the current playlist. Defaults to current paused song
-  pause          Pause playback
-  unpause        Unpause playback
-  togglepause    Toggles between play and pause
-  stop           Stops playback
-  next           Plays the next song in the playlist
-  prev           Plays the previous song in the playlist
-  volume         Sets volume, relative if prefixed by + or -. Prints current volume if no arguments is given
-  repeat         On or off
-  random         On or off
-  single         On, off or oneshot
-  consume        On, off or oneshot
-  seek           Seeks current song(seconds), relative if prefixed by + or -
-  clear          Clear the current queue
-  add            Add a song to the current queue. Relative to music database root. '/' to add all files to the queue
-  addyt          Add a song from youtube to the current queue
-  outputs        List MPD outputs
-  toggleoutput   Toggle MPD output on or off
-  enableoutput   Enable MPD output
-  disableoutput  Disable MPD output
-  decoders       List MPD decoder plugins
-  status         Prints various information like the playback status
-  song           Prints info about the current song. If --path specified, prints information about the song at the given path instead. If --path is specified multiple times, prints an array containing all the songs
-  mount          Mounts supported storage to MPD
-  unmount        Unmounts storage with given name
-  listmounts     List currently mounted storages
-  sticker        Manipulate and query song stickers
-  remote         Send a remote command to running rmpc instance
-  help           Print this message or the help of the given subcommand(s)
+  addrandom
+  config          Prints the default config. Can be used to bootstrap your config file
+  theme           Prints the default theme. Can be used to bootstrap your theme file
+  lyricsindex     Index the lyrics dir and display result, meant only for debugging purposes
+  update          Scan MPD's music directory for updates
+  rescan          Scan MPD's music directory for updates. Also rescans unmodified files
+  albumart        Saves the current album art to a file. Exit codes: * 0: Success * 1: Error * 2: No album art found * 3: No song playing
+  debuginfo       Prints information about optional runtime dependencies
+  version         Prints the rmpc version
+  play            Plays song at the position in the current playlist. Defaults to current paused song
+  pause           Pause playback
+  unpause         Unpause playback
+  togglepause     Toggles between play and pause
+  stop            Stops playback
+  next            Plays the next song in the playlist
+  prev            Plays the previous song in the playlist
+  volume          Sets volume, relative if prefixed by + or -. Prints current volume if no arguments is given
+  repeat          On or off
+  random          On or off
+  single          On, off or oneshot
+  consume         On, off or oneshot
+  togglerepeat    Toggles the repeat mode
+  togglerandom    Toggles the random mode
+  togglesingle    Toggles the single mode
+  toggleconsume   Toggles the consume mode
+  seek            Seeks current song(seconds), relative if prefixed by + or -
+  clear           Clear the current queue
+  add             Add a song to the current queue. Relative to music database root. '/' to add all files to the queue
+  addyt           Add a song from youtube to the current queue
+  outputs         List MPD outputs
+  toggleoutput    Toggle MPD output on or off
+  enableoutput    Enable MPD output
+  disableoutput   Disable MPD output
+  decoders        List MPD decoder plugins
+  status          Prints various information like the playback status
+  song            Prints info about the current song. If --path specified, prints information about the song at the given path instead. If --path is specified multiple times, prints an array containing all the songs
+  mount           Mounts supported storage to MPD
+  unmount         Unmounts storage with given name
+  listmounts      List currently mounted storages
+  listpartitions  List the currently existing partitions
+  sticker         Manipulate and query song stickers
+  remote          Send a remote command to running rmpc instance
+  help            Print this message or the help of the given subcommand(s)
 
 Options:
-  -c, --config <FILE>      [default: /home/<USER>/.config/rmpc/config.debug.ron]
-  -a, --address <ADDRESS>  Override the address to connect to. Defaults to value in the config file
-  -h, --help               Print help
+  -c, --config <FILE>
+  -t, --theme <FILE>
+  -a, --address <ADDRESS>      Override the address to connect to. Defaults to value in the config file
+  -p, --password <PASSWORD>    Override the MPD password
+      --partition <PARTITION>  Partition to connect to at startup
+      --autocreate             Automatically create the partition if it does not exist. Requires partition to be set
+  -h, --help                   Print help
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,10 +183,10 @@ fn main() -> Result<()> {
                     ConfigFile::default().into()
                 }
             };
-            let mut config = config.into_config(args.address, args.password);
+            let config = config.into_config(args.address, args.password);
             let mut client = Client::init(
-                std::mem::take(&mut config.address),
-                std::mem::take(&mut config.password),
+                config.address.clone(),
+                config.password.clone(),
                 "main",
                 args.partition.partition,
                 args.partition.autocreate,


### PR DESCRIPTION
## Description

Warning about socket connection was incorrectly shown in the CLI. Also update CLI reference in docs.

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
