### PR TITLE
refactor: split MPD client in sending/reading parts

### DIFF
--- a/src/mpd/client.rs
+++ b/src/mpd/client.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     io::{BufRead, BufReader, Write},
     net::{Shutdown, TcpStream},
     os::unix::net::UnixStream,
@@ -261,7 +262,7 @@ impl<'name> Client<'name> {
 
     pub fn send<'cmd>(
         &mut self,
-        command: &'cmd str,
+        command: impl Into<Cow<'cmd, str>>,
     ) -> Result<ProtoClient<'cmd, '_, Self>, MpdError> {
         ProtoClient::new(command, self)
     }

--- a/src/mpd/mpd_client.rs
+++ b/src/mpd/mpd_client.rs
@@ -41,6 +41,7 @@ use super::{
 use crate::shared::{ext::error::ErrorExt, macros::status_error};
 
 type MpdResult<T> = Result<T, MpdError>;
+type MpdCommandSubmitResult<'cmd, 'client, C> = Result<ProtoClient<'cmd, 'client, C>, MpdError>;
 
 #[derive(AsRefStr, Debug)]
 #[allow(dead_code)]
@@ -86,6 +87,176 @@ impl ValueChange {
 }
 
 #[allow(dead_code)]
+pub trait MpdCommand<C: SocketClient> {
+    fn send_binary_limit<'cmd>(&mut self, limit: u64) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_password<'cmd>(&mut self, password: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_commands<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_update<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_rescan<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_idle<'cmd>(
+        &mut self,
+        subsystem: Option<IdleEvent>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_noidle<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_start_cmd_list<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_start_cmd_list_ok<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_execute_cmd_list<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_get_volume<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_set_volume<'cmd>(&mut self, volume: Volume) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_volume<'cmd>(&mut self, change: ValueChange) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_get_current_song<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_get_status<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_pause_toggle<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_pause<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_unpause<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_next<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_prev<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_play_pos<'cmd>(&mut self, pos: usize) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_play<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_play_id<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_stop<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_seek_current<'cmd>(
+        &mut self,
+        value: ValueChange,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_repeat<'cmd>(&mut self, enabled: bool) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_random<'cmd>(&mut self, enabled: bool) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_single<'cmd>(&mut self, single: OnOffOneshot) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_consume<'cmd>(&mut self, consume: OnOffOneshot) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_mount<'cmd>(&mut self, name: &str, path: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_unmount<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_list_mounts<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_add<'cmd>(
+        &mut self,
+        path: &str,
+        position: Option<QueuePosition>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_clear<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_delete_id<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_delete_from_queue<'cmd>(
+        &mut self,
+        songs: SingleOrRange,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_playlist_info<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_find<'cmd>(&mut self, filter: &[Filter<'_>]) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_search<'cmd>(&mut self, filter: &[Filter<'_>]) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_move_in_queue<'cmd>(
+        &mut self,
+        from: SingleOrRange,
+        to: QueuePosition,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_move_id<'cmd>(
+        &mut self,
+        id: u32,
+        to: QueuePosition,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_find_add<'cmd>(
+        &mut self,
+        filter: &[Filter<'_>],
+        position: Option<QueuePosition>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_search_add<'cmd>(
+        &mut self,
+        filter: &[Filter<'_>],
+        position: Option<QueuePosition>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_list_tag<'cmd>(
+        &mut self,
+        tag: Tag,
+        filter: Option<&[Filter<'_>]>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_shuffle<'cmd>(
+        &mut self,
+        range: Option<SingleOrRange>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_add_random_songs<'cmd>(
+        &mut self,
+        count: usize,
+        filter: Option<&[Filter<'_>]>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_add_random_tag<'cmd>(
+        &mut self,
+        count: usize,
+        tag: Tag,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_list_all<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_lsinfo<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_list_files<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_read_picture<'cmd>(&mut self, path: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_albumart<'cmd>(&mut self, path: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_list_playlists<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_list_playlist<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_list_playlist_info<'cmd>(
+        &mut self,
+        playlist: &str,
+        range: Option<SingleOrRange>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_load_playlist<'cmd>(
+        &mut self,
+        name: &str,
+        position: Option<QueuePosition>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_rename_playlist<'cmd>(
+        &mut self,
+        name: &str,
+        new_name: &str,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_delete_playlist<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_delete_from_playlist<'cmd>(
+        &mut self,
+        playlist_name: &str,
+        songs: &SingleOrRange,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_move_in_playlist<'cmd>(
+        &mut self,
+        playlist_name: &str,
+        range: &SingleOrRange,
+        target_position: usize,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_add_to_playlist<'cmd>(
+        &mut self,
+        playlist_name: &str,
+        uri: &str,
+        target_position: Option<usize>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_save_queue_as_playlist<'cmd>(
+        &mut self,
+        name: &str,
+        mode: Option<SaveMode>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_outputs<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_toggle_output<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_enable_output<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_disable_output<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_decoders<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_sticker<'cmd>(&mut self, uri: &str, name: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_set_sticker<'cmd>(
+        &mut self,
+        uri: &str,
+        name: &str,
+        value: &str,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_delete_sticker<'cmd>(
+        &mut self,
+        uri: &str,
+        name: &str,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_delete_all_stickers<'cmd>(&mut self, uri: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_list_stickers<'cmd>(&mut self, uri: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_find_stickers<'cmd>(
+        &mut self,
+        uri: &str,
+        name: &str,
+    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_switch_to_partition<'cmd>(&mut self, name: &str)
+    -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_new_partition<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_delete_partition<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_list_partitions<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    fn send_move_output<'cmd>(&mut self, output_name: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
+}
+
+#[allow(dead_code)]
 pub trait MpdClient: Sized {
     fn version(&mut self) -> Version;
     fn config(&mut self) -> Option<&MpdConfig>;
@@ -99,12 +270,6 @@ pub trait MpdClient: Sized {
     where
         Self: SocketClient;
     fn noidle(&mut self) -> MpdResult<()>;
-
-    fn start_cmd_list(&mut self) -> Result<()>;
-    fn start_cmd_list_ok(&mut self) -> Result<()>;
-    fn execute_cmd_list(&mut self) -> MpdResult<ProtoClient<'static, '_, Self>>
-    where
-        Self: SocketClient;
 
     fn get_volume(&mut self) -> MpdResult<Volume>;
     fn set_volume(&mut self, volume: Volume) -> MpdResult<()>;
@@ -172,8 +337,7 @@ pub trait MpdClient: Sized {
     fn load_playlist(&mut self, name: &str, position: Option<QueuePosition>) -> MpdResult<()>;
     fn rename_playlist(&mut self, name: &str, new_name: &str) -> MpdResult<()>;
     fn delete_playlist(&mut self, name: &str) -> MpdResult<()>;
-    fn delete_from_playlist(&mut self, playlist_name: &str, songs: &SingleOrRange)
-    -> MpdResult<()>;
+    fn delete_from_playlist(&mut self, name: &str, songs: &SingleOrRange) -> MpdResult<()>;
     fn move_in_playlist(
         &mut self,
         playlist_name: &str,
@@ -266,193 +430,148 @@ impl MpdClient for Client<'_> {
     }
 
     fn binary_limit(&mut self, limit: u64) -> MpdResult<()> {
-        self.send(&format!("binarylimit {limit}")).and_then(read_ok)
+        self.send_binary_limit(limit).and_then(read_ok)
     }
 
     fn password(&mut self, password: &str) -> MpdResult<()> {
-        self.send(&format!("password {}", password.quote_and_escape())).and_then(read_ok)
+        self.send_password(password).and_then(read_ok)
     }
 
     // Lists commands supported by the MPD server
     fn commands(&mut self) -> MpdResult<MpdList> {
-        self.send("commands").and_then(read_response)
+        self.send_commands().and_then(read_response)
     }
 
     fn update(&mut self, path: Option<&str>) -> MpdResult<Update> {
-        if let Some(path) = path {
-            self.send(&format!("update {}", path.quote_and_escape())).and_then(read_response)
-        } else {
-            self.send("update").and_then(read_response)
-        }
+        self.send_update(path).and_then(read_response)
     }
 
     fn rescan(&mut self, path: Option<&str>) -> MpdResult<Update> {
-        if let Some(path) = path {
-            self.send(&format!("rescan {}", path.quote_and_escape())).and_then(read_response)
-        } else {
-            self.send("rescan").and_then(read_response)
-        }
+        self.send_rescan(path).and_then(read_response)
     }
 
     // Queries
     fn idle(&mut self, subsystem: Option<IdleEvent>) -> MpdResult<Vec<IdleEvent>> {
-        if let Some(subsystem) = subsystem {
-            self.send(&format!("idle {subsystem}")).and_then(read_response)
-        } else {
-            self.send("idle").and_then(read_response)
-        }
+        self.send_idle(subsystem).and_then(read_response)
     }
 
-    fn enter_idle(&mut self) -> MpdResult<ProtoClient<'static, '_, Self>>
-    where
-        Self: SocketClient,
-    {
-        self.send("idle")
+    fn enter_idle(&mut self) -> MpdResult<ProtoClient<'static, '_, Self>> {
+        self.send_idle(None)
     }
 
     fn noidle(&mut self) -> MpdResult<()> {
-        self.send("noidle").and_then(read_ok)
-    }
-
-    fn start_cmd_list(&mut self) -> Result<()> {
-        self.send("command_list_begin")?;
-        Ok(())
-    }
-
-    fn start_cmd_list_ok(&mut self) -> Result<()> {
-        self.send("command_list_ok_begin")?;
-        Ok(())
-    }
-
-    fn execute_cmd_list(&mut self) -> MpdResult<ProtoClient<'static, '_, Self>> {
-        self.send("command_list_end")
+        self.send_noidle().and_then(read_ok)
     }
 
     fn get_volume(&mut self) -> MpdResult<Volume> {
-        if self.version < Version::new(0, 23, 0) {
-            Err(MpdError::UnsupportedMpdVersion("getvol can be used since MPD 0.23.0"))
-        } else {
-            self.send("getvol").and_then(read_response)
-        }
+        self.send_get_volume().and_then(read_response)
     }
 
     fn set_volume(&mut self, volume: Volume) -> MpdResult<()> {
-        self.send(&format!("setvol {}", volume.value())).and_then(read_ok)
+        self.send_set_volume(volume).and_then(read_ok)
     }
 
     fn volume(&mut self, change: ValueChange) -> MpdResult<()> {
-        match change {
-            ValueChange::Increase(_) | ValueChange::Decrease(_) => {
-                self.send(&format!("volume {}", change.to_mpd_str())).and_then(read_ok)
-            }
-            ValueChange::Set(val) => self.send(&format!("setvol {val}")).and_then(read_ok),
-        }
+        self.send_volume(change).and_then(read_ok)
     }
 
     fn get_current_song(&mut self) -> MpdResult<Option<Song>> {
-        self.send("currentsong").and_then(read_opt_response)
+        self.send_get_current_song().and_then(read_opt_response)
     }
 
     fn get_status(&mut self) -> MpdResult<Status> {
-        self.send("status").and_then(read_response)
+        self.send_get_status().and_then(read_response)
     }
 
     // Playback control
     fn pause_toggle(&mut self) -> MpdResult<()> {
-        self.send("pause").and_then(read_ok)
+        self.send_pause_toggle().and_then(read_ok)
     }
 
     fn pause(&mut self) -> MpdResult<()> {
-        self.send("pause 1").and_then(read_ok)
+        self.send_pause().and_then(read_ok)
     }
 
     fn unpause(&mut self) -> MpdResult<()> {
-        self.send("pause 0").and_then(read_ok)
+        self.send_unpause().and_then(read_ok)
     }
 
     fn next(&mut self) -> MpdResult<()> {
-        self.send("next").and_then(read_ok)
+        self.send_next().and_then(read_ok)
     }
 
     fn prev(&mut self) -> MpdResult<()> {
-        self.send("previous").and_then(read_ok)
+        self.send_prev().and_then(read_ok)
     }
 
     fn play_pos(&mut self, pos: usize) -> MpdResult<()> {
-        self.send(&format!("play {pos}")).and_then(read_ok)
+        self.send_play_pos(pos).and_then(read_ok)
     }
 
     fn play(&mut self) -> MpdResult<()> {
-        self.send("play").and_then(read_ok)
+        self.send_play().and_then(read_ok)
     }
 
     fn play_id(&mut self, id: u32) -> MpdResult<()> {
-        self.send(&format!("playid {id}")).and_then(read_ok)
+        self.send_play_id(id).and_then(read_ok)
     }
 
     fn stop(&mut self) -> MpdResult<()> {
-        self.send("stop").and_then(read_ok)
+        self.send_stop().and_then(read_ok)
     }
 
     fn seek_current(&mut self, value: ValueChange) -> MpdResult<()> {
-        self.send(&format!("seekcur {}", value.to_mpd_str())).and_then(read_ok)
+        self.send_seek_current(value).and_then(read_ok)
     }
 
     fn repeat(&mut self, enabled: bool) -> MpdResult<()> {
-        self.send(&format!("repeat {}", u8::from(enabled))).and_then(read_ok)
+        self.send_repeat(enabled).and_then(read_ok)
     }
 
     fn random(&mut self, enabled: bool) -> MpdResult<()> {
-        self.send(&format!("random {}", u8::from(enabled))).and_then(read_ok)
+        self.send_random(enabled).and_then(read_ok)
     }
 
     fn single(&mut self, single: OnOffOneshot) -> MpdResult<()> {
-        self.send(&format!("single {}", single.to_mpd_value())).and_then(read_ok)
+        self.send_single(single).and_then(read_ok)
     }
 
     fn consume(&mut self, consume: OnOffOneshot) -> MpdResult<()> {
-        if self.version < Version::new(0, 24, 0) && matches!(consume, OnOffOneshot::Oneshot) {
-            Err(MpdError::UnsupportedMpdVersion("consume oneshot can be used since MPD 0.24.0"))
-        } else {
-            self.send(&format!("consume {}", consume.to_mpd_value())).and_then(read_ok)
-        }
+        self.send_consume(consume).and_then(read_ok)
     }
 
     // Mounts
     fn mount(&mut self, name: &str, path: &str) -> MpdResult<()> {
-        self.send(&format!("mount {} {}", name.quote_and_escape(), path.quote_and_escape()))
-            .and_then(read_ok)
+        self.send_mount(name, path).and_then(read_ok)
     }
 
     fn unmount(&mut self, name: &str) -> MpdResult<()> {
-        self.send(&format!("unmount {}", name.quote_and_escape())).and_then(read_ok)
+        self.send_unmount(name).and_then(read_ok)
     }
 
     fn list_mounts(&mut self) -> MpdResult<Mounts> {
-        self.send("listmounts").and_then(read_response)
+        self.send_list_mounts().and_then(read_response)
     }
 
     // Current queue
     fn add(&mut self, uri: &str, position: Option<QueuePosition>) -> MpdResult<()> {
-        let position_arg: String =
-            position.map_or(String::new(), |v| format!(" {}", v.as_mpd_str()));
-        self.send(&format!("add {}{position_arg}", uri.quote_and_escape())).and_then(read_ok)
+        self.send_add(uri, position).and_then(read_ok)
     }
 
     fn clear(&mut self) -> MpdResult<()> {
-        self.send("clear").and_then(read_ok)
+        self.send_clear().and_then(read_ok)
     }
 
     fn delete_id(&mut self, id: u32) -> MpdResult<()> {
-        self.send(&format!("deleteid {id}")).and_then(read_ok)
+        self.send_delete_id(id).and_then(read_ok)
     }
 
     fn delete_from_queue(&mut self, songs: SingleOrRange) -> MpdResult<()> {
-        self.send(&format!("delete {}", songs.as_mpd_range())).and_then(read_ok)
+        self.send_delete_from_queue(songs).and_then(read_ok)
     }
 
     fn playlist_info(&mut self, fetch_stickers: bool) -> MpdResult<Option<Vec<Song>>> {
-        let songs: Option<Vec<Song>> = self.send("playlistinfo").and_then(read_opt_response)?;
+        let songs: Option<Vec<Song>> = self.send_playlist_info().and_then(read_opt_response)?;
 
         if !fetch_stickers {
             return Ok(songs);
@@ -486,31 +605,26 @@ impl MpdClient for Client<'_> {
 
     /// Search the database for songs matching FILTER
     fn find(&mut self, filter: &[Filter<'_>]) -> MpdResult<Vec<Song>> {
-        self.send(&format!("find \"({})\"", filter.to_query_str())).and_then(read_response)
+        self.send_find(filter).and_then(read_response)
     }
 
     /// Search the database for songs matching FILTER (see Filters).
     /// Parameters have the same meaning as for find, except that search is not
     /// case sensitive.
     fn search(&mut self, filter: &[Filter<'_>]) -> MpdResult<Vec<Song>> {
-        let query = filter.to_query_str();
-        let query = query.as_str();
-        log::debug!(query; "Searching for songs");
-        self.send(&format!("search \"({query})\"")).and_then(read_response)
+        self.send_search(filter).and_then(read_response)
     }
 
     fn move_in_queue(&mut self, from: SingleOrRange, to: QueuePosition) -> MpdResult<()> {
-        self.send(&format!("move {} {}", from.as_mpd_range(), to.as_mpd_str())).and_then(read_ok)
+        self.send_move_in_queue(from, to).and_then(read_ok)
     }
 
     fn move_id(&mut self, id: u32, to: QueuePosition) -> MpdResult<()> {
-        self.send(&format!("moveid {id} \"{}\"", to.as_mpd_str())).and_then(read_ok)
+        self.send_move_id(id, to).and_then(read_ok)
     }
 
     fn find_one(&mut self, filter: &[Filter<'_>]) -> MpdResult<Option<Song>> {
-        let mut songs: Vec<Song> =
-            self.send(&format!("find \"({})\"", filter.to_query_str())).and_then(read_response)?;
-
+        let mut songs: Vec<Song> = self.send_find(filter).and_then(read_response)?;
         Ok(songs.pop())
     }
 
@@ -519,10 +633,7 @@ impl MpdClient for Client<'_> {
         filter: &[Filter<'_>],
         position: Option<QueuePosition>,
     ) -> MpdResult<()> {
-        let position_arg: String =
-            position.map_or(String::new(), |v| format!(" position {}", v.as_mpd_str()));
-        self.send(&format!("findadd \"({})\"{position_arg}", filter.to_query_str()))
-            .and_then(read_ok)
+        self.send_find_add(filter, position).and_then(read_ok)
     }
 
     /// Search the database for songs matching FILTER (see Filters) AND add them
@@ -533,29 +644,15 @@ impl MpdClient for Client<'_> {
         filter: &[Filter<'_>],
         position: Option<QueuePosition>,
     ) -> MpdResult<()> {
-        let query = filter.to_query_str();
-        let query = query.as_str();
-        let position_arg: String =
-            position.map_or(String::new(), |v| format!(" position {}", v.as_mpd_str()));
-        log::debug!(query; "Searching for songs and adding them");
-        self.send(&format!("searchadd \"({query})\"{position_arg}")).and_then(read_ok)
+        self.send_search_add(filter, position).and_then(read_ok)
     }
 
     fn list_tag(&mut self, tag: Tag, filter: Option<&[Filter<'_>]>) -> MpdResult<MpdList> {
-        self.send(&if let Some(filter) = filter {
-            format!("list {} \"({})\"", tag.as_str(), filter.to_query_str())
-        } else {
-            format!("list {}", tag.as_str())
-        })
-        .and_then(read_response)
+        self.send_list_tag(tag, filter).and_then(read_response)
     }
 
     fn shuffle(&mut self, range: Option<SingleOrRange>) -> MpdResult<()> {
-        if let Some(range) = range {
-            self.send(&format!("shuffle {}", range.as_mpd_range())).and_then(read_ok)
-        } else {
-            self.send("shuffle").and_then(read_ok)
-        }
+        self.send_shuffle(range).and_then(read_ok)
     }
 
     #[allow(clippy::needless_range_loop)]
@@ -574,11 +671,11 @@ impl MpdClient for Client<'_> {
         }
         result.shuffle(&mut rand::rng());
 
-        self.start_cmd_list()?;
+        self.send_start_cmd_list()?;
         for i in 0..count {
-            self.send(&format!("add {}", result[i].quote_and_escape()))?;
+            self.send_add(&result[i], None)?;
         }
-        self.execute_cmd_list().and_then(read_ok)
+        self.send_execute_cmd_list().and_then(read_ok)
     }
 
     #[allow(clippy::needless_range_loop)]
@@ -594,62 +691,46 @@ impl MpdClient for Client<'_> {
 
         tag_values.shuffle(&mut rand::rng());
 
-        self.start_cmd_list()?;
+        self.send_start_cmd_list()?;
         for i in 0..count {
             let filter = &[Filter::new_with_kind(
                 tag.clone(),
                 std::mem::take(&mut tag_values[i]),
                 FilterKind::Exact,
             )] as &[_];
-            self.send(&format!("findadd \"({})\"", filter.to_query_str()))?;
+            self.send_find_add(filter, None)?;
         }
-        self.execute_cmd_list().and_then(read_ok)
+        self.send_execute_cmd_list().and_then(read_ok)
     }
 
     fn list_all(&mut self, path: Option<&str>) -> MpdResult<LsInfo> {
-        if let Some(path) = path {
-            self.send(&format!("listall {}", path.quote_and_escape())).and_then(read_response)
-        } else {
-            self.send("listall").and_then(read_response)
-        }
+        self.send_list_all(path).and_then(read_response)
     }
 
     // Database
     fn lsinfo(&mut self, path: Option<&str>) -> MpdResult<LsInfo> {
-        Ok(if let Some(path) = path {
-            self.send(&format!("lsinfo {}", path.quote_and_escape()))
-                .and_then(read_opt_response)?
-                .unwrap_or_default()
-        } else {
-            self.send("lsinfo").and_then(read_opt_response)?.unwrap_or_default()
-        })
+        Ok(self.send_lsinfo(path).and_then(read_opt_response)?.unwrap_or_default())
     }
 
     fn list_files(&mut self, path: Option<&str>) -> MpdResult<ListFiles> {
-        Ok(if let Some(path) = path {
-            self.send(&format!("listfiles {}", path.quote_and_escape()))
-                .and_then(read_opt_response)?
-                .unwrap_or_default()
-        } else {
-            self.send("listfiles").and_then(read_opt_response)?.unwrap_or_default()
-        })
+        Ok(self.send_list_files(path).and_then(read_opt_response)?.unwrap_or_default())
     }
 
     fn read_picture(&mut self, path: &str) -> MpdResult<Option<Vec<u8>>> {
-        self.send(&format!("readpicture {} 0", path.quote_and_escape())).and_then(read_bin)
+        self.send_read_picture(path).and_then(read_bin)
     }
 
     fn albumart(&mut self, path: &str) -> MpdResult<Option<Vec<u8>>> {
-        self.send(&format!("albumart {} 0", path.quote_and_escape())).and_then(read_bin)
+        self.send_albumart(path).and_then(read_bin)
     }
 
     // Stored playlists
     fn list_playlists(&mut self) -> MpdResult<Vec<Playlist>> {
-        self.send("listplaylists").and_then(read_response)
+        self.send_list_playlists().and_then(read_response)
     }
 
     fn list_playlist(&mut self, name: &str) -> MpdResult<FileList> {
-        self.send(&format!("listplaylist {}", name.quote_and_escape())).and_then(read_response)
+        self.send_list_playlist(name).and_then(read_response)
     }
 
     fn list_playlist_info(
@@ -657,50 +738,23 @@ impl MpdClient for Client<'_> {
         playlist: &str,
         range: Option<SingleOrRange>,
     ) -> MpdResult<Vec<Song>> {
-        if let Some(range) = range {
-            if self.version < Version::new(0, 24, 0) {
-                return Err(MpdError::UnsupportedMpdVersion(
-                    "listplaylistinfo with range can only be used since MPD 0.24.0",
-                ));
-            }
-            self.send(&format!(
-                "listplaylistinfo {} {}",
-                playlist.quote_and_escape(),
-                range.as_mpd_range()
-            ))
-            .and_then(read_response)
-        } else {
-            self.send(&format!("listplaylistinfo {}", playlist.quote_and_escape()))
-                .and_then(read_response)
-        }
+        self.send_list_playlist_info(playlist, range).and_then(read_response)
     }
 
     fn load_playlist(&mut self, name: &str, position: Option<QueuePosition>) -> MpdResult<()> {
-        let position_arg: String =
-            position.map_or(String::new(), |v| format!(" {}", v.as_mpd_str()));
-        self.send(&format!("load {} 0:{position_arg}", name.quote_and_escape())).and_then(read_ok)
+        self.send_load_playlist(name, position).and_then(read_ok)
     }
 
     fn rename_playlist(&mut self, name: &str, new_name: &str) -> MpdResult<()> {
-        self.send(&format!("rename {} {}", name.quote_and_escape(), new_name.quote_and_escape()))
-            .and_then(read_ok)
+        self.send_rename_playlist(name, new_name).and_then(read_ok)
     }
 
     fn delete_playlist(&mut self, name: &str) -> MpdResult<()> {
-        self.send(&format!("rm {}", name.quote_and_escape())).and_then(read_ok)
+        self.send_delete_playlist(name).and_then(read_ok)
     }
 
-    fn delete_from_playlist(
-        &mut self,
-        playlist_name: &str,
-        range: &SingleOrRange,
-    ) -> MpdResult<()> {
-        self.send(&format!(
-            "playlistdelete {} {}",
-            playlist_name.quote_and_escape(),
-            range.as_mpd_range()
-        ))
-        .and_then(read_ok)
+    fn delete_from_playlist(&mut self, name: &str, range: &SingleOrRange) -> MpdResult<()> {
+        self.send_delete_from_playlist(name, range).and_then(read_ok)
     }
 
     fn move_in_playlist(
@@ -709,12 +763,7 @@ impl MpdClient for Client<'_> {
         range: &SingleOrRange,
         target_position: usize,
     ) -> MpdResult<()> {
-        self.send(&format!(
-            "playlistmove {} {} {target_position}",
-            playlist_name.quote_and_escape(),
-            range.as_mpd_range()
-        ))
-        .and_then(read_ok)
+        self.send_move_in_playlist(playlist_name, range, target_position).and_then(read_ok)
     }
 
     fn add_to_playlist(
@@ -723,36 +772,11 @@ impl MpdClient for Client<'_> {
         uri: &str,
         target_position: Option<usize>,
     ) -> MpdResult<()> {
-        match target_position {
-            Some(target_position) => self
-                .send(&format!(
-                    "playlistadd {} {} {target_position}",
-                    playlist_name.quote_and_escape(),
-                    uri.quote_and_escape()
-                ))
-                .and_then(read_ok),
-            None => self
-                .send(&format!(
-                    "playlistadd {} {}",
-                    playlist_name.quote_and_escape(),
-                    uri.quote_and_escape()
-                ))
-                .and_then(read_ok),
-        }
+        self.send_add_to_playlist(playlist_name, uri, target_position).and_then(read_ok)
     }
 
     fn save_queue_as_playlist(&mut self, name: &str, mode: Option<SaveMode>) -> MpdResult<()> {
-        if let Some(mode) = mode {
-            if self.version < Version::new(0, 24, 0) {
-                return Err(MpdError::UnsupportedMpdVersion(
-                    "save mode can be used since MPD 0.24.0",
-                ));
-            }
-            self.send(&format!("save {} \"{}\"", name.quote_and_escape(), mode.as_ref()))
-                .and_then(read_ok)
-        } else {
-            self.send(&format!("save {}", name.quote_and_escape())).and_then(read_ok)
-        }
+        self.send_save_queue_as_playlist(name, mode).and_then(read_ok)
     }
 
     fn find_album_art(&mut self, path: &str) -> MpdResult<Option<Vec<u8>>> {
@@ -785,35 +809,29 @@ impl MpdClient for Client<'_> {
 
     // Outputs
     fn outputs(&mut self) -> MpdResult<Outputs> {
-        self.send("outputs").and_then(read_response)
+        self.send_outputs().and_then(read_response)
     }
 
     fn toggle_output(&mut self, id: u32) -> MpdResult<()> {
-        self.send(&format!("toggleoutput {id}")).and_then(read_ok)
+        self.send_toggle_output(id).and_then(read_ok)
     }
 
     fn enable_output(&mut self, id: u32) -> MpdResult<()> {
-        self.send(&format!("enableoutput {id}")).and_then(read_ok)
+        self.send_enable_output(id).and_then(read_ok)
     }
 
     fn disable_output(&mut self, id: u32) -> MpdResult<()> {
-        self.send(&format!("disableoutput {id}")).and_then(read_ok)
+        self.send_disable_output(id).and_then(read_ok)
     }
 
     // Decoders
     fn decoders(&mut self) -> MpdResult<Decoders> {
-        self.send("decoders").and_then(read_response)
+        self.send_decoders().and_then(read_response)
     }
 
     // Stickers
     fn sticker(&mut self, uri: &str, key: &str) -> MpdResult<Option<Sticker>> {
-        let result: MpdResult<Sticker> = self
-            .send(&format!(
-                "sticker get song {} {}",
-                uri.quote_and_escape(),
-                key.quote_and_escape()
-            ))
-            .and_then(read_response);
+        let result: MpdResult<Sticker> = self.send_sticker(uri, key).and_then(read_response);
 
         if let Err(MpdError::Mpd(MpdFailureResponse { code: ErrorCode::NoExist, .. })) = result {
             return Ok(None);
@@ -823,30 +841,19 @@ impl MpdClient for Client<'_> {
     }
 
     fn set_sticker(&mut self, uri: &str, key: &str, value: &str) -> MpdResult<()> {
-        self.send(&format!(
-            "sticker set song {} {} {}",
-            uri.quote_and_escape(),
-            key.quote_and_escape(),
-            value.quote_and_escape()
-        ))
-        .and_then(read_ok)
+        self.send_set_sticker(uri, key, value).and_then(read_ok)
     }
 
     fn delete_sticker(&mut self, uri: &str, key: &str) -> MpdResult<()> {
-        self.send(&format!(
-            "sticker delete song {} {}",
-            uri.quote_and_escape(),
-            key.quote_and_escape()
-        ))
-        .and_then(read_ok)
+        self.send_delete_sticker(uri, key).and_then(read_ok)
     }
 
     fn delete_all_stickers(&mut self, uri: &str) -> MpdResult<()> {
-        self.send(&format!("sticker delete song {}", uri.quote_and_escape())).and_then(read_ok)
+        self.send_delete_all_stickers(uri).and_then(read_ok)
     }
 
     fn list_stickers(&mut self, uri: &str) -> MpdResult<Stickers> {
-        self.send(&format!("sticker list song {}", uri.quote_and_escape())).and_then(read_response)
+        self.send_list_stickers(uri).and_then(read_response)
     }
 
     /// Resulting `Vec` is of the same length as input `uri`s.
@@ -858,12 +865,12 @@ impl MpdClient for Client<'_> {
         let mut i = 0;
 
         while i < uris.len() {
-            self.start_cmd_list_ok()?;
+            self.send_start_cmd_list_ok()?;
 
             for uri in &uris[i..] {
-                self.send(&format!("sticker list song {}", uri.quote_and_escape()))?;
+                self.send_list_stickers(uri)?;
             }
-            let mut proto = self.execute_cmd_list()?;
+            let mut proto = self.send_execute_cmd_list()?;
 
             for uri in &uris[i..] {
                 let res: MpdResult<Stickers> = proto.read_response();
@@ -893,32 +900,616 @@ impl MpdClient for Client<'_> {
     }
 
     fn find_stickers(&mut self, uri: &str, key: &str) -> MpdResult<StickersWithFile> {
-        self.send(&format!(
+        self.send_find_stickers(uri, key).and_then(read_response)
+    }
+
+    fn switch_to_partition(&mut self, name: &str) -> MpdResult<()> {
+        self.send_switch_to_partition(name).and_then(read_ok)
+    }
+
+    fn new_partition(&mut self, name: &str) -> MpdResult<()> {
+        self.send_new_partition(name).and_then(read_ok)
+    }
+
+    fn list_partitions(&mut self) -> MpdResult<MpdList> {
+        self.send_list_partitions().and_then(read_response)
+    }
+
+    fn delete_partition(&mut self, name: &str) -> MpdResult<()> {
+        self.send_delete_partition(name).and_then(read_ok)
+    }
+
+    fn move_output(&mut self, output_name: &str) -> MpdResult<()> {
+        self.send_move_output(output_name).and_then(read_ok)
+    }
+}
+
+impl MpdCommand<Self> for Client<'_> {
+    fn send_binary_limit<'cmd>(&mut self, limit: u64) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("binarylimit {limit}"))
+    }
+
+    fn send_password<'cmd>(&mut self, password: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("password {}", password.quote_and_escape()))
+    }
+
+    fn send_commands<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("commands")
+    }
+
+    fn send_update<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        if let Some(path) = path {
+            self.send(format!("update {}", path.quote_and_escape()))
+        } else {
+            self.send("update")
+        }
+    }
+
+    fn send_rescan<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        if let Some(path) = path {
+            self.send(format!("rescan {}", path.quote_and_escape()))
+        } else {
+            self.send("rescan")
+        }
+    }
+
+    fn send_idle<'cmd>(
+        &mut self,
+        subsystem: Option<IdleEvent>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        if let Some(subsystem) = subsystem {
+            self.send(format!("idle {subsystem}"))
+        } else {
+            self.send("idle")
+        }
+    }
+
+    fn send_noidle<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("noidle")
+    }
+
+    fn send_start_cmd_list<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("command_list_begin")
+    }
+
+    fn send_start_cmd_list_ok<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("command_list_ok_begin")
+    }
+
+    fn send_execute_cmd_list<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("command_list_end")
+    }
+
+    fn send_get_volume<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        if self.version < Version::new(0, 23, 0) {
+            Err(MpdError::UnsupportedMpdVersion("getvol can be used since MPD 0.23.0"))
+        } else {
+            self.send("getvol")
+        }
+    }
+
+    fn send_set_volume<'cmd>(&mut self, volume: Volume) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("setvol {}", volume.value()))
+    }
+
+    fn send_volume<'cmd>(&mut self, change: ValueChange) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        match change {
+            ValueChange::Increase(_) | ValueChange::Decrease(_) => {
+                self.send(format!("volume {}", change.to_mpd_str()))
+            }
+            ValueChange::Set(val) => self.send(format!("setvol {val}")),
+        }
+    }
+
+    fn send_get_current_song<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("currentsong")
+    }
+
+    fn send_get_status<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("status")
+    }
+
+    fn send_pause_toggle<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("pause")
+    }
+
+    fn send_pause<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("pause 1")
+    }
+
+    fn send_unpause<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("pause 0")
+    }
+
+    fn send_next<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("next")
+    }
+
+    fn send_prev<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("previous")
+    }
+
+    fn send_play_pos<'cmd>(&mut self, pos: usize) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("play {pos}"))
+    }
+
+    fn send_play<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("play")
+    }
+
+    fn send_play_id<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("playid {id}"))
+    }
+
+    fn send_stop<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("stop")
+    }
+
+    fn send_seek_current<'cmd>(
+        &mut self,
+        value: ValueChange,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("seekcur {}", value.to_mpd_str()))
+    }
+
+    fn send_repeat<'cmd>(&mut self, enabled: bool) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("repeat {}", u8::from(enabled)))
+    }
+
+    fn send_random<'cmd>(&mut self, enabled: bool) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("random {}", u8::from(enabled)))
+    }
+
+    fn send_single<'cmd>(
+        &mut self,
+        single: OnOffOneshot,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("single {}", single.to_mpd_value()))
+    }
+
+    fn send_consume<'cmd>(
+        &mut self,
+        consume: OnOffOneshot,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        if self.version < Version::new(0, 24, 0) && matches!(consume, OnOffOneshot::Oneshot) {
+            Err(MpdError::UnsupportedMpdVersion("consume oneshot can be used since MPD 0.24.0"))
+        } else {
+            self.send(format!("consume {}", consume.to_mpd_value()))
+        }
+    }
+
+    fn send_mount<'cmd>(
+        &mut self,
+        name: &str,
+        path: &str,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("mount {} {}", name.quote_and_escape(), path.quote_and_escape()))
+    }
+
+    fn send_unmount<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("unmount {}", name.quote_and_escape()))
+    }
+
+    fn send_list_mounts<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("listmounts")
+    }
+
+    fn send_add<'cmd>(
+        &mut self,
+        uri: &str,
+        position: Option<QueuePosition>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        let position_arg: String =
+            position.map_or(String::new(), |v| format!(" {}", v.as_mpd_str()));
+        self.send(format!("add {}{position_arg}", uri.quote_and_escape()))
+    }
+
+    fn send_clear<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("clear")
+    }
+
+    fn send_delete_id<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("deleteid {id}"))
+    }
+
+    fn send_delete_from_queue<'cmd>(
+        &mut self,
+        songs: SingleOrRange,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("delete {}", songs.as_mpd_range()))
+    }
+
+    fn send_playlist_info<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("playlistinfo")
+    }
+
+    fn send_find<'cmd>(&mut self, filter: &[Filter<'_>]) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("find \"({})\"", filter.to_query_str()))
+    }
+
+    fn send_search<'cmd>(
+        &mut self,
+        filter: &[Filter<'_>],
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        let query = filter.to_query_str();
+        let query = query.as_str();
+        log::debug!(query; "Searching for songs");
+        self.send(format!("search \"({query})\""))
+    }
+
+    fn send_move_in_queue<'cmd>(
+        &mut self,
+        from: SingleOrRange,
+        to: QueuePosition,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("move {} {}", from.as_mpd_range(), to.as_mpd_str()))
+    }
+
+    fn send_move_id<'cmd>(
+        &mut self,
+        id: u32,
+        to: QueuePosition,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("moveid {id} \"{}\"", to.as_mpd_str()))
+    }
+
+    fn send_find_add<'cmd>(
+        &mut self,
+        filter: &[Filter<'_>],
+        position: Option<QueuePosition>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        let position_arg: String =
+            position.map_or(String::new(), |v| format!(" position {}", v.as_mpd_str()));
+        self.send(format!("findadd \"({})\"{position_arg}", filter.to_query_str()))
+    }
+
+    fn send_search_add<'cmd>(
+        &mut self,
+        filter: &[Filter<'_>],
+        position: Option<QueuePosition>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        let query = filter.to_query_str();
+        let query = query.as_str();
+        let position_arg: String =
+            position.map_or(String::new(), |v| format!(" position {}", v.as_mpd_str()));
+        log::debug!(query; "Searching for songs and adding them");
+        self.send(format!("searchadd \"({query})\"{position_arg}"))
+    }
+
+    fn send_list_tag<'cmd>(
+        &mut self,
+        tag: Tag,
+        filter: Option<&[Filter<'_>]>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(if let Some(filter) = filter {
+            format!("list {} \"({})\"", tag.as_str(), filter.to_query_str())
+        } else {
+            format!("list {}", tag.as_str())
+        })
+    }
+
+    fn send_shuffle<'cmd>(
+        &mut self,
+        range: Option<SingleOrRange>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        if let Some(range) = range {
+            self.send(format!("shuffle {}", range.as_mpd_range()))
+        } else {
+            self.send("shuffle")
+        }
+    }
+
+    #[allow(clippy::needless_range_loop)]
+    fn send_add_random_songs<'cmd>(
+        &mut self,
+        count: usize,
+        filter: Option<&[Filter<'_>]>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        let mut result = if let Some(filter) = filter {
+            self.find(filter)?.into_iter().map(|song| song.file).collect_vec()
+        } else {
+            self.list_all(None)?.into_files().collect_vec()
+        };
+
+        if result.len() < count {
+            return Err(MpdError::Generic(format!(
+                "Cannot add {count} songs. The database contains only {} entries.",
+                result.len()
+            )));
+        }
+        result.shuffle(&mut rand::rng());
+
+        self.send_start_cmd_list()?;
+        for i in 0..count {
+            self.send(format!("add {}", result[i].quote_and_escape()))?;
+        }
+        self.send_execute_cmd_list()
+    }
+
+    #[allow(clippy::needless_range_loop)]
+    fn send_add_random_tag<'cmd>(
+        &mut self,
+        count: usize,
+        tag: Tag,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        let mut tag_values = self.list_tag(tag.clone(), None)?.0;
+
+        if tag_values.len() < count {
+            return Err(MpdError::Generic(format!(
+                "Cannot add {count} {tag}s. The database contains only {} entries.",
+                tag_values.len()
+            )));
+        }
+
+        tag_values.shuffle(&mut rand::rng());
+
+        self.send_start_cmd_list()?;
+        for i in 0..count {
+            let filter = &[Filter::new_with_kind(
+                tag.clone(),
+                std::mem::take(&mut tag_values[i]),
+                FilterKind::Exact,
+            )] as &[_];
+            self.send(format!("findadd \"({})\"", filter.to_query_str()))?;
+        }
+        self.send_execute_cmd_list()
+    }
+
+    fn send_list_all<'cmd>(
+        &mut self,
+        path: Option<&str>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        if let Some(path) = path {
+            self.send(format!("listall {}", path.quote_and_escape()))
+        } else {
+            self.send("listall")
+        }
+    }
+
+    fn send_lsinfo<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        if let Some(path) = path {
+            self.send(format!("lsinfo {}", path.quote_and_escape()))
+        } else {
+            self.send("lsinfo")
+        }
+    }
+
+    fn send_list_files<'cmd>(
+        &mut self,
+        path: Option<&str>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        if let Some(path) = path {
+            self.send(format!("listfiles {}", path.quote_and_escape()))
+        } else {
+            self.send("listfiles")
+        }
+    }
+
+    fn send_read_picture<'cmd>(&mut self, path: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("readpicture {} 0", path.quote_and_escape()))
+    }
+
+    fn send_albumart<'cmd>(&mut self, path: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("albumart {} 0", path.quote_and_escape()))
+    }
+
+    fn send_list_playlists<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("listplaylists")
+    }
+
+    fn send_list_playlist<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("listplaylist {}", name.quote_and_escape()))
+    }
+
+    fn send_list_playlist_info<'cmd>(
+        &mut self,
+        playlist: &str,
+        range: Option<SingleOrRange>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        if let Some(range) = range {
+            if self.version < Version::new(0, 24, 0) {
+                return Err(MpdError::UnsupportedMpdVersion(
+                    "listplaylistinfo with range can only be used since MPD 0.24.0",
+                ));
+            }
+            self.send(format!(
+                "listplaylistinfo {} {}",
+                playlist.quote_and_escape(),
+                range.as_mpd_range()
+            ))
+        } else {
+            self.send(format!("listplaylistinfo {}", playlist.quote_and_escape()))
+        }
+    }
+
+    fn send_load_playlist<'cmd>(
+        &mut self,
+        name: &str,
+        position: Option<QueuePosition>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        let position_arg: String =
+            position.map_or(String::new(), |v| format!(" {}", v.as_mpd_str()));
+        self.send(format!("load {} 0:{position_arg}", name.quote_and_escape()))
+    }
+
+    fn send_rename_playlist<'cmd>(
+        &mut self,
+        name: &str,
+        new_name: &str,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("rename {} {}", name.quote_and_escape(), new_name.quote_and_escape()))
+    }
+
+    fn send_delete_playlist<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("rm {}", name.quote_and_escape()))
+    }
+
+    fn send_delete_from_playlist<'cmd>(
+        &mut self,
+        playlist_name: &str,
+        range: &SingleOrRange,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!(
+            "playlistdelete {} {}",
+            playlist_name.quote_and_escape(),
+            range.as_mpd_range()
+        ))
+    }
+
+    fn send_move_in_playlist<'cmd>(
+        &mut self,
+        playlist_name: &str,
+        range: &SingleOrRange,
+        target_position: usize,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!(
+            "playlistmove {} {} {target_position}",
+            playlist_name.quote_and_escape(),
+            range.as_mpd_range()
+        ))
+    }
+
+    fn send_add_to_playlist<'cmd>(
+        &mut self,
+        playlist_name: &str,
+        uri: &str,
+        target_position: Option<usize>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        match target_position {
+            Some(target_position) => self.send(format!(
+                "playlistadd {} {} {target_position}",
+                playlist_name.quote_and_escape(),
+                uri.quote_and_escape()
+            )),
+            None => self.send(format!(
+                "playlistadd {} {}",
+                playlist_name.quote_and_escape(),
+                uri.quote_and_escape()
+            )),
+        }
+    }
+
+    fn send_save_queue_as_playlist<'cmd>(
+        &mut self,
+        name: &str,
+        mode: Option<SaveMode>,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        if let Some(mode) = mode {
+            if self.version < Version::new(0, 24, 0) {
+                return Err(MpdError::UnsupportedMpdVersion(
+                    "save mode can be used since MPD 0.24.0",
+                ));
+            }
+            self.send(format!("save {} \"{}\"", name.quote_and_escape(), mode.as_ref()))
+        } else {
+            self.send(format!("save {}", name.quote_and_escape()))
+        }
+    }
+
+    fn send_outputs<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("outputs")
+    }
+
+    fn send_toggle_output<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("toggleoutput {id}"))
+    }
+
+    fn send_enable_output<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("enableoutput {id}"))
+    }
+
+    fn send_disable_output<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("disableoutput {id}"))
+    }
+
+    fn send_decoders<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("decoders")
+    }
+
+    fn send_sticker<'cmd>(
+        &mut self,
+        uri: &str,
+        key: &str,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("sticker get song {} {}", uri.quote_and_escape(), key.quote_and_escape()))
+    }
+
+    fn send_set_sticker<'cmd>(
+        &mut self,
+        uri: &str,
+        key: &str,
+        value: &str,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!(
+            "sticker set song {} {} {}",
+            uri.quote_and_escape(),
+            key.quote_and_escape(),
+            value.quote_and_escape()
+        ))
+    }
+
+    fn send_delete_sticker<'cmd>(
+        &mut self,
+        uri: &str,
+        key: &str,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!(
+            "sticker delete song {} {}",
+            uri.quote_and_escape(),
+            key.quote_and_escape()
+        ))
+    }
+
+    fn send_delete_all_stickers<'cmd>(
+        &mut self,
+        uri: &str,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("sticker delete song {}", uri.quote_and_escape()))
+    }
+
+    fn send_list_stickers<'cmd>(&mut self, uri: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("sticker list song {}", uri.quote_and_escape()))
+    }
+
+    fn send_find_stickers<'cmd>(
+        &mut self,
+        uri: &str,
+        key: &str,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!(
             "sticker find song {} {}",
             uri.quote_and_escape(),
             key.quote_and_escape()
         ))
