### PR TITLE
feat: cava orientation config

### DIFF
--- a/docs/src/content/docs/next/configuration/cava.mdx
+++ b/docs/src/content/docs/next/configuration/cava.mdx
@@ -81,6 +81,12 @@ cava: (
     bar_width: 1, // width of a single bar in columns
     bar_spacing: 1, // free space between bars in columns
 
+    // Possible values are "Top", "Bottom" and "Horizontal". Top makes the bars go from top to
+    // bottom, "Bottom" is from bottom up, and "Horizontal" is split in the middle with bars going
+    // both down and up from there.
+    // Using non-default bar_symbols with "Top" and "Horizontal" will produce undesired output.
+    orientation: Bottom,
+
     // Colors can be configured in three different ways: a single color, different colors
     // per row and a gradient. You can use the same colors as everywhere else. Only specify
     // one of these:

--- a/src/config/theme/cava.rs
+++ b/src/config/theme/cava.rs
@@ -27,6 +27,8 @@ pub struct CavaThemeFile {
     pub bar_spacing: u16,
     #[serde(default = "defaults::u16::<1>")]
     pub bar_width: u16,
+    #[serde(default)]
+    pub orientation: Orientation,
 }
 
 impl Default for CavaThemeFile {
@@ -37,6 +39,7 @@ impl Default for CavaThemeFile {
             bar_color: CavaColorFile::Single("blue".into()),
             bar_spacing: 1,
             bar_width: 1,
+            orientation: Orientation::default(),
         }
     }
 }
