### PR TITLE
Feat/add diacritics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1954,6 +1954,7 @@ dependencies = [
  "textwrap",
  "thiserror 2.0.12",
  "unicase",
+ "unicode-normalization",
  "unicode-width 0.2.0",
  "url",
  "vergen-gitcl",
@@ -2500,6 +2501,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,6 +2566,15 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,6 +1936,7 @@ dependencies = [
  "crossbeam",
  "crossterm",
  "derive_more",
+ "deunicode",
  "either",
  "enum-map",
  "flate2",
@@ -1954,7 +1961,6 @@ dependencies = [
  "textwrap",
  "thiserror 2.0.12",
  "unicase",
- "unicode-normalization",
  "unicode-width 0.2.0",
  "url",
  "vergen-gitcl",
@@ -2501,21 +2507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "toml"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,15 +2557,6 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,11 @@ homepage = "https://mierak.github.io/rmpc/"
 repository = "https://github.com/mierak/rmpc"
 readme = "README.md"
 rust-version = "1.85.0"
-exclude = ["/docs/**/*", "!/docs/src/content/docs/next/assets/example_theme.ron", "!/docs/src/content/docs/next/assets/example_config.ron"]
+exclude = [
+    "/docs/**/*",
+    "!/docs/src/content/docs/next/assets/example_theme.ron",
+    "!/docs/src/content/docs/next/assets/example_config.ron",
+]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -25,7 +29,15 @@ strum = { workspace = true }
 flate2 = { version = "1.1.2" }
 itertools = "0.14.0"
 ron = "0.10.1"
-derive_more = { version = "2.0.1", features = ["into_iterator", "into", "as_ref", "into_iterator", "display", "deref", "debug"] }
+derive_more = { version = "2.0.1", features = [
+    "into_iterator",
+    "into",
+    "as_ref",
+    "into_iterator",
+    "display",
+    "deref",
+    "debug",
+] }
 rustix = { version = "1.0.7", features = ["termios", "fs", "stdio", "process"] }
 bitflags = { version = "2.9.1", features = ["serde"] }
 log = { version = "0.4.27", features = ["kv"] }
@@ -50,6 +62,7 @@ rand = "0.9.1"
 ansi_colours = "1"
 thiserror = "2.0.12"
 parking_lot = { version = "0.12.4", features = [] }
+unicode-normalization = "0.1.23"
 
 [build-dependencies]
 clap = { workspace = true }
@@ -64,7 +77,7 @@ rstest = "0.25.0"
 test-case = "3.3.1"
 
 [workspace.dependencies]
-clap = { version = "4.5.40", features = ["derive", "cargo", "string" ] }
+clap = { version = "4.5.40", features = ["derive", "cargo", "string"] }
 strum = { version = "0.27.1", features = ["derive"] }
 
 [lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ rand = "0.9.1"
 ansi_colours = "1"
 thiserror = "2.0.12"
 parking_lot = { version = "0.12.4", features = [] }
-unicode-normalization = "0.1.23"
+deunicode = "1.6.2"
 
 [build-dependencies]
 clap = { workspace = true }

--- a/docs/src/content/docs/next/assets/example_config.ron
+++ b/docs/src/content/docs/next/assets/example_config.ron
@@ -105,6 +105,7 @@
     ),
     search: (
         case_sensitive: false,
+        ignore_diacritics: false,
         mode: Contains,
         tags: [
             (value: "any",         label: "Any Tag"),
@@ -154,4 +155,3 @@
         ),
     ],
 )
-

--- a/src/config/search.rs
+++ b/src/config/search.rs
@@ -8,11 +8,13 @@ pub struct Search {
     pub case_sensitive: bool,
     pub mode: FilterKind,
     pub tags: Vec<SearchableTag>,
+    pub ignore_diacritics: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SearchFile {
     case_sensitive: bool,
+    ignore_diacritics: bool,
     mode: FilterKindFile,
     tags: Vec<SearchableTagFile>,
 }
@@ -33,6 +35,7 @@ impl From<SearchFile> for Search {
     fn from(value: SearchFile) -> Self {
         Self {
             case_sensitive: value.case_sensitive,
+            ignore_diacritics: value.ignore_diacritics,
             mode: value.mode.into(),
             tags: if value.tags.is_empty() {
                 vec![SearchableTag { label: "Any Tag".to_string(), value: "any".to_string() }]
@@ -51,6 +54,7 @@ impl Default for SearchFile {
     fn default() -> Self {
         Self {
             case_sensitive: false,
+            ignore_diacritics: false,
             mode: FilterKindFile::Contains,
             tags: [
                 SearchableTagFile { value: "any".to_string(), label: "Any Tag".to_string() },

--- a/src/mpd/mpd_client.rs
+++ b/src/mpd/mpd_client.rs
@@ -13,10 +13,19 @@ use rand::seq::SliceRandom;
 use strum::{AsRefStr, Display};
 
 use super::{
-    FromMpd, QueuePosition,
+    FromMpd,
+    QueuePosition,
     client::Client,
     commands::{
-        IdleEvent, ListFiles, LsInfo, Mounts, Playlist, Song, Status, Update, Volume,
+        IdleEvent,
+        ListFiles,
+        LsInfo,
+        Mounts,
+        Playlist,
+        Song,
+        Status,
+        Update,
+        Volume,
         decoders::Decoders,
         list::MpdList,
         list_playlist::FileList,
@@ -1231,8 +1240,9 @@ mod filter_tests {
 
     #[cfg(test)]
     mod filter_diacritics_tests {
-        use super::{Filter, FilterExt, FilterKind, Tag};
         use test_case::test_case;
+
+        use super::{Filter, FilterExt, FilterKind, Tag};
 
         #[test]
         fn exact_with_ignore_diacritics() {


### PR DESCRIPTION
## Description

I added support for diacritic-insensitive search via a new ignore_diacritics flag on Filter. When enabled, the search input is normalized using Unicode NFD decomposition (via deunicode crate) to remove diacritic marks, this will allow names like lopez to match both Lopez and López, or annbjorg to match Annbjørg I also added additional unit tests to verify that the normalization behaves correctly for a wide range of diacritic use cases, like French, Spanish, German, Norwegian, Swedish, Cyrillic, and CJK characters.

### Related issues

fixes #359 

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [ ] Changelog has been updated
