### PR TITLE
feat: transforms and truncate transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added `Transform` properties and `Truncate` transformation
+
 ### Changed
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1954,6 +1954,7 @@ dependencies = [
  "textwrap",
  "thiserror 2.0.12",
  "unicase",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
  "url",
  "vergen-gitcl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ rand = "0.9.1"
 ansi_colours = "1"
 thiserror = "2.0.12"
 parking_lot = { version = "0.12.4", features = [] }
+unicode-segmentation = "1.12.0"
 
 [build-dependencies]
 clap = { workspace = true }

--- a/docs/src/content/docs/next/configuration/header.mdx
+++ b/docs/src/content/docs/next/configuration/header.mdx
@@ -52,6 +52,35 @@ or predefined widgets.
 Will display static text in the table. Mostly useful for default values. For example if a song is missing an album tag,
 "Unknown Album" can be displayed by specifying `Text("Unknown Album")` as the default.
 
+### Transform
+
+<ConfigValue name="kind" type="other" customText="Transform(<transform>)" link="#property" />
+
+Apply a transformation to the given property. All transformations ignore style definitions, instead
+style the property directly.
+
+#### Truncate
+
+<ConfigValue
+    name="kind"
+    type="other"
+    customText="Transform(Truncate(content: <property>, length: <number>, from_start: bool))"
+    link="#property"
+/>
+
+Truncate the given property to a specified length. If `from_start` is true, the property is instead
+truncated from start.
+
+For exmaple to truncate song's `date` in the `song_table_format` to the first 4 characters:
+
+```rust
+(
+    prop: (kind: Transform(Truncate(content: (kind: Property(Other("date"))), from_start: false, length: 4))),
+    width: "20%",
+    label: "Date"
+),
+```
+
 ### Group
 
 <ConfigValue name="kind" type="other" customText="Group(<property>[])" link="#property" />

--- a/src/config/theme/queue_table.rs
+++ b/src/config/theme/queue_table.rs
@@ -17,6 +17,8 @@ use super::{
         PropertyKindOrText,
         SongProperty,
         SongPropertyFile,
+        Transform,
+        TransformFile,
     },
     style::ToConfigOr,
 };
