### PR TITLE
fix: use 32 bit usize constants in tests

### DIFF
--- a/src/shared/ext.rs
+++ b/src/shared/ext.rs
@@ -452,7 +452,7 @@ pub mod num {
         #[test_case(6789, "6,789")]
         #[test_case(1, "1")]
         #[test_case(0, "0")]
-        #[test_case(99_999_999_999, "99,999,999,999")]
+        #[test_case(4_294_967_295, "4,294,967,295")] // equivalent to u32::MAX, as not to break 32 bit architectures
         fn usize_format(input: usize, expected: &str) {
             let result = input.with_thousands_separator(",");
 


### PR DESCRIPTION
## Description

This is causing rmpc 0.9.0 to fail to compile on Alpine's 32-bit architectures (x86, armv7, armhf). I will probably just add a patch in aports for now so that you don't need to make a new release just for this.

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [ ] Changelog has been updated 
  - not sure if this is really relevant
