### PR TITLE
fix: fix scrollbar panic on empty area, further progress bar fix

### DIFF
--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -235,11 +235,13 @@ impl Pane for QueuePane {
 
         self.scrolling_state.set_viewport_len(Some(self.areas[Areas::Table].height.into()));
         if let Some(scrollbar) = config.as_styled_scrollbar() {
-            frame.render_stateful_widget(
-                scrollbar,
-                self.areas[Areas::Scrollbar],
-                self.scrolling_state.as_scrollbar_state_ref(),
-            );
+            if self.areas[Areas::Scrollbar].width > 0 {
+                frame.render_stateful_widget(
+                    scrollbar,
+                    self.areas[Areas::Scrollbar],
+                    self.scrolling_state.as_scrollbar_state_ref(),
+                );
+            }
         }
 
         if let Some(filter_text) = filter_text {

--- a/src/ui/widgets/progress_bar.rs
+++ b/src/ui/widgets/progress_bar.rs
@@ -79,7 +79,7 @@ impl<'a> ProgressBar<'a> {
 
 impl Widget for ProgressBar<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
-        if area.height < 1 {
+        if area.height < 1 || area.width < 1 {
             return;
         }
 


### PR DESCRIPTION
## Description

Fix UI thread panicking when scrollbar area is empty, add further check to progress bar
### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