@@ -49,6 +52,7 @@ pub struct CavaTheme {
     pub bar_color: CavaColor,
     pub bar_spacing: u16,
     pub bar_width: u16,
+    pub orientation: Orientation,
 }
 
 impl Default for CavaTheme {
@@ -60,8 +64,17 @@ impl Default for CavaTheme {
             bar_color: CavaColor::Single(CrosstermColor::Blue),
             bar_spacing: 1,
             bar_width: 1,
+            orientation: Orientation::default(),
         }
     }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Orientation {
+    Top,
+    #[default]
+    Bottom,
+    Horizontal,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -106,6 +119,7 @@ impl CavaThemeFile {
                 .collect(),
             bar_spacing: self.bar_spacing,
             bar_width: self.bar_width,
+            orientation: self.orientation,
             bg_color: self
                 .bg_color
                 .map(|c| -> Result<RatatuiColor> {

--- a/src/ui/panes/cava.rs
+++ b/src/ui/panes/cava.rs
@@ -17,7 +17,10 @@ use ratatui::{Frame, layout::Rect};
 
 use super::Pane;
 use crate::{
-    config::{cava::Cava, theme::cava::CavaTheme},
+    config::{
+        cava::Cava,
+        theme::cava::{CavaTheme, Orientation},
+    },
     context::AppContext,
     mpd::commands::State,
     shared::{
@@ -111,8 +114,11 @@ impl CavaPane {
         empty_bar_symbol: &str,
         theme: &CavaTheme,
     ) -> Result<()> {
-        let height = area.height;
         let mut writer = writer.lock();
+        let height = match theme.orientation {
+            Orientation::Top | Orientation::Bottom => area.height,
+            Orientation::Horizontal => area.height / 2,
+        };
 
         queue!(writer, BeginSynchronizedUpdate, SavePosition)?;
 
@@ -121,17 +127,46 @@ impl CavaPane {
             let x = area.x + x_offset + col_idx * theme.bar_width + col_idx * theme.bar_spacing;
 
             for y in 0..height {
-                let h = area.y + (height - 1) - y;
-                let color = theme.bar_color.get_color(y as usize, area.height);
+                let color = theme.bar_color.get_color(y as usize, height);
                 let fill_amount = (*column - f32::from(y)).clamp(0.0, 0.99);
-                queue!(writer, MoveTo(x, h))?;
-                if fill_amount < 0.01 {
-                    queue!(writer, PrintStyledContent(empty_bar_symbol.on(theme.bg_color)))?;
-                } else {
-                    let char_index =
-                        (fill_amount * theme.bar_symbols_count as f32).floor() as usize;
-                    let fill_char = theme.bar_symbols[char_index].as_str();
-                    queue!(writer, PrintStyledContent(fill_char.with(color).on(theme.bg_color)))?;
+
+                // render from bottom to top
+                if matches!(theme.orientation, Orientation::Horizontal | Orientation::Top) {
+                    let y = area.y + (height - 1) - y;
+                    queue!(writer, MoveTo(x, y))?;
+                    if fill_amount < 0.01 {
+                        queue!(writer, PrintStyledContent(empty_bar_symbol.on(theme.bg_color)))?;
+                    } else {
+                        let char_index =
+                            (fill_amount * theme.bar_symbols_count as f32).floor() as usize;
+                        let fill_char = theme.bar_symbols[char_index].as_str();
+                        queue!(
+                            writer,
+                            PrintStyledContent(fill_char.with(color).on(theme.bg_color))
+                        )?;
+                    }
+                }
+
+                // render from top to bottom with inverted characters
+                let y = match theme.orientation {
+                    Orientation::Bottom => Some(area.y + y),
+                    Orientation::Horizontal => Some(area.y + height + y),
+                    Orientation::Top => None,
+                };
+                if let Some(y) = y {
+                    queue!(writer, MoveTo(x, y))?;
+                    if fill_amount > 0.98 {
+                        queue!(writer, PrintStyledContent(empty_bar_symbol.on(color)))?;
+                    } else {
+                        let char_index =
+                            (fill_amount * theme.bar_symbols_count as f32).floor() as usize;
+                        let fill_char =
+                            theme.bar_symbols[theme.bar_symbols.len() - 1 - char_index].as_str();
+                        queue!(
+                            writer,
+                            PrintStyledContent(fill_char.with(theme.bg_color).on(color))
+                        )?;
+                    }
                 }
             }
         }
@@ -218,8 +253,13 @@ impl CavaPane {
             let mut columns = vec![0_f32; bars as usize];
             let mut buf = vec![0_u8; 2 * bars as usize];
 
+            let bar_height = match cava_theme.orientation {
+                Orientation::Top | Orientation::Bottom => area.height,
+                Orientation::Horizontal => area.height / 2,
+            };
+
             'inner: loop {
-                Self::read_cava_data(area.height, &mut buf, &mut columns, stdout, stderr)?;
+                Self::read_cava_data(bar_height, &mut buf, &mut columns, stdout, stderr)?;
                 Self::render_cava(
                     writer,
                     area,

--- a/src/ui/panes/cava.rs
+++ b/src/ui/panes/cava.rs
@@ -129,6 +129,7 @@ impl CavaPane {
             for y in 0..height {
                 let color = theme.bar_color.get_color(y as usize, height);
                 let fill_amount = (*column - f32::from(y)).clamp(0.0, 0.99);
+                let char_index = (fill_amount * theme.bar_symbols_count as f32).floor() as usize;
 
                 // render from bottom to top
                 if matches!(theme.orientation, Orientation::Horizontal | Orientation::Bottom) {
@@ -137,8 +138,6 @@ impl CavaPane {
                     if fill_amount < 0.01 {
                         queue!(writer, PrintStyledContent(empty_bar_symbol.on(theme.bg_color)))?;
                     } else {
-                        let char_index =
-                            (fill_amount * theme.bar_symbols_count as f32).floor() as usize;
                         let fill_char = theme.bar_symbols[char_index].as_str();
                         queue!(
                             writer,
@@ -158,10 +157,8 @@ impl CavaPane {
                     if fill_amount > 0.98 {
                         queue!(writer, PrintStyledContent(empty_bar_symbol.on(color)))?;
                     } else {
-                        let char_index =
-                            (fill_amount * theme.bar_symbols_count as f32).floor() as usize;
                         let fill_char =
-                            theme.bar_symbols[theme.bar_symbols.len() - 1 - char_index].as_str();
+                            theme.bar_symbols[theme.bar_symbols_count - 1 - char_index].as_str();
                         queue!(
                             writer,
                             PrintStyledContent(fill_char.with(theme.bg_color).on(color))

--- a/src/ui/panes/cava.rs
+++ b/src/ui/panes/cava.rs
@@ -131,7 +131,7 @@ impl CavaPane {
                 let fill_amount = (*column - f32::from(y)).clamp(0.0, 0.99);
 
                 // render from bottom to top
-                if matches!(theme.orientation, Orientation::Horizontal | Orientation::Top) {
+                if matches!(theme.orientation, Orientation::Horizontal | Orientation::Bottom) {
                     let y = area.y + (height - 1) - y;
                     queue!(writer, MoveTo(x, y))?;
                     if fill_amount < 0.01 {
@@ -149,9 +149,9 @@ impl CavaPane {
 
                 // render from top to bottom with inverted characters
                 let y = match theme.orientation {
-                    Orientation::Bottom => Some(area.y + y),
+                    Orientation::Top => Some(area.y + y),
                     Orientation::Horizontal => Some(area.y + height + y),
-                    Orientation::Top => None,
+                    Orientation::Bottom => None,
                 };
                 if let Some(y) = y {
                     queue!(writer, MoveTo(x, y))?;


### PR DESCRIPTION
## Description

```ron
orientation: Horizontal
```
![image](https://github.com/user-attachments/assets/b6f52045-4616-4b3c-84d3-b10de51dddf2)

```ron
orientation: Top
```
![image](https://github.com/user-attachments/assets/e7bd8ad7-2d54-4404-a2c7-021a89b6cabe)


### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
