### PR TITLE
Add youtu.be url support for addyt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ lists they are listed as multiple entries.
 - Directories pane now displays playlists located in your music directory. Also added `show_playlists_in_browser`
 to hide them.
 - Added ratio size. This size is relative to its parent size.
+- Added youtu.be URL support
 
 ### Changed
 

--- a/src/shared/ytdlp.rs
+++ b/src/shared/ytdlp.rs
@@ -224,6 +224,16 @@ impl FromStr for YtDlpHost {
                     })
                     .ok_or_else(|| anyhow!("No video id found in url"))
             }
+            "youtu.be" => url
+                .path_segments()
+                .with_context(|| format!("Invalid youtube video url: '{s}'"))?
+                .next()
+                .map(|x| YtDlpHost {
+                    id: x.to_string(),
+                    filename: x.to_string(),
+                    kind: YtDlpHostKind::Youtube,
+                })
+                .ok_or_else(|| anyhow!("No video id foun in url")),
             "soundcloud.com" => {
                 let mut path_segments = url.path_segments().context("cannot-be-a-base URL")?;
                 let Some(username) = path_segments.next() else {


### PR DESCRIPTION
## Description
Using a [youtu.be url](https://www.youtu.be/dQw4w9WgXcQ) returns an error because the URL wasn't supported, this pull request fixes that (I guess)
Thanks for this AMAZING mpd client btw!
### Related issues
None that I noticed
### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
