### PR TITLE
docs: fix typos

### DIFF
--- a/docs/src/content/docs/next/configuration/cava.mdx
+++ b/docs/src/content/docs/next/configuration/cava.mdx
@@ -51,7 +51,7 @@ After that you need to setup Cava, MPD and rmpc to talk to each other.
             source: "/tmp/mpd.fifo",
             sample_rate: 44100,
             channels: 2,
-            samble_bits: 16,
+            sample_bits: 16,
         ),
         smoothing: (
             noise_reduction: 77, // default 77

--- a/docs/src/content/docs/next/configuration/keybinds.mdx
+++ b/docs/src/content/docs/next/configuration/keybinds.mdx
@@ -148,6 +148,6 @@ Keybinds specific to the queue pane.
 |     `D`     | DeleteAll     | Clear current queue                                           |
 |   `Enter`   | Play          | Play song under cursor                                        |
 |     `a`     | AddToPlaylist | Add song under cursor to an existing playlist                 |
-|     `d`     | Delete        | Remove song under curor from the queue                        |
+|     `d`     | Delete        | Remove song under cursor from the queue                        |
 |     `C`     | JumpToCurrent | Moves the cursor in Queue table to the currently playing song |
 |     `X`     | Shuffle       | Shuffles the whole queue or selected range(s)                 |

--- a/docs/src/content/docs/release-0-9-0/configuration/cava.mdx
+++ b/docs/src/content/docs/release-0-9-0/configuration/cava.mdx
@@ -51,7 +51,7 @@ After that you need to setup Cava, MPD and rmpc to talk to each other.
             source: "/tmp/mpd.fifo",
             sample_rate: 44100,
             channels: 2,
-            samble_bits: 16,
+            sample_bits: 16,
         ),
         smoothing: (
             noise_reduction: 77, // default 77


### PR DESCRIPTION
## Description
Browsing the keybinding and cava page to configure rmpc and finding some typos.

I only fixed the next release docs, tell me if you want me to also change the current release docs
### Related issues

### Checklist

- [ ] All tests passed
- [ ] Code has been formatted with nightly
- [ ] Code has been checked with clippy (stable)
- [ ] Documentation has been updated (if needed)
- [ ] Changelog has been updated