@@ -182,6 +184,7 @@ impl TryFrom<QueueTableColumnsFile> for QueueTableColumns {
                     let label = v.label.unwrap_or_else(|| match &prop.kind {
                         PropertyKindOrText::Text { .. } => String::new(),
                         PropertyKindOrText::Sticker { .. } => String::new(),
+                        PropertyKindOrText::Transform { .. } => String::new(),
                         PropertyKindOrText::Property(prop) => prop.to_string(),
                         PropertyKindOrText::Group(_) => String::new(),
                     });
@@ -231,6 +234,15 @@ impl TryFrom<PropertyFile<SongPropertyFile>> for Property<SongProperty> {
         Ok(Self {
             kind: match value.kind {
                 PropertyKindFileOrText::Text(value) => PropertyKindOrText::Text(value),
+                PropertyKindFileOrText::Transform(TransformFile::Truncate {
+                    content,
+                    length,
+                    from_start,
+                }) => PropertyKindOrText::Transform(Transform::Truncate {
+                    content: Box::new((*content).try_into()?),
+                    length,
+                    from_start,
+                }),
                 PropertyKindFileOrText::Sticker(value) => PropertyKindOrText::Sticker(value),
                 PropertyKindFileOrText::Property(prop) => PropertyKindOrText::Property(prop.into()),
                 PropertyKindFileOrText::Group(group) => {

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -1,4 +1,9 @@
-use std::{borrow::Cow, cmp::Ordering, collections::HashMap, time::Duration};
+use std::{
+    borrow::Cow,
+    cmp::Ordering,
+    collections::{HashMap, VecDeque},
+    time::Duration,
+};
 
 use album_art::AlbumArtPane;
 use albums::AlbumsPane;
@@ -45,6 +50,7 @@ use crate::{
                 PropertyKindOrText,
                 SongProperty,
                 StatusProperty,
+                Transform,
                 WidgetProperty,
             },
         },
@@ -55,7 +61,7 @@ use crate::{
         mpd_client::Tag,
     },
     shared::{
-        ext::{duration::DurationExt, num::NumExt},
+        ext::{duration::DurationExt, num::NumExt, span::SpanExt},
         key_event::KeyEvent,
         mouse_event::MouseEvent,
     },
@@ -641,6 +647,9 @@ impl Song {
                 PropertyKindOrText::Group(_) => format
                     .as_string(Some(self), "", TagResolutionStrategy::All)
                     .map(|v| v.to_lowercase().contains(&filter.to_lowercase())),
+                PropertyKindOrText::Transform(Transform::Truncate { .. }) => format
+                    .as_string(Some(self), "", TagResolutionStrategy::All)
+                    .map(|v| v.to_lowercase().contains(&filter.to_lowercase())),
             };
             if match_found.is_some_and(|v| v) {
                 return true;
@@ -729,6 +738,44 @@ impl Song {
                 }
                 return Some(buf);
             }
+            PropertyKindOrText::Transform(Transform::Truncate { content, length, from_start }) => {
+                self.as_line_ellipsized(content, max_len, symbols, tag_separator, strategy)
+                    .map(|mut line| {
+                        let mut buf = VecDeque::new();
+                        let mut remaining_len = *length;
+                        let push_fn =
+                            if *from_start { VecDeque::push_front } else { VecDeque::push_back };
+                        let truncate_fn =
+                            if *from_start { Span::truncate_start } else { Span::truncate_end };
+                        let spans_len = line.spans.len();
+
+                        for i in 0..spans_len {
+                            if remaining_len == 0 {
+                                break;
+                            }
+                            let i = if *from_start { spans_len - 1 - i } else { i };
+                            let mut span = std::mem::take(&mut line.spans[i]);
+
+                            let remaining = truncate_fn(&mut span, remaining_len);
+                            push_fn(&mut buf, span);
+                            remaining_len = remaining_len.saturating_sub(remaining);
+                        }
+
+                        line.spans = Vec::from(buf);
+                        line
+                    })
+                    .or_else(|| {
+                        format.default.as_ref().and_then(|format| {
+                            self.as_line_ellipsized(
+                                format,
+                                max_len,
+                                symbols,
+                                tag_separator,
+                                strategy,
+                            )
+                        })
+                    })
+            }
         }
     }
 }
@@ -783,6 +830,23 @@ impl Property<SongProperty> {
                     }
                 }
                 return Some(buf);
+            }
+            PropertyKindOrText::Transform(Transform::Truncate { content, length, from_start }) => {
+                content
+                    .as_string(song, tag_separator, strategy)
+                    .map(|mut result| {
+                        if *from_start {
+                            result.truncate_start(*length);
+                        } else {
+                            result.truncate_end(*length);
+                        }
+                        result
+                    })
+                    .or_else(|| {
+                        self.default
+                            .as_ref()
+                            .and_then(|d| d.as_string(song, tag_separator, strategy))
+                    })
             }
         }
     }
@@ -992,6 +1056,37 @@ impl Property<PropertyKind> {
                 }
                 return Some(Either::Right(buf));
             }
+            PropertyKindOrText::Transform(Transform::Truncate { content, length, from_start }) => {
+                let truncate_fn =
+                    if *from_start { Span::truncate_start } else { Span::truncate_end };
+                match content.as_span(song, context, tag_separator, strategy) {
+                    Some(Either::Left(mut span)) => {
+                        truncate_fn(&mut span, *length);
+                        Some(Either::Left(span))
+                    }
+                    Some(Either::Right(mut spans)) => {
+                        let mut buf = VecDeque::new();
+                        let mut remaining_len = *length;
+                        let push_fn =
+                            if *from_start { VecDeque::push_front } else { VecDeque::push_back };
+                        let spans_len = spans.len();
+
+                        for i in 0..spans.len() {
+                            if remaining_len == 0 {
+                                break;
+                            }
+                            let i = if *from_start { spans_len - 1 - i } else { i };
+                            let mut span = std::mem::take(&mut spans[i]);
+
+                            let remaining = truncate_fn(&mut span, remaining_len);
+                            push_fn(&mut buf, span);
+                            remaining_len = remaining_len.saturating_sub(remaining);
+                        }
+                        Some(Either::Right(buf.into()))
+                    }
+                    None => self.default_as_span(song, context, tag_separator, strategy),
+                }
+            }
         }
     }
 }
