### PR TITLE
refactor: split mpd client part 2

### DIFF
--- a/src/mpd/client.rs
+++ b/src/mpd/client.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     io::{BufRead, BufReader, Write},
     net::{Shutdown, TcpStream},
     os::unix::net::UnixStream,
@@ -11,7 +10,7 @@ use log::debug;
 use super::{
     commands::mpd_config::MpdConfig,
     errors::MpdError,
-    proto_client::{ProtoClient, SocketClient},
+    proto_client::SocketClient,
     version::Version,
 };
 use crate::{
@@ -260,13 +259,6 @@ impl<'name> Client<'name> {
         self.stream.set_write_timeout(timeout)
     }
 
-    pub fn send<'cmd>(
-        &mut self,
-        command: impl Into<Cow<'cmd, str>>,
-    ) -> Result<ProtoClient<'cmd, '_, Self>, MpdError> {
-        ProtoClient::new(command, self)
-    }
-
     fn clear_read_buf(&mut self) -> Result<()> {
         log::trace!("Reinitialized read buffer");
         self.rx = BufReader::new(self.stream.try_clone()?);
@@ -285,5 +277,9 @@ impl SocketClient for Client<'_> {
 
     fn clear_read_buf(&mut self) -> Result<()> {
         self.clear_read_buf()
+    }
+
+    fn version(&self) -> Version {
+        self.version
     }
 }

