### PR TITLE
Fix/queue remaining update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 ### Fixed
+- Fixed `QueueTimeRemaining` not updating remaining time
 
 ## [0.9.0] - 2025-06-23
 

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -1012,13 +1012,19 @@ impl Property<PropertyKind> {
                 StatusProperty::QueueTimeRemaining { separator } => {
                     let sum = context.find_current_song_in_queue().map_or(
                         Duration::default(),
-                        |(current_song_idx, _)| {
-                            context
+                        |(current_song_idx, current_song)| {
+                            let total_remaining: Duration = context
                                 .queue
                                 .iter()
                                 .skip(current_song_idx)
                                 .filter_map(|s| s.duration)
-                                .sum()
+                                .sum();
+
+                            if current_song.duration.is_some() {
+                                total_remaining.saturating_sub(context.status.elapsed)
+                            } else {
+                                total_remaining
+                            }
                         },
                     );
                     Some(Either::Left(Span::styled(sum.format_to_duration(separator), style)))


### PR DESCRIPTION
## Description

Allows `QueueRemainingTime` to calculate and display remaining time of the queue. Basically working like `Elapsed` except it's calculating the remaining time.

### Related issues

fixes #513

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