-        .and_then(read_response)
     }
 
-    fn switch_to_partition(&mut self, name: &str) -> MpdResult<()> {
-        self.send(&format!("partition {}", name.quote_and_escape())).and_then(read_ok)
+    fn send_switch_to_partition<'cmd>(
+        &mut self,
+        name: &str,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("partition {}", name.quote_and_escape()))
     }
 
-    fn new_partition(&mut self, name: &str) -> MpdResult<()> {
-        self.send(&format!("newpartition {}", name.quote_and_escape())).and_then(read_ok)
+    fn send_new_partition<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("newpartition {}", name.quote_and_escape()))
     }
 
-    fn list_partitions(&mut self) -> MpdResult<MpdList> {
-        self.send("listpartitions").and_then(read_response)
+    fn send_list_partitions<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send("listpartitions")
     }
 
-    fn delete_partition(&mut self, name: &str) -> MpdResult<()> {
-        self.send(&format!("delpartition {}", name.quote_and_escape())).and_then(read_ok)
+    fn send_delete_partition<'cmd>(
+        &mut self,
+        name: &str,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("delpartition {}", name.quote_and_escape()))
     }
 
-    fn move_output(&mut self, output_name: &str) -> MpdResult<()> {
-        self.send(&format!("moveoutput {}", output_name.quote_and_escape())).and_then(read_ok)
+    fn send_move_output<'cmd>(
+        &mut self,
+        output_name: &str,
+    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+        self.send(format!("moveoutput {}", output_name.quote_and_escape()))
     }
 }
 

--- a/src/tests/fixtures/mpd_client.rs
+++ b/src/tests/fixtures/mpd_client.rs
@@ -152,23 +152,6 @@ impl MpdClient for TestMpdClient {
         todo!()
     }
 
-    fn start_cmd_list(&mut self) -> anyhow::Result<()> {
-        todo!()
-    }
-
-    fn start_cmd_list_ok(&mut self) -> anyhow::Result<()> {
-        todo!("Not yet implemented")
-    }
-
-    fn execute_cmd_list(
-        &mut self,
-    ) -> MpdResult<crate::mpd::proto_client::ProtoClient<'static, '_, Self>>
-    where
-        Self: SocketClient,
-    {
-        todo!("Not yet implemented")
-    }
-
     fn get_volume(&mut self) -> MpdResult<Volume> {
         Ok(self.volume)
     }


### PR DESCRIPTION
## Description

Splits MPD client in two parts, one sends the commands, the second reads correct response for the
given command. This was a long time coming to better support MPD's command lists.
There should be no beavior changes.

First part of 2(?). The ProtoClient needs to go next.

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
