### PR TITLE
fix: cava bg color and add inverted symbols

### DIFF
--- a/docs/src/content/docs/next/configuration/cava.mdx
+++ b/docs/src/content/docs/next/configuration/cava.mdx
@@ -76,6 +76,9 @@ cava: (
     // symbols that will be used to draw the bar in the visualiser, in ascending order of
     // fill fraction
     bar_symbols: ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'],
+    // similar to bar_symbols but these are used for the top-down rendering, meaning for orientation
+    // "Horizontal" and "Top"
+    inverted_bar_symbols: ['▔', '🮂', '🮃', '▀', '🮄', '🮅', '🮆', '█'],
 
     bg_color: "black", // background color, defaults to rmpc's bg color if not provided
     bar_width: 1, // width of a single bar in columns
@@ -84,7 +87,7 @@ cava: (
     // Possible values are "Top", "Bottom" and "Horizontal". Top makes the bars go from top to
     // bottom, "Bottom" is from bottom up, and "Horizontal" is split in the middle with bars going
     // both down and up from there.
-    // Using non-default bar_symbols with "Top" and "Horizontal" will produce undesired output.
+    // Using non-default symbols with "Top" and "Horizontal" may produce undesired output.
     orientation: Bottom,
 
     // Colors can be configured in three different ways: a single color, different colors

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -34,6 +34,10 @@ pub fn default_bar_symbols() -> Vec<char> {
     "▁▂▃▄▅▆▇█".chars().collect()
 }
 
+pub fn default_inverted_bar_symbols() -> Vec<char> {
+    "▔🮂🮃▀🮄🮅🮆█".chars().collect()
+}
+
 pub fn default_progress_update_interval_ms() -> Option<u64> {
     Some(1000)
 }

--- a/src/config/theme/cava.rs
+++ b/src/config/theme/cava.rs
@@ -19,6 +19,8 @@ use crate::shared::ext::vec::VecExt;
 pub struct CavaThemeFile {
     #[serde(default = "defaults::default_bar_symbols")]
     pub bar_symbols: Vec<char>,
+    #[serde(default = "defaults::default_inverted_bar_symbols")]
+    pub inverted_bar_symbols: Vec<char>,
     #[serde(default)]
     pub bg_color: Option<String>,
     #[serde(default)]
@@ -35,7 +37,8 @@ impl Default for CavaThemeFile {
     fn default() -> Self {
         Self {
             bar_symbols: "▁▂▃▄▅▆▇█".chars().collect(),
-            bg_color: Some("black".to_owned()),
+            inverted_bar_symbols: "▔🮂🮃▀🮄🮅🮆█".chars().collect(),
+            bg_color: None,
             bar_color: CavaColorFile::Single("blue".into()),
             bar_spacing: 1,
             bar_width: 1,
@@ -47,7 +50,9 @@ impl Default for CavaThemeFile {
 #[derive(Debug, Clone)]
 pub struct CavaTheme {
     pub bar_symbols: Vec<String>,
+    pub inverted_bar_symbols: Vec<String>,
     pub bar_symbols_count: usize,
+    pub inverted_bar_symbols_count: usize,
     pub bg_color: CrosstermColor,
     pub bar_color: CavaColor,
     pub bar_spacing: u16,
@@ -59,7 +64,9 @@ impl Default for CavaTheme {
     fn default() -> Self {
         Self {
             bar_symbols_count: 8,
+            inverted_bar_symbols_count: 8,
             bar_symbols: "▁▂▃▄▅▆▇█".chars().map(|c| c.to_string()).collect(),
+            inverted_bar_symbols: "▔🮂🮃▀🮄🮅🮆█".chars().map(|c| c.to_string()).collect(),
             bg_color: CrosstermColor::Black,
             bar_color: CavaColor::Single(CrosstermColor::Blue),
             bar_spacing: 1,
@@ -112,8 +119,14 @@ impl CavaThemeFile {
     pub fn into_config(self, default_bg_color: Option<RatatuiColor>) -> Result<CavaTheme> {
         Ok(CavaTheme {
             bar_symbols_count: self.bar_symbols.len(),
+            inverted_bar_symbols_count: self.inverted_bar_symbols.len(),
             bar_symbols: self
                 .bar_symbols
+                .into_iter()
+                .map(|c| c.to_string().repeat(self.bar_width as usize))
+                .collect(),
+            inverted_bar_symbols: self
+                .inverted_bar_symbols
                 .into_iter()
                 .map(|c| c.to_string().repeat(self.bar_width as usize))
                 .collect(),

--- a/src/core/event_loop.rs
+++ b/src/core/event_loop.rs
@@ -404,6 +404,7 @@ fn main_task<B: Backend + std::io::Write>(
                     if let Err(err) = terminal.clear() {
                         log::error!(error:? = err; "Failed to clear terminal after a resize");
                     }
+                    render_wanted = true;
                 }
                 AppEvent::UiEvent(event) => match ui.on_ui_app_event(event, &mut context) {
                     Ok(()) => {}

--- a/src/ui/image/mod.rs
+++ b/src/ui/image/mod.rs
@@ -5,7 +5,7 @@ use crossbeam::channel::Receiver;
 use crossterm::{
     cursor::{RestorePosition, SavePosition},
     queue,
-    style::{Colors, SetColors},
+    style::{Colors, ResetColor, SetColors},
 };
 use ratatui::layout::Rect;
 
@@ -50,6 +50,7 @@ pub fn clear_area(mut w: impl Write, colors: Colors, area: Rect) -> Result<()> {
     w.write_all(&buf)?;
     w.flush()?;
     queue!(w, RestorePosition)?;
+    queue!(w, ResetColor)?;
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Fixes handling of cavas background color. It should now render the background color in cava's pane
at all times and also render inbetween the columns.
Also fixes fallback to rmpc's background color if cava's color was not defined.
Additionally, `inverted_bar_symbols` were added to config to be used for the bottom part of the
rendering when using orientation `Horizontal` or `Top` instead of simply inverting colors on the
normal `bar_symbols`. This should match cava's behavior.
And also fixed a small issue introduced recently with cava where rmpc would not issue a rerender
right away after a resize occured.

### Related issues

https://github.com/mierak/rmpc/issues/482

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