@@ -1109,33 +1204,267 @@ impl StringExt for String {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod format_tests {
+    use std::{collections::HashMap, time::Duration};
+
+    use either::Either;
+    use ratatui::{
+        style::{Style, Stylize},
+        text::Span,
+    };
+    use rstest::rstest;
+
     use crate::{
-        config::theme::properties::{Property, PropertyKindOrText, SongProperty},
-        mpd::commands::Song,
+        config::theme::{
+            StyleFile,
+            TagResolutionStrategy,
+            properties::{
+                Property,
+                PropertyKind,
+                PropertyKindOrText,
+                SongProperty,
+                StatusProperty,
+                StatusPropertyFile,
+            },
+        },
+        context::AppContext,
+        mpd::commands::{Song, State, Status, Volume, status::OnOffOneshot},
+        tests::fixtures::app_context,
     };
 
-    mod correct_values {
-        use std::{collections::HashMap, time::Duration};
+    mod truncate {
+        use itertools::Itertools;
+        use ratatui::text::Line;
 
-        use either::Either;
-        use ratatui::{
-            style::{Style, Stylize},
-            text::Span,
-        };
-        use rstest::rstest;
+        use super::*;
+        use crate::config::theme::{SymbolsConfig, properties::Transform};
+
+        #[rstest]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 0, false, Either::Left(""))]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 0, true, Either::Left(""))]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 3, false, Either::Left("abc"))]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 3, true, Either::Left("fgh"))]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 8, false, Either::Left("abcdefgh"))]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 8, true, Either::Left("abcdefgh"))]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 99, false, Either::Left("abcdefgh"))]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 99, true, Either::Left("abcdefgh"))]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 3, false, Either::Right(vec!["ab", "c"]))]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 3, true, Either::Right(vec!["f", "gh"]))]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 8, false, Either::Right(vec!["ab", "cd", "ef", "gh"]))]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 8, true, Either::Right(vec!["ab", "cd", "ef", "gh"]))]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 99, false, Either::Right(vec!["ab", "cd", "ef", "gh"]))]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 99, true, Either::Right(vec!["ab", "cd", "ef", "gh"]))]
+        fn as_span(
+            app_context: AppContext,
+            #[case] props: PropertyKindOrText<PropertyKind>,
+            #[case] length: usize,
+            #[case] from_start: bool,
+            #[case] expected: Either<&str, Vec<&str>>,
+        ) {
+            let format = Property::<PropertyKind> {
+                kind: PropertyKindOrText::Transform(Transform::Truncate {
+                    content: Box::new(Property { kind: props, style: None, default: None }),
+                    length,
+                    from_start,
+                }),
+                style: None,
+                default: None,
+            };
+
+            let result = format.as_span(None, &app_context, "", TagResolutionStrategy::All);
+
+            assert_eq!(
+                result,
+                Some(match expected {
+                    Either::Left(value) =>
+                        either::Either::<Span<'_>, Vec<Span<'_>>>::Left(Span::raw(value)),
+                    Either::Right(values) => either::Either::<Span<'_>, Vec<Span<'_>>>::Right(
+                        values.into_iter().map(Span::raw).collect()
+                    ),
+                })
+            );
+        }
+
+        #[rstest]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 0, false, "")]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 0, true, "")]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 3, false, "abc")]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 3, true, "fgh")]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 8, false, "abcdefgh")]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 8, true, "abcdefgh")]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 99, false, "abcdefgh")]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 99, true, "abcdefgh")]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 3, false, "abc")]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 3, true, "fgh")]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 8, false, "abcdefgh")]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 8, true, "abcdefgh")]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 99, false, "abcdefgh")]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 99, true, "abcdefgh")]
+        fn as_string(
+            #[case] props: PropertyKindOrText<SongProperty>,
+            #[case] length: usize,
+            #[case] from_start: bool,
+            #[case] expected: &str,
+        ) {
+            let format = Property::<SongProperty> {
+                kind: PropertyKindOrText::Transform(Transform::Truncate {
+                    content: Box::new(Property { kind: props, style: None, default: None }),
+                    length,
+                    from_start,
+                }),
+                style: None,
+                default: None,
+            };
+
+            let result = format.as_string(None, "", TagResolutionStrategy::All);
+
+            assert_eq!(result, Some(expected.to_string()));
+        }
+
+        #[rstest]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 0, false, Either::Left(""))]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 0, true, Either::Left(""))]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 3, false, Either::Left("abc"))]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 3, true, Either::Left("fgh"))]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 8, false, Either::Left("abcdefgh"))]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 8, true, Either::Left("abcdefgh"))]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 99, false, Either::Left("abcdefgh"))]
+        #[case(PropertyKindOrText::Text("abcdefgh".into()), 99, true, Either::Left("abcdefgh"))]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 3, false, Either::Right(vec!["ab", "c"]))]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 3, true, Either::Right(vec!["f", "gh"]))]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 8, false, Either::Right(vec!["ab", "cd", "ef", "gh"]))]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 8, true, Either::Right(vec!["ab", "cd", "ef", "gh"]))]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 99, false, Either::Right(vec!["ab", "cd", "ef", "gh"]))]
+        #[case(PropertyKindOrText::Group(vec![
+                Property::builder().kind(PropertyKindOrText::Text("ab".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("cd".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("ef".into())).build(),
+                Property::builder().kind(PropertyKindOrText::Text("gh".into())).build(),
+            ]), 99, true, Either::Right(vec!["ab", "cd", "ef", "gh"]))]
+        fn as_line_ellipsized(
+            #[case] props: PropertyKindOrText<SongProperty>,
+            #[case] length: usize,
+            #[case] from_start: bool,
+            #[case] expected: Either<&str, Vec<&str>>,
+        ) {
+            let format = Property::<SongProperty> {
+                kind: PropertyKindOrText::Transform(Transform::Truncate {
+                    content: Box::new(Property { kind: props, style: None, default: None }),
+                    length,
+                    from_start,
+                }),
+                style: None,
+                default: None,
+            };
+
+            let song = Song::default();
+            let result = song.as_line_ellipsized(
+                &format,
+                999,
+                &SymbolsConfig::default(),
+                "",
+                TagResolutionStrategy::All,
+            );
+
+            assert_eq!(
+                result,
+                Some(match expected {
+                    Either::Left(value) => Line::from(value),
+                    Either::Right(values) =>
+                        Line::from(values.into_iter().map(Span::raw).collect_vec()),
+                })
+            );
+        }
+    }
+
+    mod correct_values {
         use test_case::test_case;
 
         use super::*;
-        use crate::{
-            config::theme::{
-                StyleFile,
-                TagResolutionStrategy,
-                properties::{PropertyKind, StatusProperty, StatusPropertyFile},
-            },
-            context::AppContext,
-            mpd::commands::{State, Status, Volume, status::OnOffOneshot},
-            tests::fixtures::app_context,
-        };
 
         #[test_case(SongProperty::Title, "title")]
         #[test_case(SongProperty::Artist, "artist")]
@@ -1337,10 +1666,7 @@ mod format_tests {
     }
 
     mod property {
-        use std::collections::HashMap;
-
         use super::*;
-        use crate::config::theme::TagResolutionStrategy;
 
         #[test]
         fn works() {
@@ -1414,10 +1740,7 @@ mod format_tests {
     }
 
     mod text {
-        use std::collections::HashMap;
-
         use super::*;
-        use crate::config::theme::TagResolutionStrategy;
 
         #[test]
         fn works() {
@@ -1470,10 +1793,7 @@ mod format_tests {
     }
 
     mod group {
-        use std::collections::HashMap;
-
         use super::*;
-        use crate::config::theme::TagResolutionStrategy;
 
         #[test]
         fn group_no_fallback() {


### PR DESCRIPTION
## Description

Adds new type of properties, the `Transform`s. First transformation is `Truncate` allowing you
to truncate the property to a given length.

### Related issues

https://github.com/mierak/rmpc/issues/361

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