--- a/src/mpd/mpd_client.rs
+++ b/src/mpd/mpd_client.rs
@@ -12,7 +12,6 @@ use rand::seq::SliceRandom;
 use strum::{AsRefStr, Display};
 
 use super::{
-    FromMpd,
     QueuePosition,
     client::Client,
     commands::{
@@ -41,7 +40,6 @@ use super::{
 use crate::shared::{ext::error::ErrorExt, macros::status_error};
 
 type MpdResult<T> = Result<T, MpdError>;
-type MpdCommandSubmitResult<'cmd, 'client, C> = Result<ProtoClient<'cmd, 'client, C>, MpdError>;
 
 #[derive(AsRefStr, Debug)]
 #[allow(dead_code)]
@@ -87,163 +85,109 @@ impl ValueChange {
 }
 
 #[allow(dead_code)]
-pub trait MpdCommand<C: SocketClient> {
-    fn send_binary_limit<'cmd>(&mut self, limit: u64) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_password<'cmd>(&mut self, password: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_commands<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_update<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_rescan<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_idle<'cmd>(
-        &mut self,
-        subsystem: Option<IdleEvent>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_noidle<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_start_cmd_list<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_start_cmd_list_ok<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_execute_cmd_list<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_get_volume<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_set_volume<'cmd>(&mut self, volume: Volume) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_volume<'cmd>(&mut self, change: ValueChange) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_get_current_song<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_get_status<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_pause_toggle<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_pause<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_unpause<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_next<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_prev<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_play_pos<'cmd>(&mut self, pos: usize) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_play<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_play_id<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_stop<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_seek_current<'cmd>(
-        &mut self,
-        value: ValueChange,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_repeat<'cmd>(&mut self, enabled: bool) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_random<'cmd>(&mut self, enabled: bool) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_single<'cmd>(&mut self, single: OnOffOneshot) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_consume<'cmd>(&mut self, consume: OnOffOneshot) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_mount<'cmd>(&mut self, name: &str, path: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_unmount<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_list_mounts<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_add<'cmd>(
-        &mut self,
-        path: &str,
-        position: Option<QueuePosition>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_clear<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_delete_id<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_delete_from_queue<'cmd>(
-        &mut self,
-        songs: SingleOrRange,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_playlist_info<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_find<'cmd>(&mut self, filter: &[Filter<'_>]) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_search<'cmd>(&mut self, filter: &[Filter<'_>]) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_move_in_queue<'cmd>(
-        &mut self,
-        from: SingleOrRange,
-        to: QueuePosition,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_move_id<'cmd>(
-        &mut self,
-        id: u32,
-        to: QueuePosition,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_find_add<'cmd>(
+pub trait MpdCommand {
+    fn send_binary_limit(&mut self, limit: u64) -> MpdResult<()>;
+    fn send_password(&mut self, password: &str) -> MpdResult<()>;
+    fn send_commands(&mut self) -> MpdResult<()>;
+    fn send_update(&mut self, path: Option<&str>) -> MpdResult<()>;
+    fn send_rescan(&mut self, path: Option<&str>) -> MpdResult<()>;
+    fn send_idle(&mut self, subsystem: Option<IdleEvent>) -> MpdResult<()>;
+    fn send_noidle(&mut self) -> MpdResult<()>;
+    fn send_start_cmd_list(&mut self) -> MpdResult<()>;
+    fn send_start_cmd_list_ok(&mut self) -> MpdResult<()>;
+    fn send_execute_cmd_list(&mut self) -> MpdResult<()>;
+    fn send_get_volume(&mut self) -> MpdResult<()>;
+    fn send_set_volume(&mut self, volume: Volume) -> MpdResult<()>;
+    fn send_volume(&mut self, change: ValueChange) -> MpdResult<()>;
+    fn send_get_current_song(&mut self) -> MpdResult<()>;
+    fn send_get_status(&mut self) -> MpdResult<()>;
+    fn send_pause_toggle(&mut self) -> MpdResult<()>;
+    fn send_pause(&mut self) -> MpdResult<()>;
+    fn send_unpause(&mut self) -> MpdResult<()>;
+    fn send_next(&mut self) -> MpdResult<()>;
+    fn send_prev(&mut self) -> MpdResult<()>;
+    fn send_play_pos(&mut self, pos: usize) -> MpdResult<()>;
+    fn send_play(&mut self) -> MpdResult<()>;
+    fn send_play_id(&mut self, id: u32) -> MpdResult<()>;
+    fn send_stop(&mut self) -> MpdResult<()>;
+    fn send_seek_current(&mut self, value: ValueChange) -> MpdResult<()>;
+    fn send_repeat(&mut self, enabled: bool) -> MpdResult<()>;
+    fn send_random(&mut self, enabled: bool) -> MpdResult<()>;
+    fn send_single(&mut self, single: OnOffOneshot) -> MpdResult<()>;
+    fn send_consume(&mut self, consume: OnOffOneshot) -> MpdResult<()>;
+    fn send_mount(&mut self, name: &str, path: &str) -> MpdResult<()>;
+    fn send_unmount(&mut self, name: &str) -> MpdResult<()>;
+    fn send_list_mounts(&mut self) -> MpdResult<()>;
+    fn send_add(&mut self, path: &str, position: Option<QueuePosition>) -> MpdResult<()>;
+    fn send_clear(&mut self) -> MpdResult<()>;
+    fn send_delete_id(&mut self, id: u32) -> MpdResult<()>;
+    fn send_delete_from_queue(&mut self, songs: SingleOrRange) -> MpdResult<()>;
+    fn send_playlist_info(&mut self) -> MpdResult<()>;
+    fn send_find(&mut self, filter: &[Filter<'_>]) -> MpdResult<()>;
+    fn send_search(&mut self, filter: &[Filter<'_>]) -> MpdResult<()>;
+    fn send_move_in_queue(&mut self, from: SingleOrRange, to: QueuePosition) -> MpdResult<()>;
+    fn send_move_id(&mut self, id: u32, to: QueuePosition) -> MpdResult<()>;
+    fn send_find_add(
         &mut self,
         filter: &[Filter<'_>],
         position: Option<QueuePosition>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_search_add<'cmd>(
+    ) -> MpdResult<()>;
+    fn send_search_add(
         &mut self,
         filter: &[Filter<'_>],
         position: Option<QueuePosition>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_list_tag<'cmd>(
-        &mut self,
-        tag: Tag,
-        filter: Option<&[Filter<'_>]>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_shuffle<'cmd>(
-        &mut self,
-        range: Option<SingleOrRange>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_list_all<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_lsinfo<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_list_files<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_read_picture<'cmd>(&mut self, path: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_albumart<'cmd>(&mut self, path: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_list_playlists<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_list_playlist<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_list_playlist_info<'cmd>(
+    ) -> MpdResult<()>;
+    fn send_list_tag(&mut self, tag: Tag, filter: Option<&[Filter<'_>]>) -> MpdResult<()>;
+    fn send_shuffle(&mut self, range: Option<SingleOrRange>) -> MpdResult<()>;
+    fn send_list_all(&mut self, path: Option<&str>) -> MpdResult<()>;
+    fn send_lsinfo(&mut self, path: Option<&str>) -> MpdResult<()>;
+    fn send_list_files(&mut self, path: Option<&str>) -> MpdResult<()>;
+    fn send_read_picture(&mut self, path: &str) -> MpdResult<String>;
+    fn send_albumart(&mut self, path: &str) -> MpdResult<String>;
+    fn send_list_playlists(&mut self) -> MpdResult<()>;
+    fn send_list_playlist(&mut self, name: &str) -> MpdResult<()>;
+    fn send_list_playlist_info(
         &mut self,
         playlist: &str,
         range: Option<SingleOrRange>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_load_playlist<'cmd>(
-        &mut self,
-        name: &str,
-        position: Option<QueuePosition>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_rename_playlist<'cmd>(
-        &mut self,
-        name: &str,
-        new_name: &str,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_delete_playlist<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_delete_from_playlist<'cmd>(
+    ) -> MpdResult<()>;
+    fn send_load_playlist(&mut self, name: &str, position: Option<QueuePosition>) -> MpdResult<()>;
+    fn send_rename_playlist(&mut self, name: &str, new_name: &str) -> MpdResult<()>;
+    fn send_delete_playlist(&mut self, name: &str) -> MpdResult<()>;
+    fn send_delete_from_playlist(
         &mut self,
         playlist_name: &str,
         songs: &SingleOrRange,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_move_in_playlist<'cmd>(
+    ) -> MpdResult<()>;
+    fn send_move_in_playlist(
         &mut self,
         playlist_name: &str,
         range: &SingleOrRange,
         target_position: usize,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_add_to_playlist<'cmd>(
+    ) -> MpdResult<()>;
+    fn send_add_to_playlist(
         &mut self,
         playlist_name: &str,
         uri: &str,
         target_position: Option<usize>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_save_queue_as_playlist<'cmd>(
-        &mut self,
-        name: &str,
-        mode: Option<SaveMode>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_outputs<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_toggle_output<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_enable_output<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_disable_output<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_decoders<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_sticker<'cmd>(&mut self, uri: &str, name: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_set_sticker<'cmd>(
-        &mut self,
-        uri: &str,
-        name: &str,
-        value: &str,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_delete_sticker<'cmd>(
-        &mut self,
-        uri: &str,
-        name: &str,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_delete_all_stickers<'cmd>(&mut self, uri: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_list_stickers<'cmd>(&mut self, uri: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_find_stickers<'cmd>(
-        &mut self,
-        uri: &str,
-        name: &str,
-    ) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_switch_to_partition<'cmd>(&mut self, name: &str)
-    -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_new_partition<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_delete_partition<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_list_partitions<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, C>;
-    fn send_move_output<'cmd>(&mut self, output_name: &str) -> MpdCommandSubmitResult<'cmd, '_, C>;
+    ) -> MpdResult<()>;
+    fn send_save_queue_as_playlist(&mut self, name: &str, mode: Option<SaveMode>) -> MpdResult<()>;
+    fn send_outputs(&mut self) -> MpdResult<()>;
+    fn send_toggle_output(&mut self, id: u32) -> MpdResult<()>;
+    fn send_enable_output(&mut self, id: u32) -> MpdResult<()>;
+    fn send_disable_output(&mut self, id: u32) -> MpdResult<()>;
+    fn send_decoders(&mut self) -> MpdResult<()>;
+    fn send_sticker(&mut self, uri: &str, name: &str) -> MpdResult<()>;
+    fn send_set_sticker(&mut self, uri: &str, name: &str, value: &str) -> MpdResult<()>;
+    fn send_delete_sticker(&mut self, uri: &str, name: &str) -> MpdResult<()>;
+    fn send_delete_all_stickers(&mut self, uri: &str) -> MpdResult<()>;
+    fn send_list_stickers(&mut self, uri: &str) -> MpdResult<()>;
+    fn send_find_stickers(&mut self, uri: &str, name: &str) -> MpdResult<()>;
+    fn send_switch_to_partition(&mut self, name: &str) -> MpdResult<()>;
+    fn send_new_partition(&mut self, name: &str) -> MpdResult<()>;
+    fn send_delete_partition(&mut self, name: &str) -> MpdResult<()>;
+    fn send_list_partitions(&mut self) -> MpdResult<()>;
+    fn send_move_output(&mut self, output_name: &str) -> MpdResult<()>;
 }
 
 #[allow(dead_code)]
@@ -256,9 +200,7 @@ pub trait MpdClient: Sized {
     fn update(&mut self, path: Option<&str>) -> MpdResult<Update>;
     fn rescan(&mut self, path: Option<&str>) -> MpdResult<Update>;
     fn idle(&mut self, subsystem: Option<IdleEvent>) -> MpdResult<Vec<IdleEvent>>;
-    fn enter_idle(&mut self) -> MpdResult<ProtoClient<'static, '_, Self>>
-    where
-        Self: SocketClient;
+    fn enter_idle(&mut self) -> MpdResult<()>;
     fn noidle(&mut self) -> MpdResult<()>;
 
     fn get_volume(&mut self) -> MpdResult<Volume>;
@@ -379,26 +321,6 @@ pub trait MpdClient: Sized {
     fn move_output(&mut self, output_name: &str) -> MpdResult<()>;
 }
 
-fn read_response<T: Default + FromMpd, S: SocketClient>(
-    mut c: ProtoClient<'_, '_, S>,
-) -> MpdResult<T> {
-    c.read_response()
-}
-
-fn read_opt_response<T: Default + FromMpd, S: SocketClient>(
-    mut c: ProtoClient<'_, '_, S>,
-) -> MpdResult<Option<T>> {
-    c.read_opt_response()
-}
-
-fn read_bin<S: SocketClient>(mut c: ProtoClient<'_, '_, S>) -> MpdResult<Option<Vec<u8>>> {
-    c.read_bin()
-}
-
-fn read_ok<S: SocketClient>(mut c: ProtoClient<'_, '_, S>) -> MpdResult<()> {
-    c.read_ok()
-}
-
 impl MpdClient for Client<'_> {
     fn version(&mut self) -> Version {
         self.version
@@ -406,7 +328,7 @@ impl MpdClient for Client<'_> {
 
     fn config(&mut self) -> Option<&MpdConfig> {
         if self.config.is_none() {
-            match self.send("config").and_then(read_response) {
+            match self.execute("config").and_then(|()| self.read_response()) {
                 Ok(config) => {
                     self.config = Some(config);
                 }
@@ -420,148 +342,149 @@ impl MpdClient for Client<'_> {
     }
 
     fn binary_limit(&mut self, limit: u64) -> MpdResult<()> {
-        self.send_binary_limit(limit).and_then(read_ok)
+        self.send_binary_limit(limit).and_then(|()| self.read_ok())
     }
 
     fn password(&mut self, password: &str) -> MpdResult<()> {
-        self.send_password(password).and_then(read_ok)
+        self.send_password(password).and_then(|()| self.read_ok())
     }
 
     // Lists commands supported by the MPD server
     fn commands(&mut self) -> MpdResult<MpdList> {
-        self.send_commands().and_then(read_response)
+        self.send_commands().and_then(|()| self.read_response())
     }
 
     fn update(&mut self, path: Option<&str>) -> MpdResult<Update> {
-        self.send_update(path).and_then(read_response)
+        self.send_update(path).and_then(|()| self.read_response())
     }
 
     fn rescan(&mut self, path: Option<&str>) -> MpdResult<Update> {
-        self.send_rescan(path).and_then(read_response)
+        self.send_rescan(path).and_then(|()| self.read_response())
     }
 
     // Queries
     fn idle(&mut self, subsystem: Option<IdleEvent>) -> MpdResult<Vec<IdleEvent>> {
-        self.send_idle(subsystem).and_then(read_response)
+        self.send_idle(subsystem).and_then(|()| self.read_response())
     }
 
-    fn enter_idle(&mut self) -> MpdResult<ProtoClient<'static, '_, Self>> {
+    fn enter_idle(&mut self) -> MpdResult<()> {
         self.send_idle(None)
     }
 
     fn noidle(&mut self) -> MpdResult<()> {
-        self.send_noidle().and_then(read_ok)
+        self.send_noidle().and_then(|()| self.read_ok())
     }
 
     fn get_volume(&mut self) -> MpdResult<Volume> {
-        self.send_get_volume().and_then(read_response)
+        self.send_get_volume().and_then(|()| self.read_response())
     }
 
     fn set_volume(&mut self, volume: Volume) -> MpdResult<()> {
-        self.send_set_volume(volume).and_then(read_ok)
+        self.send_set_volume(volume).and_then(|()| self.read_ok())
     }
 
     fn volume(&mut self, change: ValueChange) -> MpdResult<()> {
-        self.send_volume(change).and_then(read_ok)
+        self.send_volume(change).and_then(|()| self.read_ok())
     }
 
     fn get_current_song(&mut self) -> MpdResult<Option<Song>> {
-        self.send_get_current_song().and_then(read_opt_response)
+        self.send_get_current_song().and_then(|()| self.read_opt_response())
     }
 
     fn get_status(&mut self) -> MpdResult<Status> {
-        self.send_get_status().and_then(read_response)
+        self.send_get_status().and_then(|()| self.read_response())
     }
 
     // Playback control
     fn pause_toggle(&mut self) -> MpdResult<()> {
-        self.send_pause_toggle().and_then(read_ok)
+        self.send_pause_toggle().and_then(|()| self.read_ok())
     }
 
     fn pause(&mut self) -> MpdResult<()> {
-        self.send_pause().and_then(read_ok)
+        self.send_pause().and_then(|()| self.read_ok())
     }
 
     fn unpause(&mut self) -> MpdResult<()> {
-        self.send_unpause().and_then(read_ok)
+        self.send_unpause().and_then(|()| self.read_ok())
     }
 
     fn next(&mut self) -> MpdResult<()> {
-        self.send_next().and_then(read_ok)
+        self.send_next().and_then(|()| self.read_ok())
     }
 
     fn prev(&mut self) -> MpdResult<()> {
-        self.send_prev().and_then(read_ok)
+        self.send_prev().and_then(|()| self.read_ok())
     }
 
     fn play_pos(&mut self, pos: usize) -> MpdResult<()> {
-        self.send_play_pos(pos).and_then(read_ok)
+        self.send_play_pos(pos).and_then(|()| self.read_ok())
     }
 
     fn play(&mut self) -> MpdResult<()> {
-        self.send_play().and_then(read_ok)
+        self.send_play().and_then(|()| self.read_ok())
     }
 
     fn play_id(&mut self, id: u32) -> MpdResult<()> {
-        self.send_play_id(id).and_then(read_ok)
+        self.send_play_id(id).and_then(|()| self.read_ok())
     }
 
     fn stop(&mut self) -> MpdResult<()> {
-        self.send_stop().and_then(read_ok)
+        self.send_stop().and_then(|()| self.read_ok())
     }
 
     fn seek_current(&mut self, value: ValueChange) -> MpdResult<()> {
-        self.send_seek_current(value).and_then(read_ok)
+        self.send_seek_current(value).and_then(|()| self.read_ok())
     }
 
     fn repeat(&mut self, enabled: bool) -> MpdResult<()> {
-        self.send_repeat(enabled).and_then(read_ok)
+        self.send_repeat(enabled).and_then(|()| self.read_ok())
     }
 
     fn random(&mut self, enabled: bool) -> MpdResult<()> {
-        self.send_random(enabled).and_then(read_ok)
+        self.send_random(enabled).and_then(|()| self.read_ok())
     }
 
     fn single(&mut self, single: OnOffOneshot) -> MpdResult<()> {
-        self.send_single(single).and_then(read_ok)
+        self.send_single(single).and_then(|()| self.read_ok())
     }
 
     fn consume(&mut self, consume: OnOffOneshot) -> MpdResult<()> {
-        self.send_consume(consume).and_then(read_ok)
+        self.send_consume(consume).and_then(|()| self.read_ok())
     }
 
     // Mounts
     fn mount(&mut self, name: &str, path: &str) -> MpdResult<()> {
-        self.send_mount(name, path).and_then(read_ok)
+        self.send_mount(name, path).and_then(|()| self.read_ok())
     }
 
     fn unmount(&mut self, name: &str) -> MpdResult<()> {
-        self.send_unmount(name).and_then(read_ok)
+        self.send_unmount(name).and_then(|()| self.read_ok())
     }
 
     fn list_mounts(&mut self) -> MpdResult<Mounts> {
-        self.send_list_mounts().and_then(read_response)
+        self.send_list_mounts().and_then(|()| self.read_response())
     }
 
     // Current queue
     fn add(&mut self, uri: &str, position: Option<QueuePosition>) -> MpdResult<()> {
-        self.send_add(uri, position).and_then(read_ok)
+        self.send_add(uri, position).and_then(|()| self.read_ok())
     }
 
     fn clear(&mut self) -> MpdResult<()> {
-        self.send_clear().and_then(read_ok)
+        self.send_clear().and_then(|()| self.read_ok())
     }
 
     fn delete_id(&mut self, id: u32) -> MpdResult<()> {
-        self.send_delete_id(id).and_then(read_ok)
+        self.send_delete_id(id).and_then(|()| self.read_ok())
     }
 
     fn delete_from_queue(&mut self, songs: SingleOrRange) -> MpdResult<()> {
-        self.send_delete_from_queue(songs).and_then(read_ok)
+        self.send_delete_from_queue(songs).and_then(|()| self.read_ok())
     }
 
     fn playlist_info(&mut self, fetch_stickers: bool) -> MpdResult<Option<Vec<Song>>> {
-        let songs: Option<Vec<Song>> = self.send_playlist_info().and_then(read_opt_response)?;
+        let songs: Option<Vec<Song>> =
+            self.send_playlist_info().and_then(|()| self.read_opt_response())?;
 
         if !fetch_stickers {
             return Ok(songs);
@@ -595,26 +518,26 @@ impl MpdClient for Client<'_> {
 
     /// Search the database for songs matching FILTER
     fn find(&mut self, filter: &[Filter<'_>]) -> MpdResult<Vec<Song>> {
-        self.send_find(filter).and_then(read_response)
+        self.send_find(filter).and_then(|()| self.read_response())
     }
 
     /// Search the database for songs matching FILTER (see Filters).
     /// Parameters have the same meaning as for find, except that search is not
     /// case sensitive.
     fn search(&mut self, filter: &[Filter<'_>]) -> MpdResult<Vec<Song>> {
-        self.send_search(filter).and_then(read_response)
+        self.send_search(filter).and_then(|()| self.read_response())
     }
 
     fn move_in_queue(&mut self, from: SingleOrRange, to: QueuePosition) -> MpdResult<()> {
-        self.send_move_in_queue(from, to).and_then(read_ok)
+        self.send_move_in_queue(from, to).and_then(|()| self.read_ok())
     }
 
     fn move_id(&mut self, id: u32, to: QueuePosition) -> MpdResult<()> {
-        self.send_move_id(id, to).and_then(read_ok)
+        self.send_move_id(id, to).and_then(|()| self.read_ok())
     }
 
     fn find_one(&mut self, filter: &[Filter<'_>]) -> MpdResult<Option<Song>> {
-        let mut songs: Vec<Song> = self.send_find(filter).and_then(read_response)?;
+        let mut songs: Vec<Song> = self.send_find(filter).and_then(|()| self.read_response())?;
         Ok(songs.pop())
     }
 
@@ -623,7 +546,7 @@ impl MpdClient for Client<'_> {
         filter: &[Filter<'_>],
         position: Option<QueuePosition>,
     ) -> MpdResult<()> {
-        self.send_find_add(filter, position).and_then(read_ok)
+        self.send_find_add(filter, position).and_then(|()| self.read_ok())
     }
 
     /// Search the database for songs matching FILTER (see Filters) AND add them
@@ -634,15 +557,15 @@ impl MpdClient for Client<'_> {
         filter: &[Filter<'_>],
         position: Option<QueuePosition>,
     ) -> MpdResult<()> {
-        self.send_search_add(filter, position).and_then(read_ok)
+        self.send_search_add(filter, position).and_then(|()| self.read_ok())
     }
 
     fn list_tag(&mut self, tag: Tag, filter: Option<&[Filter<'_>]>) -> MpdResult<MpdList> {
-        self.send_list_tag(tag, filter).and_then(read_response)
+        self.send_list_tag(tag, filter).and_then(|()| self.read_response())
     }
 
     fn shuffle(&mut self, range: Option<SingleOrRange>) -> MpdResult<()> {
-        self.send_shuffle(range).and_then(read_ok)
+        self.send_shuffle(range).and_then(|()| self.read_ok())
     }
 
     #[allow(clippy::needless_range_loop)]
@@ -665,7 +588,7 @@ impl MpdClient for Client<'_> {
         for i in 0..count {
             self.send_add(&result[i], None)?;
         }
-        self.send_execute_cmd_list().and_then(read_ok)
+        self.send_execute_cmd_list().and_then(|()| self.read_ok())
     }
 
     #[allow(clippy::needless_range_loop)]
@@ -690,37 +613,37 @@ impl MpdClient for Client<'_> {
             )] as &[_];
             self.send_find_add(filter, None)?;
         }
-        self.send_execute_cmd_list().and_then(read_ok)
+        self.send_execute_cmd_list().and_then(|()| self.read_ok())
     }
 
     fn list_all(&mut self, path: Option<&str>) -> MpdResult<LsInfo> {
-        self.send_list_all(path).and_then(read_response)
+        self.send_list_all(path).and_then(|()| self.read_response())
     }
 
     // Database
     fn lsinfo(&mut self, path: Option<&str>) -> MpdResult<LsInfo> {
-        Ok(self.send_lsinfo(path).and_then(read_opt_response)?.unwrap_or_default())
+        Ok(self.send_lsinfo(path).and_then(|()| self.read_opt_response())?.unwrap_or_default())
     }
 
     fn list_files(&mut self, path: Option<&str>) -> MpdResult<ListFiles> {
-        Ok(self.send_list_files(path).and_then(read_opt_response)?.unwrap_or_default())
+        Ok(self.send_list_files(path).and_then(|()| self.read_opt_response())?.unwrap_or_default())
     }
 
     fn read_picture(&mut self, path: &str) -> MpdResult<Option<Vec<u8>>> {
-        self.send_read_picture(path).and_then(read_bin)
+        self.send_read_picture(path).and_then(|cmd| self.read_bin(&cmd))
     }
 
     fn albumart(&mut self, path: &str) -> MpdResult<Option<Vec<u8>>> {
-        self.send_albumart(path).and_then(read_bin)
+        self.send_albumart(path).and_then(|cmd| self.read_bin(&cmd))
     }
 
     // Stored playlists
     fn list_playlists(&mut self) -> MpdResult<Vec<Playlist>> {
-        self.send_list_playlists().and_then(read_response)
+        self.send_list_playlists().and_then(|()| self.read_response())
     }
 
     fn list_playlist(&mut self, name: &str) -> MpdResult<FileList> {
-        self.send_list_playlist(name).and_then(read_response)
+        self.send_list_playlist(name).and_then(|()| self.read_response())
     }
 
     fn list_playlist_info(
@@ -728,23 +651,23 @@ impl MpdClient for Client<'_> {
         playlist: &str,
         range: Option<SingleOrRange>,
     ) -> MpdResult<Vec<Song>> {
-        self.send_list_playlist_info(playlist, range).and_then(read_response)
+        self.send_list_playlist_info(playlist, range).and_then(|()| self.read_response())
     }
 
     fn load_playlist(&mut self, name: &str, position: Option<QueuePosition>) -> MpdResult<()> {
-        self.send_load_playlist(name, position).and_then(read_ok)
+        self.send_load_playlist(name, position).and_then(|()| self.read_ok())
     }
 
     fn rename_playlist(&mut self, name: &str, new_name: &str) -> MpdResult<()> {
-        self.send_rename_playlist(name, new_name).and_then(read_ok)
+        self.send_rename_playlist(name, new_name).and_then(|()| self.read_ok())
     }
 
     fn delete_playlist(&mut self, name: &str) -> MpdResult<()> {
-        self.send_delete_playlist(name).and_then(read_ok)
+        self.send_delete_playlist(name).and_then(|()| self.read_ok())
     }
 
     fn delete_from_playlist(&mut self, name: &str, range: &SingleOrRange) -> MpdResult<()> {
-        self.send_delete_from_playlist(name, range).and_then(read_ok)
+        self.send_delete_from_playlist(name, range).and_then(|()| self.read_ok())
     }
 
     fn move_in_playlist(
@@ -753,7 +676,8 @@ impl MpdClient for Client<'_> {
         range: &SingleOrRange,
         target_position: usize,
     ) -> MpdResult<()> {
-        self.send_move_in_playlist(playlist_name, range, target_position).and_then(read_ok)
+        self.send_move_in_playlist(playlist_name, range, target_position)
+            .and_then(|()| self.read_ok())
     }
 
     fn add_to_playlist(
@@ -762,11 +686,11 @@ impl MpdClient for Client<'_> {
         uri: &str,
         target_position: Option<usize>,
     ) -> MpdResult<()> {
-        self.send_add_to_playlist(playlist_name, uri, target_position).and_then(read_ok)
+        self.send_add_to_playlist(playlist_name, uri, target_position).and_then(|()| self.read_ok())
     }
 
     fn save_queue_as_playlist(&mut self, name: &str, mode: Option<SaveMode>) -> MpdResult<()> {
-        self.send_save_queue_as_playlist(name, mode).and_then(read_ok)
+        self.send_save_queue_as_playlist(name, mode).and_then(|()| self.read_ok())
     }
 
     fn find_album_art(&mut self, path: &str) -> MpdResult<Option<Vec<u8>>> {
@@ -799,29 +723,30 @@ impl MpdClient for Client<'_> {
 
     // Outputs
     fn outputs(&mut self) -> MpdResult<Outputs> {
-        self.send_outputs().and_then(read_response)
+        self.send_outputs().and_then(|()| self.read_response())
     }
 
     fn toggle_output(&mut self, id: u32) -> MpdResult<()> {
-        self.send_toggle_output(id).and_then(read_ok)
+        self.send_toggle_output(id).and_then(|()| self.read_ok())
     }
 
     fn enable_output(&mut self, id: u32) -> MpdResult<()> {
-        self.send_enable_output(id).and_then(read_ok)
+        self.send_enable_output(id).and_then(|()| self.read_ok())
     }
 
     fn disable_output(&mut self, id: u32) -> MpdResult<()> {
-        self.send_disable_output(id).and_then(read_ok)
+        self.send_disable_output(id).and_then(|()| self.read_ok())
     }
 
     // Decoders
     fn decoders(&mut self) -> MpdResult<Decoders> {
-        self.send_decoders().and_then(read_response)
+        self.send_decoders().and_then(|()| self.read_response())
     }
 
     // Stickers
     fn sticker(&mut self, uri: &str, key: &str) -> MpdResult<Option<Sticker>> {
-        let result: MpdResult<Sticker> = self.send_sticker(uri, key).and_then(read_response);
+        let result: MpdResult<Sticker> =
+            self.send_sticker(uri, key).and_then(|()| self.read_response());
 
         if let Err(MpdError::Mpd(MpdFailureResponse { code: ErrorCode::NoExist, .. })) = result {
             return Ok(None);
@@ -831,19 +756,19 @@ impl MpdClient for Client<'_> {
     }
 
     fn set_sticker(&mut self, uri: &str, key: &str, value: &str) -> MpdResult<()> {
-        self.send_set_sticker(uri, key, value).and_then(read_ok)
+        self.send_set_sticker(uri, key, value).and_then(|()| self.read_ok())
     }
 
     fn delete_sticker(&mut self, uri: &str, key: &str) -> MpdResult<()> {
-        self.send_delete_sticker(uri, key).and_then(read_ok)
+        self.send_delete_sticker(uri, key).and_then(|()| self.read_ok())
     }
 
     fn delete_all_stickers(&mut self, uri: &str) -> MpdResult<()> {
-        self.send_delete_all_stickers(uri).and_then(read_ok)
+        self.send_delete_all_stickers(uri).and_then(|()| self.read_ok())
     }
 
     fn list_stickers(&mut self, uri: &str) -> MpdResult<Stickers> {
-        self.send_list_stickers(uri).and_then(read_response)
+        self.send_list_stickers(uri).and_then(|()| self.read_response())
     }
 
     /// Resulting `Vec` is of the same length as input `uri`s.
@@ -860,10 +785,10 @@ impl MpdClient for Client<'_> {
             for uri in &uris[i..] {
                 self.send_list_stickers(uri)?;
             }
-            let mut proto = self.send_execute_cmd_list()?;
+            self.send_execute_cmd_list()?;
 
             for uri in &uris[i..] {
-                let res: MpdResult<Stickers> = proto.read_response();
+                let res: MpdResult<Stickers> = self.read_response();
                 i += 1;
                 match res {
                     Ok(v) => {
@@ -883,439 +808,388 @@ impl MpdClient for Client<'_> {
         // In case the last sticker was fetched successfully we have to read an
         // OK as an ack for the whole command list
         if !list_ended_with_err {
-            ProtoClient::new_read_only(self).read_ok()?;
+            self.read_ok()?;
         }
 
         Ok(result)
     }
 
     fn find_stickers(&mut self, uri: &str, key: &str) -> MpdResult<StickersWithFile> {
-        self.send_find_stickers(uri, key).and_then(read_response)
+        self.send_find_stickers(uri, key).and_then(|()| self.read_response())
     }
 
     fn switch_to_partition(&mut self, name: &str) -> MpdResult<()> {
-        self.send_switch_to_partition(name).and_then(read_ok)
+        self.send_switch_to_partition(name).and_then(|()| self.read_ok())
     }
 
     fn new_partition(&mut self, name: &str) -> MpdResult<()> {
-        self.send_new_partition(name).and_then(read_ok)
+        self.send_new_partition(name).and_then(|()| self.read_ok())
     }
 
     fn list_partitions(&mut self) -> MpdResult<MpdList> {
-        self.send_list_partitions().and_then(read_response)
+        self.send_list_partitions().and_then(|()| self.read_response())
     }
 
     fn delete_partition(&mut self, name: &str) -> MpdResult<()> {
-        self.send_delete_partition(name).and_then(read_ok)
+        self.send_delete_partition(name).and_then(|()| self.read_ok())
     }
 
     fn move_output(&mut self, output_name: &str) -> MpdResult<()> {
-        self.send_move_output(output_name).and_then(read_ok)
+        self.send_move_output(output_name).and_then(|()| self.read_ok())
     }
 }
 
-impl MpdCommand<Self> for Client<'_> {
-    fn send_binary_limit<'cmd>(&mut self, limit: u64) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("binarylimit {limit}"))
+impl<T: SocketClient> MpdCommand for T {
+    fn send_binary_limit(&mut self, limit: u64) -> MpdResult<()> {
+        self.execute(&format!("binarylimit {limit}"))
     }
 
-    fn send_password<'cmd>(&mut self, password: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("password {}", password.quote_and_escape()))
+    fn send_password(&mut self, password: &str) -> MpdResult<()> {
+        self.execute(&format!("password {}", password.quote_and_escape()))
     }
 
-    fn send_commands<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("commands")
+    fn send_commands(&mut self) -> MpdResult<()> {
+        self.execute("commands")
     }
 
-    fn send_update<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    fn send_update(&mut self, path: Option<&str>) -> MpdResult<()> {
         if let Some(path) = path {
-            self.send(format!("update {}", path.quote_and_escape()))
+            self.execute(&format!("update {}", path.quote_and_escape()))
         } else {
-            self.send("update")
+            self.execute("update")
         }
     }
 
-    fn send_rescan<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    fn send_rescan(&mut self, path: Option<&str>) -> MpdResult<()> {
         if let Some(path) = path {
-            self.send(format!("rescan {}", path.quote_and_escape()))
+            self.execute(&format!("rescan {}", path.quote_and_escape()))
         } else {
-            self.send("rescan")
+            self.execute("rescan")
         }
     }
 
-    fn send_idle<'cmd>(
-        &mut self,
-        subsystem: Option<IdleEvent>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    fn send_idle(&mut self, subsystem: Option<IdleEvent>) -> MpdResult<()> {
         if let Some(subsystem) = subsystem {
-            self.send(format!("idle {subsystem}"))
+            self.execute(&format!("idle {subsystem}"))
         } else {
-            self.send("idle")
+            self.execute("idle")
         }
     }
 
-    fn send_noidle<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("noidle")
+    fn send_noidle(&mut self) -> MpdResult<()> {
+        self.execute("noidle")
     }
 
-    fn send_start_cmd_list<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("command_list_begin")
+    fn send_start_cmd_list(&mut self) -> MpdResult<()> {
+        self.execute("command_list_begin")
     }
 
-    fn send_start_cmd_list_ok<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("command_list_ok_begin")
+    fn send_start_cmd_list_ok(&mut self) -> MpdResult<()> {
+        self.execute("command_list_ok_begin")
     }
 
-    fn send_execute_cmd_list<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("command_list_end")
+    fn send_execute_cmd_list(&mut self) -> MpdResult<()> {
+        self.execute("command_list_end")
     }
 
-    fn send_get_volume<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        if self.version < Version::new(0, 23, 0) {
+    fn send_get_volume(&mut self) -> MpdResult<()> {
+        if self.version() < Version::new(0, 23, 0) {
             Err(MpdError::UnsupportedMpdVersion("getvol can be used since MPD 0.23.0"))
         } else {
-            self.send("getvol")
+            self.execute("getvol")
         }
     }
 
-    fn send_set_volume<'cmd>(&mut self, volume: Volume) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("setvol {}", volume.value()))
+    fn send_set_volume(&mut self, volume: Volume) -> MpdResult<()> {
+        self.execute(&format!("setvol {}", volume.value()))
     }
 
-    fn send_volume<'cmd>(&mut self, change: ValueChange) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    fn send_volume(&mut self, change: ValueChange) -> MpdResult<()> {
         match change {
             ValueChange::Increase(_) | ValueChange::Decrease(_) => {
-                self.send(format!("volume {}", change.to_mpd_str()))
+                self.execute(&format!("volume {}", change.to_mpd_str()))
             }
-            ValueChange::Set(val) => self.send(format!("setvol {val}")),
+            ValueChange::Set(val) => self.execute(&format!("setvol {val}")),
         }
     }
 
-    fn send_get_current_song<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("currentsong")
+    fn send_get_current_song(&mut self) -> MpdResult<()> {
+        self.execute("currentsong")
     }
 
-    fn send_get_status<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("status")
+    fn send_get_status(&mut self) -> MpdResult<()> {
+        self.execute("status")
     }
 
-    fn send_pause_toggle<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("pause")
+    fn send_pause_toggle(&mut self) -> MpdResult<()> {
+        self.execute("pause")
     }
 
-    fn send_pause<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("pause 1")
+    fn send_pause(&mut self) -> MpdResult<()> {
+        self.execute("pause 1")
     }
 
-    fn send_unpause<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("pause 0")
+    fn send_unpause(&mut self) -> MpdResult<()> {
+        self.execute("pause 0")
     }
 
-    fn send_next<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("next")
+    fn send_next(&mut self) -> MpdResult<()> {
+        self.execute("next")
     }
 
-    fn send_prev<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("previous")
+    fn send_prev(&mut self) -> MpdResult<()> {
+        self.execute("previous")
     }
 
-    fn send_play_pos<'cmd>(&mut self, pos: usize) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("play {pos}"))
+    fn send_play_pos(&mut self, pos: usize) -> MpdResult<()> {
+        self.execute(&format!("play {pos}"))
     }
 
-    fn send_play<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("play")
+    fn send_play(&mut self) -> MpdResult<()> {
+        self.execute("play")
     }
 
-    fn send_play_id<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("playid {id}"))
+    fn send_play_id(&mut self, id: u32) -> MpdResult<()> {
+        self.execute(&format!("playid {id}"))
     }
 
-    fn send_stop<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("stop")
+    fn send_stop(&mut self) -> MpdResult<()> {
+        self.execute("stop")
     }
 
-    fn send_seek_current<'cmd>(
-        &mut self,
-        value: ValueChange,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("seekcur {}", value.to_mpd_str()))
+    fn send_seek_current(&mut self, value: ValueChange) -> MpdResult<()> {
+        self.execute(&format!("seekcur {}", value.to_mpd_str()))
     }
 
-    fn send_repeat<'cmd>(&mut self, enabled: bool) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("repeat {}", u8::from(enabled)))
+    fn send_repeat(&mut self, enabled: bool) -> MpdResult<()> {
+        self.execute(&format!("repeat {}", u8::from(enabled)))
     }
 
-    fn send_random<'cmd>(&mut self, enabled: bool) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("random {}", u8::from(enabled)))
+    fn send_random(&mut self, enabled: bool) -> MpdResult<()> {
+        self.execute(&format!("random {}", u8::from(enabled)))
     }
 
-    fn send_single<'cmd>(
-        &mut self,
-        single: OnOffOneshot,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("single {}", single.to_mpd_value()))
+    fn send_single(&mut self, single: OnOffOneshot) -> MpdResult<()> {
+        self.execute(&format!("single {}", single.to_mpd_value()))
     }
 
-    fn send_consume<'cmd>(
-        &mut self,
-        consume: OnOffOneshot,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        if self.version < Version::new(0, 24, 0) && matches!(consume, OnOffOneshot::Oneshot) {
+    fn send_consume(&mut self, consume: OnOffOneshot) -> MpdResult<()> {
+        if self.version() < Version::new(0, 24, 0) && matches!(consume, OnOffOneshot::Oneshot) {
             Err(MpdError::UnsupportedMpdVersion("consume oneshot can be used since MPD 0.24.0"))
         } else {
-            self.send(format!("consume {}", consume.to_mpd_value()))
+            self.execute(&format!("consume {}", consume.to_mpd_value()))
         }
     }
 
-    fn send_mount<'cmd>(
-        &mut self,
-        name: &str,
-        path: &str,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("mount {} {}", name.quote_and_escape(), path.quote_and_escape()))
+    fn send_mount(&mut self, name: &str, path: &str) -> MpdResult<()> {
+        self.execute(&format!("mount {} {}", name.quote_and_escape(), path.quote_and_escape()))
     }
 
-    fn send_unmount<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("unmount {}", name.quote_and_escape()))
+    fn send_unmount(&mut self, name: &str) -> MpdResult<()> {
+        self.execute(&format!("unmount {}", name.quote_and_escape()))
     }
 
-    fn send_list_mounts<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("listmounts")
+    fn send_list_mounts(&mut self) -> MpdResult<()> {
+        self.execute("listmounts")
     }
 
-    fn send_add<'cmd>(
-        &mut self,
-        uri: &str,
-        position: Option<QueuePosition>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    fn send_add(&mut self, uri: &str, position: Option<QueuePosition>) -> MpdResult<()> {
         let position_arg: String =
             position.map_or(String::new(), |v| format!(" {}", v.as_mpd_str()));
-        self.send(format!("add {}{position_arg}", uri.quote_and_escape()))
+        self.execute(&format!("add {}{position_arg}", uri.quote_and_escape()))
     }
 
-    fn send_clear<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("clear")
+    fn send_clear(&mut self) -> MpdResult<()> {
+        self.execute("clear")
     }
 
-    fn send_delete_id<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("deleteid {id}"))
+    fn send_delete_id(&mut self, id: u32) -> MpdResult<()> {
+        self.execute(&format!("deleteid {id}"))
     }
 
-    fn send_delete_from_queue<'cmd>(
-        &mut self,
-        songs: SingleOrRange,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("delete {}", songs.as_mpd_range()))
+    fn send_delete_from_queue(&mut self, songs: SingleOrRange) -> MpdResult<()> {
+        self.execute(&format!("delete {}", songs.as_mpd_range()))
     }
 
-    fn send_playlist_info<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("playlistinfo")
+    fn send_playlist_info(&mut self) -> MpdResult<()> {
+        self.execute("playlistinfo")
     }
 
-    fn send_find<'cmd>(&mut self, filter: &[Filter<'_>]) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("find \"({})\"", filter.to_query_str()))
+    fn send_find(&mut self, filter: &[Filter<'_>]) -> MpdResult<()> {
+        self.execute(&format!("find \"({})\"", filter.to_query_str()))
     }
 
-    fn send_search<'cmd>(
-        &mut self,
-        filter: &[Filter<'_>],
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    fn send_search(&mut self, filter: &[Filter<'_>]) -> MpdResult<()> {
         let query = filter.to_query_str();
         let query = query.as_str();
         log::debug!(query; "Searching for songs");
-        self.send(format!("search \"({query})\""))
+        self.execute(&format!("search \"({query})\""))
     }
 
-    fn send_move_in_queue<'cmd>(
-        &mut self,
-        from: SingleOrRange,
-        to: QueuePosition,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("move {} {}", from.as_mpd_range(), to.as_mpd_str()))
+    fn send_move_in_queue(&mut self, from: SingleOrRange, to: QueuePosition) -> MpdResult<()> {
+        self.execute(&format!("move {} {}", from.as_mpd_range(), to.as_mpd_str()))
     }
 
-    fn send_move_id<'cmd>(
-        &mut self,
-        id: u32,
-        to: QueuePosition,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("moveid {id} \"{}\"", to.as_mpd_str()))
+    fn send_move_id(&mut self, id: u32, to: QueuePosition) -> MpdResult<()> {
+        self.execute(&format!("moveid {id} \"{}\"", to.as_mpd_str()))
     }
 
-    fn send_find_add<'cmd>(
+    fn send_find_add(
         &mut self,
         filter: &[Filter<'_>],
         position: Option<QueuePosition>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    ) -> MpdResult<()> {
         let position_arg: String =
             position.map_or(String::new(), |v| format!(" position {}", v.as_mpd_str()));
-        self.send(format!("findadd \"({})\"{position_arg}", filter.to_query_str()))
+        self.execute(&format!("findadd \"({})\"{position_arg}", filter.to_query_str()))
     }
 
-    fn send_search_add<'cmd>(
+    fn send_search_add(
         &mut self,
         filter: &[Filter<'_>],
         position: Option<QueuePosition>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    ) -> MpdResult<()> {
         let query = filter.to_query_str();
         let query = query.as_str();
         let position_arg: String =
             position.map_or(String::new(), |v| format!(" position {}", v.as_mpd_str()));
         log::debug!(query; "Searching for songs and adding them");
-        self.send(format!("searchadd \"({query})\"{position_arg}"))
+        self.execute(&format!("searchadd \"({query})\"{position_arg}"))
     }
 
-    fn send_list_tag<'cmd>(
-        &mut self,
-        tag: Tag,
-        filter: Option<&[Filter<'_>]>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(if let Some(filter) = filter {
-            format!("list {} \"({})\"", tag.as_str(), filter.to_query_str())
+    fn send_list_tag(&mut self, tag: Tag, filter: Option<&[Filter<'_>]>) -> MpdResult<()> {
+        if let Some(filter) = filter {
+            self.execute(&format!("list {} \"({})\"", tag.as_str(), filter.to_query_str()))
         } else {
-            format!("list {}", tag.as_str())
-        })
+            self.execute(&format!("list {}", tag.as_str()))
+        }
     }
 
-    fn send_shuffle<'cmd>(
-        &mut self,
-        range: Option<SingleOrRange>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    fn send_shuffle(&mut self, range: Option<SingleOrRange>) -> MpdResult<()> {
         if let Some(range) = range {
-            self.send(format!("shuffle {}", range.as_mpd_range()))
+            self.execute(&format!("shuffle {}", range.as_mpd_range()))
         } else {
-            self.send("shuffle")
+            self.execute("shuffle")
         }
     }
 
-    fn send_list_all<'cmd>(
-        &mut self,
-        path: Option<&str>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    fn send_list_all(&mut self, path: Option<&str>) -> MpdResult<()> {
         if let Some(path) = path {
-            self.send(format!("listall {}", path.quote_and_escape()))
+            self.execute(&format!("listall {}", path.quote_and_escape()))
         } else {
-            self.send("listall")
+            self.execute("listall")
         }
     }
 
-    fn send_lsinfo<'cmd>(&mut self, path: Option<&str>) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    fn send_lsinfo(&mut self, path: Option<&str>) -> MpdResult<()> {
         if let Some(path) = path {
-            self.send(format!("lsinfo {}", path.quote_and_escape()))
+            self.execute(&format!("lsinfo {}", path.quote_and_escape()))
         } else {
-            self.send("lsinfo")
+            self.execute("lsinfo")
         }
     }
 
-    fn send_list_files<'cmd>(
-        &mut self,
-        path: Option<&str>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    fn send_list_files(&mut self, path: Option<&str>) -> MpdResult<()> {
         if let Some(path) = path {
-            self.send(format!("listfiles {}", path.quote_and_escape()))
+            self.execute(&format!("listfiles {}", path.quote_and_escape()))
         } else {
-            self.send("listfiles")
+            self.execute("listfiles")
         }
     }
 
-    fn send_read_picture<'cmd>(&mut self, path: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("readpicture {} 0", path.quote_and_escape()))
+    fn send_read_picture(&mut self, path: &str) -> MpdResult<String> {
+        let cmd = format!("readpicture {} 0", path.quote_and_escape());
+        self.execute(&cmd)?;
+        Ok(cmd)
     }
 
-    fn send_albumart<'cmd>(&mut self, path: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("albumart {} 0", path.quote_and_escape()))
+    fn send_albumart(&mut self, path: &str) -> MpdResult<String> {
+        let cmd = format!("albumart {} 0", path.quote_and_escape());
+        self.execute(&cmd)?;
+        Ok(cmd)
     }
 
-    fn send_list_playlists<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("listplaylists")
+    fn send_list_playlists(&mut self) -> MpdResult<()> {
+        self.execute("listplaylists")
     }
 
-    fn send_list_playlist<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("listplaylist {}", name.quote_and_escape()))
+    fn send_list_playlist(&mut self, name: &str) -> MpdResult<()> {
+        self.execute(&format!("listplaylist {}", name.quote_and_escape()))
     }
 
-    fn send_list_playlist_info<'cmd>(
+    fn send_list_playlist_info(
         &mut self,
         playlist: &str,
         range: Option<SingleOrRange>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    ) -> MpdResult<()> {
         if let Some(range) = range {
-            if self.version < Version::new(0, 24, 0) {
+            if self.version() < Version::new(0, 24, 0) {
                 return Err(MpdError::UnsupportedMpdVersion(
                     "listplaylistinfo with range can only be used since MPD 0.24.0",
                 ));
             }
-            self.send(format!(
+            self.execute(&format!(
                 "listplaylistinfo {} {}",
                 playlist.quote_and_escape(),
                 range.as_mpd_range()
             ))
         } else {
-            self.send(format!("listplaylistinfo {}", playlist.quote_and_escape()))
+            self.execute(&format!("listplaylistinfo {}", playlist.quote_and_escape()))
         }
     }
 
-    fn send_load_playlist<'cmd>(
-        &mut self,
-        name: &str,
-        position: Option<QueuePosition>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    fn send_load_playlist(&mut self, name: &str, position: Option<QueuePosition>) -> MpdResult<()> {
         let position_arg: String =
             position.map_or(String::new(), |v| format!(" {}", v.as_mpd_str()));
-        self.send(format!("load {} 0:{position_arg}", name.quote_and_escape()))
+        self.execute(&format!("load {} 0:{position_arg}", name.quote_and_escape()))
     }
 
-    fn send_rename_playlist<'cmd>(
-        &mut self,
-        name: &str,
-        new_name: &str,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("rename {} {}", name.quote_and_escape(), new_name.quote_and_escape()))
+    fn send_rename_playlist(&mut self, name: &str, new_name: &str) -> MpdResult<()> {
+        self.execute(&format!("rename {} {}", name.quote_and_escape(), new_name.quote_and_escape()))
     }
 
-    fn send_delete_playlist<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("rm {}", name.quote_and_escape()))
+    fn send_delete_playlist(&mut self, name: &str) -> MpdResult<()> {
+        self.execute(&format!("rm {}", name.quote_and_escape()))
     }
 
-    fn send_delete_from_playlist<'cmd>(
+    fn send_delete_from_playlist(
         &mut self,
         playlist_name: &str,
         range: &SingleOrRange,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!(
+    ) -> MpdResult<()> {
+        self.execute(&format!(
             "playlistdelete {} {}",
             playlist_name.quote_and_escape(),
             range.as_mpd_range()
         ))
     }
 
-    fn send_move_in_playlist<'cmd>(
+    fn send_move_in_playlist(
         &mut self,
         playlist_name: &str,
         range: &SingleOrRange,
         target_position: usize,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!(
+    ) -> MpdResult<()> {
+        self.execute(&format!(
             "playlistmove {} {} {target_position}",
             playlist_name.quote_and_escape(),
             range.as_mpd_range()
         ))
     }
 
-    fn send_add_to_playlist<'cmd>(
+    fn send_add_to_playlist(
         &mut self,
         playlist_name: &str,
         uri: &str,
         target_position: Option<usize>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    ) -> MpdResult<()> {
         match target_position {
-            Some(target_position) => self.send(format!(
+            Some(target_position) => self.execute(&format!(
                 "playlistadd {} {} {target_position}",
                 playlist_name.quote_and_escape(),
                 uri.quote_and_escape()
             )),
-            None => self.send(format!(
+            None => self.execute(&format!(
                 "playlistadd {} {}",
                 playlist_name.quote_and_escape(),
                 uri.quote_and_escape()
@@ -1323,58 +1197,49 @@ impl MpdCommand<Self> for Client<'_> {
         }
     }
 
-    fn send_save_queue_as_playlist<'cmd>(
-        &mut self,
-        name: &str,
-        mode: Option<SaveMode>,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
+    fn send_save_queue_as_playlist(&mut self, name: &str, mode: Option<SaveMode>) -> MpdResult<()> {
         if let Some(mode) = mode {
-            if self.version < Version::new(0, 24, 0) {
+            if self.version() < Version::new(0, 24, 0) {
                 return Err(MpdError::UnsupportedMpdVersion(
                     "save mode can be used since MPD 0.24.0",
                 ));
             }
-            self.send(format!("save {} \"{}\"", name.quote_and_escape(), mode.as_ref()))
+            self.execute(&format!("save {} \"{}\"", name.quote_and_escape(), mode.as_ref()))
         } else {
-            self.send(format!("save {}", name.quote_and_escape()))
+            self.execute(&format!("save {}", name.quote_and_escape()))
         }
     }
 
-    fn send_outputs<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("outputs")
+    fn send_outputs(&mut self) -> MpdResult<()> {
+        self.execute("outputs")
     }
 
-    fn send_toggle_output<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("toggleoutput {id}"))
+    fn send_toggle_output(&mut self, id: u32) -> MpdResult<()> {
+        self.execute(&format!("toggleoutput {id}"))
     }
 
-    fn send_enable_output<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("enableoutput {id}"))
+    fn send_enable_output(&mut self, id: u32) -> MpdResult<()> {
+        self.execute(&format!("enableoutput {id}"))
     }
 
-    fn send_disable_output<'cmd>(&mut self, id: u32) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("disableoutput {id}"))
+    fn send_disable_output(&mut self, id: u32) -> MpdResult<()> {
+        self.execute(&format!("disableoutput {id}"))
     }
 
-    fn send_decoders<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("decoders")
+    fn send_decoders(&mut self) -> MpdResult<()> {
+        self.execute("decoders")
     }
 
-    fn send_sticker<'cmd>(
-        &mut self,
-        uri: &str,
-        key: &str,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("sticker get song {} {}", uri.quote_and_escape(), key.quote_and_escape()))
+    fn send_sticker(&mut self, uri: &str, key: &str) -> MpdResult<()> {
+        self.execute(&format!(
+            "sticker get song {} {}",
+            uri.quote_and_escape(),
+            key.quote_and_escape()
+        ))
     }
 
-    fn send_set_sticker<'cmd>(
-        &mut self,
-        uri: &str,
-        key: &str,
-        value: &str,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!(
+    fn send_set_sticker(&mut self, uri: &str, key: &str, value: &str) -> MpdResult<()> {
+        self.execute(&format!(
             "sticker set song {} {} {}",
             uri.quote_and_escape(),
             key.quote_and_escape(),
@@ -1382,68 +1247,48 @@ impl MpdCommand<Self> for Client<'_> {
         ))
     }
 
-    fn send_delete_sticker<'cmd>(
-        &mut self,
-        uri: &str,
-        key: &str,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!(
+    fn send_delete_sticker(&mut self, uri: &str, key: &str) -> MpdResult<()> {
+        self.execute(&format!(
             "sticker delete song {} {}",
             uri.quote_and_escape(),
             key.quote_and_escape()
         ))
     }
 
-    fn send_delete_all_stickers<'cmd>(
-        &mut self,
-        uri: &str,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("sticker delete song {}", uri.quote_and_escape()))
+    fn send_delete_all_stickers(&mut self, uri: &str) -> MpdResult<()> {
+        self.execute(&format!("sticker delete song {}", uri.quote_and_escape()))
     }
 
-    fn send_list_stickers<'cmd>(&mut self, uri: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("sticker list song {}", uri.quote_and_escape()))
+    fn send_list_stickers(&mut self, uri: &str) -> MpdResult<()> {
+        self.execute(&format!("sticker list song {}", uri.quote_and_escape()))
     }
 
-    fn send_find_stickers<'cmd>(
-        &mut self,
-        uri: &str,
-        key: &str,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!(
+    fn send_find_stickers(&mut self, uri: &str, key: &str) -> MpdResult<()> {
+        self.execute(&format!(
             "sticker find song {} {}",
             uri.quote_and_escape(),
             key.quote_and_escape()
         ))
     }
 
-    fn send_switch_to_partition<'cmd>(
-        &mut self,
-        name: &str,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("partition {}", name.quote_and_escape()))
+    fn send_switch_to_partition(&mut self, name: &str) -> MpdResult<()> {
+        self.execute(&format!("partition {}", name.quote_and_escape()))
     }
 
-    fn send_new_partition<'cmd>(&mut self, name: &str) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("newpartition {}", name.quote_and_escape()))
+    fn send_new_partition(&mut self, name: &str) -> MpdResult<()> {
+        self.execute(&format!("newpartition {}", name.quote_and_escape()))
     }
 
-    fn send_list_partitions<'cmd>(&mut self) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send("listpartitions")
+    fn send_list_partitions(&mut self) -> MpdResult<()> {
+        self.execute("listpartitions")
     }
 
-    fn send_delete_partition<'cmd>(
-        &mut self,
-        name: &str,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("delpartition {}", name.quote_and_escape()))
+    fn send_delete_partition(&mut self, name: &str) -> MpdResult<()> {
+        self.execute(&format!("delpartition {}", name.quote_and_escape()))
     }
 
-    fn send_move_output<'cmd>(
-        &mut self,
-        output_name: &str,
-    ) -> MpdCommandSubmitResult<'cmd, '_, Self> {
-        self.send(format!("moveoutput {}", output_name.quote_and_escape()))
+    fn send_move_output(&mut self, output_name: &str) -> MpdResult<()> {
+        self.execute(&format!("moveoutput {}", output_name.quote_and_escape()))
     }
 }
 

--- a/src/tests/fixtures/mpd_client.rs
+++ b/src/tests/fixtures/mpd_client.rs
@@ -30,6 +30,7 @@ use crate::mpd::{
     errors::MpdError,
     mpd_client::{Filter, MpdClient, SaveMode, SingleOrRange, Tag, ValueChange},
     proto_client::SocketClient,
+    version::Version,
 };
 
 #[fixture]
@@ -141,7 +142,7 @@ impl MpdClient for TestMpdClient {
         todo!("Not yet implemented")
     }
 
-    fn enter_idle(&mut self) -> MpdResult<crate::mpd::proto_client::ProtoClient<'static, '_, Self>>
+    fn enter_idle(&mut self) -> MpdResult<()>
     where
         Self: SocketClient,
     {
@@ -652,5 +653,9 @@ impl SocketClient for TestMpdClient {
 
     fn clear_read_buf(&mut self) -> anyhow::Result<()> {
         Ok(())
+    }
+
+    fn version(&self) -> crate::mpd::version::Version {
+        Version::new(0, 0, 0)
     }
 }


### PR DESCRIPTION
## Description

Part 2. This removes proto client struct, gets rid of bunch of lifetime and generic nonsense.
The whole thing should now be a bit more straightforward.

### Related issues

### Checklist

- [ ] All tests passed
- [ ] Code has been formatted with nightly
- [ ] Code has been checked with clippy (stable)
- [ ] Documentation has been updated (if needed)
- [ ] Changelog has been updated
