### PR TITLE
feat/improve LRC parsing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-
 - Improved `.lrc` lyrics files parser performance and fixed parsing issues
 - Normalized duration formatting across `QueueTimeTotal` and `QueueTimeRemaining` properties for both standard (MM:SS/H:MM:SS) and verbose formats
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+
+- Improved `.lrc` lyrics files parser performance and fixed parsing issues
 - Normalized duration formatting across `QueueTimeTotal` and `QueueTimeRemaining` properties for both standard (MM:SS/H:MM:SS) and verbose formats
 
 ### Fixed

--- a/docs/src/content/docs/next/configuration/lyrics.mdx
+++ b/docs/src/content/docs/next/configuration/lyrics.mdx
@@ -42,6 +42,7 @@ LRC files are text files with a specific structure:
 - `[1:23.45]Second line` (single digit minutes work)
 - `[00:30.5]Third line` (different decimal places work)
 - `[01:30.00][02:30.00]Repeated chorus` (multiple timestamps per line)
+- `[00:10.00][Intro] Welcome` (non-timestamp content like `[Intro]` becomes part of lyrics)
 
 **What gets ignored:**
 - `# Comments like this`
@@ -98,6 +99,7 @@ Following examples assume that your MPD's music directory is set to `/home/user/
 [00:45.5]Different decimal format works
 [01:00.00]Lyrics with émojis 🎵 work fine
 [01:20.00]Text with [brackets] works too
+[01:30.00][Intro] This text becomes part of lyrics
 [01:35.00]
 [abc:30.00]Invalid timestamp - ignored
 This line has no brackets - ignored
@@ -107,7 +109,7 @@ This line has no brackets - ignored
 **What rmpc sees in this example:**
 - **Song info:** "My Song" by "Artist Name" from "Album Name"
 - **Timing:** All timestamps shifted 500ms earlier (offset)
-- **Lyrics:** 8 lines with valid timestamps (invalid lines skipped)
+- **Lyrics:** 9 lines with valid timestamps (invalid lines skipped)
 - **Ignored:** Comments, unknown tags, invalid timestamps
 
 ### Important Notes for Users
@@ -121,7 +123,9 @@ This line has no brackets - ignored
 - Use standard `[MM:SS.xx]` format for timestamps
 - Include `[ar:]` (artist) and `[ti:]` (title) tags for proper song matching
 - Files with no valid timestamps will appear empty in the lyrics pane
+- Only consecutive timestamps at the start of a line are parsed - everything after the first non-timestamp tag becomes lyrics content
 
 **Troubleshooting:**
 - If lyrics don't show up, check that artist/title metadata matches your song
 - Missing or mismatched metadata prevents automatic matching
+- Lines like `[00:10.00][tag:value][00:12.00]text` will create one line at 10.00s with content `[tag:value][00:12.00]text` - only consecutive timestamps are parsed

--- a/docs/src/content/docs/next/configuration/lyrics.mdx
+++ b/docs/src/content/docs/next/configuration/lyrics.mdx
@@ -7,24 +7,68 @@ sidebar:
 
 ## Lyrics
 
-Rmpc supports displaying [synchronized lyrics](<https://en.wikipedia.org/wiki/LRC_(file_format)>) in the `Lyrics` pane.
+Rmpc supports displaying [synchronized lyrics](https://en.wikipedia.org/wiki/LRC_\(file_format\)) in the `Lyrics` pane.
 Other lyrics formats are not supported. The `lyrics_dir` must be configured for the resolution to work. All `lrc` files
 must be on the client side.
 
+### LRC file format
+
+LRC files are text files with a specific structure:
+
+```lrc
+[ar:Artist Name]
+[ti:Song Title]
+[al:Album Name]
+[length:03:45.12]
+[offset:1000]
+
+[00:12.34]First line of lyrics
+[00:15.67]Second line of lyrics
+[01:23.45]Another line...
+```
+
+#### What gets parsed and what gets ignored
+
+**Metadata tags** (at the beginning of file):
+- `[ar:Artist Name]` - Artist name (required for matching)
+- `[ti:Song Title]` - Song title (required for matching)
+- `[al:Album Name]` - Album name (optional)
+- `[au:Author Name]` - Author/lyricist name (optional)
+- `[length:3:45]` - Song length (helps with matching)
+- `[offset:-500]` - Time adjustment in milliseconds
+
+**Timestamp lines** (lyrics with timing):
+- `[00:12.34]First line of lyrics`
+- `[1:23.45]Second line` (single digit minutes work)
+- `[00:30.5]Third line` (different decimal places work)
+- `[01:30.00][02:30.00]Repeated chorus` (multiple timestamps per line)
+
+**What gets ignored:**
+- `# Comments like this`
+- `[custom:unknown tags]`
+- `[tool:editor name]`
+- `[abc:30.00]Invalid timestamp` (invalid minutes/seconds)
+- `Lines without brackets`
+- `[unclosed bracket`
+- Empty lines
+
 ### Lrc file resolution
 
-Lrc files are resolved by rmpc via two methods(in order):
+Lrc files are resolved by rmpc via two methods (in order):
 
 - Same path as the song file, except with the `.lrc` file extension
 - By indexing all the `.lrc` files in the `lyrics_dir`
 
 #### Lyrics index
 
-Rmpc will create an index of all `.lrc` files in your `lyrics_dir` on startup. Lrc files can contain metadata about
-the song which they belong to. These metadata can include artist(ar), title(ti) and album(al) as well as length.
-`Artist`, `title` and `album` have to exactly(case insensitive) match in song's and lrc's metadata for the song to match.
-Album is not a strict requirement to match, if it is missing in either the lrc file or song metadata it will not be considered.
-If the lrc file contains `length`, it is matched to song's length plus or minus 5 seconds.
+Rmpc will create an index of all `.lrc` files in your `lyrics_dir` on startup.
+
+**How songs match to LRC files:**
+- Artist and title must match exactly (case insensitive)
+- Album is optional - if present in both, it must match
+- If LRC has a length tag, it must be within ±5 seconds of song length
+
+**Unknown tags are ignored:** `[by:Creator]`, `[tool:Editor]`, `[version:1.0]`, etc.
 
 #### Same path as the song file
 
@@ -35,3 +79,49 @@ Following examples assume that your MPD's music directory is set to `/home/user/
 
 2. If your `lyrics_dir` is set to a different path, ie. `/home/user/.lyrics`
    `/home/user/Music/artist/album/song.flac` will try to resolve `/home/user/.lyrics/artist/album/song.lrc`
+
+### Example LRC file
+
+```lrc
+# This is a comment - ignored
+[ti:My Song]
+[ar:Artist Name]
+[al:Album Name]
+[length:3:45]
+[offset:-500]
+[custom:unknown tag]  # ignored
+
+[00:00.00]Intro starts here
+[00:12.34]First verse line
+[00:15.67]Second verse line
+[00:30.00][01:30.00]This chorus repeats twice
+[00:45.5]Different decimal format works
+[01:00.00]Lyrics with émojis 🎵 work fine
+[01:20.00]Text with [brackets] works too
+[01:35.00]
+[abc:30.00]Invalid timestamp - ignored
+This line has no brackets - ignored
+[02:00.00]Back to lyrics
+```
+
+**What rmpc sees in this example:**
+- **Song info:** "My Song" by "Artist Name" from "Album Name"
+- **Timing:** All timestamps shifted 500ms earlier (offset)
+- **Lyrics:** 8 lines with valid timestamps (invalid lines skipped)
+- **Ignored:** Comments, unknown tags, invalid timestamps
+
+### Important Notes for Users
+
+**What works:**
+- Most LRC files from any source work without modification
+- Files with some parsing errors still work - only invalid lines are skipped
+- Large timestamp values are supported (up to 99:59.99)
+
+**For best results:**
+- Use standard `[MM:SS.xx]` format for timestamps
+- Include `[ar:]` (artist) and `[ti:]` (title) tags for proper song matching
+- Files with no valid timestamps will appear empty in the lyrics pane
+
+**Troubleshooting:**
+- If lyrics don't show up, check that artist/title metadata matches your song
+- Missing or mismatched metadata prevents automatic matching

--- a/src/shared/lrc/index.rs
+++ b/src/shared/lrc/index.rs
@@ -188,7 +188,7 @@ impl LrcIndex {
 impl LrcIndexEntry {
     fn read(mut read: impl BufRead, path: PathBuf) -> Result<Option<Self>> {
         let mut content = String::new();
-        
+
         loop {
             let mut line = String::new();
             if read.read_line(&mut line)? == 0 {
@@ -201,7 +201,9 @@ impl LrcIndexEntry {
             if !trimmed.is_empty() && !trimmed.starts_with('#') && trimmed.starts_with('[') {
                 if let Some(bracket_end) = trimmed.find(']') {
                     let tag_content = &trimmed[1..bracket_end];
-                    if tag_content.chars().next().is_some_and(|c| c.is_numeric()) && tag_content.contains(':') {
+                    if tag_content.chars().next().is_some_and(|c| c.is_numeric())
+                        && tag_content.contains(':')
+                    {
                         // timestamp found, add this line and stop
                         content.push_str(&line);
                         break;

--- a/src/shared/lrc/index.rs
+++ b/src/shared/lrc/index.rs
@@ -188,7 +188,28 @@ impl LrcIndex {
 impl LrcIndexEntry {
     fn read(mut read: impl BufRead, path: PathBuf) -> Result<Option<Self>> {
         let mut content = String::new();
-        read.read_to_string(&mut content)?;
+        
+        loop {
+            let mut line = String::new();
+            if read.read_line(&mut line)? == 0 {
+                break; // EOF
+            }
+            // if this line has a timestamp, stop reading
+            // We are looking for lines that start with [ and have a timestamp in them
+            // reading all the way to the end of the file is not necessary
+            let trimmed = line.trim();
+            if !trimmed.is_empty() && !trimmed.starts_with('#') && trimmed.starts_with('[') {
+                if let Some(bracket_end) = trimmed.find(']') {
+                    let tag_content = &trimmed[1..bracket_end];
+                    if tag_content.chars().next().is_some_and(|c| c.is_numeric()) && tag_content.contains(':') {
+                        // timestamp found, add this line and stop
+                        content.push_str(&line);
+                        break;
+                    }
+                }
+            }
+            content.push_str(&line);
+        }
 
         let (metadata, _) = parse_metadata_only(&content);
 

--- a/src/shared/lrc/index.rs
+++ b/src/shared/lrc/index.rs
@@ -13,21 +13,32 @@ use walkdir::WalkDir;
 use super::{Lrc, parse_metadata_only};
 use crate::{mpd::commands::Song, shared::macros::try_cont};
 
+/// Index of LRC files for fast song-to-lyrics matching.
+/// 
+/// This structure maintains an in-memory index of all LRC files in a directory,
+/// allowing for fast lookup of lyrics based on song metadata (artist, title, album).
+/// The index is built using efficient metadata-only parsing to avoid processing
+/// the entire content of each LRC file during startup.
 #[derive(Debug, Eq, PartialEq, Default, Serialize)]
 pub struct LrcIndex {
     index: Vec<LrcIndexEntry>,
 }
 
+/// A single entry in the LRC index containing metadata for fast matching.
+/// 
+/// This structure stores the essential metadata needed to match songs to their
+/// corresponding LRC files without having to parse the entire file content.
 #[derive(Debug, Eq, PartialEq, Hash, Serialize)]
 pub struct LrcIndexEntry {
+    /// Path to the LRC file
     pub path: PathBuf,
-    /// ti
+    /// Song title (from [ti:] tag)
     pub title: String,
-    /// ar
+    /// Artist name (from [ar:] tag)
     pub artist: String,
-    /// al
+    /// Album name (from [al:] tag)
     pub album: Option<String>,
-    /// length
+    /// Song length (from [length:] tag)
     pub length: Option<Duration>,
 }
 
@@ -179,7 +190,7 @@ impl LrcIndexEntry {
         let mut content = String::new();
         read.read_to_string(&mut content)?;
 
-        let metadata = parse_metadata_only(&content);
+        let (metadata, _) = parse_metadata_only(&content);
 
         let Some(artist) = metadata.artist else {
             return Ok(None);

--- a/src/shared/lrc/index.rs
+++ b/src/shared/lrc/index.rs
@@ -14,18 +14,18 @@ use super::{Lrc, parse_metadata_only};
 use crate::{mpd::commands::Song, shared::macros::try_cont};
 
 /// Index of LRC files for fast song-to-lyrics matching.
-/// 
+///
 /// This structure maintains an in-memory index of all LRC files in a directory,
-/// allowing for fast lookup of lyrics based on song metadata (artist, title, album).
-/// The index is built using efficient metadata-only parsing to avoid processing
-/// the entire content of each LRC file during startup.
+/// allowing for fast lookup of lyrics based on song metadata (artist, title,
+/// album). The index is built using efficient metadata-only parsing to avoid
+/// processing the entire content of each LRC file during startup.
 #[derive(Debug, Eq, PartialEq, Default, Serialize)]
 pub struct LrcIndex {
     index: Vec<LrcIndexEntry>,
 }
 
 /// A single entry in the LRC index containing metadata for fast matching.
-/// 
+///
 /// This structure stores the essential metadata needed to match songs to their
 /// corresponding LRC files without having to parse the entire file content.
 #[derive(Debug, Eq, PartialEq, Hash, Serialize)]

--- a/src/shared/lrc/index.rs
+++ b/src/shared/lrc/index.rs
@@ -188,9 +188,9 @@ impl LrcIndex {
 impl LrcIndexEntry {
     fn read(mut read: impl BufRead, path: PathBuf) -> Result<Option<Self>> {
         let mut content = String::new();
+        let mut line = String::new();
 
         loop {
-            let mut line = String::new();
             if read.read_line(&mut line)? == 0 {
                 break; // EOF
             }
@@ -198,7 +198,7 @@ impl LrcIndexEntry {
             // We are looking for lines that start with [ and have a timestamp in them
             // reading all the way to the end of the file is not necessary
             let trimmed = line.trim();
-            if !trimmed.is_empty() && !trimmed.starts_with('#') && trimmed.starts_with('[') {
+            if !trimmed.is_empty() && trimmed.starts_with('[') {
                 if let Some(bracket_end) = trimmed.find(']') {
                     let tag_content = &trimmed[1..bracket_end];
                     if tag_content.chars().next().is_some_and(|c| c.is_numeric())
@@ -211,6 +211,7 @@ impl LrcIndexEntry {
                 }
             }
             content.push_str(&line);
+            line.clear();
         }
 
         let (metadata, _) = parse_metadata_only(&content);

--- a/src/shared/lrc/lyrics.rs
+++ b/src/shared/lrc/lyrics.rs
@@ -30,8 +30,8 @@ pub struct Lrc {
     pub length: Option<Duration>,
 }
 
-/// Efficiently parse only metadata from LRC content, stopping at the first timestamp.
-/// and returning the line index where lyrics start.
+/// Efficiently parse only metadata from LRC content, stopping at the first
+/// timestamp. and returning the line index where lyrics start.
 pub fn parse_metadata_only(content: &str) -> (LrcMetadata, usize) {
     let mut metadata = LrcMetadata::default();
     let lines: Vec<&str> = content.lines().collect();
@@ -147,8 +147,8 @@ impl FromStr for Lrc {
             length: metadata.length,
         };
 
-        // Process only lines starting from where lyrics begin (skip already-parsed metadata)
-        // since we dont want to parse metadata again
+        // Process only lines starting from where lyrics begin (skip already-parsed
+        // metadata) since we dont want to parse metadata again
         for s in s.lines().skip(lyrics_start_line) {
             if s.is_empty() || s.starts_with('#') {
                 continue;

--- a/src/shared/lrc/lyrics.rs
+++ b/src/shared/lrc/lyrics.rs
@@ -139,12 +139,12 @@ impl FromStr for Lrc {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (metadata, lyrics_start_line) = parse_metadata_only(s);
         let offset = metadata.offset;
-        
+
         // preallocate the Vec with an estimated capacity
         // This avoids multiple reallocations during parsing
         let remaining_lines = s.lines().count().saturating_sub(lyrics_start_line);
         let estimated_capacity = remaining_lines * 2;
-        
+
         let mut result = Self {
             lines: Vec::with_capacity(estimated_capacity),
             title: metadata.title,

--- a/src/shared/lrc/lyrics.rs
+++ b/src/shared/lrc/lyrics.rs
@@ -1,6 +1,6 @@
 use std::{str::FromStr, time::Duration};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result};
 
 use super::parse_length;
 
@@ -44,71 +44,138 @@ impl FromStr for Lrc {
                 continue;
             }
 
-            let (meta_or_time, line) = s
-                .trim()
-                .strip_prefix('[')
-                .and_then(|s| s.rsplit_once(']'))
-                .with_context(|| format!("Invalid lrc line format: '{s}'"))?;
+            let line_content = s.trim();
+            if !line_content.starts_with('[') {
+                continue;
+            }
 
-            match meta_or_time.chars().next() {
-                Some(c) if c.is_numeric() => {
-                    for meta_or_time in meta_or_time.split("][") {
-                        let (minutes, time_rest) =
-                            meta_or_time.split_once(':').with_context(|| {
-                                format!("Invalid lrc minutes format: '{meta_or_time}'")
-                            })?;
-                        let (seconds, fractions_of_second) = time_rest
-                            .split_once('.')
-                            .or_else(|| time_rest.split_once(':'))
-                            .with_context(|| {
-                                format!("Invalid lrc seconds and fractions of second format: '{time_rest}'")
-                            })
-                            // Truncation here is appropriate, since no display refreshes over 1000 times
-                            // per second, and even if it did, lyrics don't need that level of precision
-                            .map(|(seconds, frac)| (seconds, &frac[..3.min(frac.len())]))?;
+            let mut remaining = &line_content[1..];
+            let mut tags = Vec::new();
+            let mut found_non_tag = false;
+            let mut lyrics_start = 0;
+            let mut offset_in_line = 1; // we skip the initial '[', so we want to include the first character after it in the offset
+                                        
 
-                        let mut milis = 0;
-                        milis += minutes.parse::<u64>()? * 60 * 1000;
-                        milis += seconds.parse::<u64>()? * 1000;
-                        milis += fractions_of_second.parse::<u64>()?
-                            * (10u64.pow(
-                                3 - u32::try_from(fractions_of_second.len()).context(
-                                    "Length of u64 is always less than u32 (u64::MAX is 20 characters long)",
-                                )?,
-                            ));
-
-                        milis = match offset {
-                            Some(offset) if offset > 0 => {
-                                milis.saturating_sub(offset.unsigned_abs())
+            while !found_non_tag {
+                let mut bracket_count = 0;
+                let mut close_pos = None;
+                for (i, c) in remaining.char_indices() {
+                    match c {
+                        '[' => bracket_count += 1,
+                        ']' => {
+                            if bracket_count == 0 {
+                                close_pos = Some(i);
+                                break;
                             }
-                            Some(offset) if offset < 0 => {
-                                milis.saturating_add(offset.unsigned_abs())
-                            }
-                            _ => milis,
-                        };
-
-                        result.lines.push(LrcLine {
-                            time: Duration::from_millis(milis),
-                            content: line.trim().to_owned(),
-                        });
-                    }
-                }
-                Some(_) => {
-                    let (key, value) = meta_or_time
-                        .split_once(':')
-                        .with_context(|| format!("Invalid metadata line: '{meta_or_time}'"))?;
-                    match key.trim() {
-                        "offset" => offset = Some(value.trim().parse()?),
-                        "ti" => result.title = Some(value.trim().to_owned()),
-                        "ar" => result.artist = Some(value.trim().to_owned()),
-                        "al" => result.album = Some(value.trim().to_owned()),
-                        "au" => result.author = Some(value.trim().to_owned()),
-                        "length" => result.length = Some(parse_length(value.trim())?),
+                            bracket_count -= 1;
+                        }
                         _ => {}
                     }
                 }
-                None => {
-                    bail!("Invalid lrc metadata/timestamp: '{meta_or_time}'");
+                let Some(close_pos) = close_pos else {
+                    break; // No closing bracket found
+                };
+                let tag_content = &remaining[..close_pos];
+                let is_timestamp = tag_content.chars().next().is_some_and(|c| c.is_numeric())
+                    && tag_content.contains(':');
+                let is_metadata = !is_timestamp && tag_content.contains(':');
+                if is_timestamp || is_metadata {
+                    tags.push(tag_content);
+                    offset_in_line += close_pos + 1;
+                    remaining = &remaining[close_pos + 1..]; // Skip past the ']'
+                    if remaining.starts_with('[') {
+                        remaining = &remaining[1..];
+                        offset_in_line += 1;
+                    } else {
+                        break;
+                    }
+                } else {
+                    // not a valid tag, treat the rest as lyrics text
+                    found_non_tag = true;
+                    lyrics_start = offset_in_line - 1; // include the '['
+                }
+            }
+
+            let lyrics_text = if found_non_tag {
+                &line_content[lyrics_start..]
+            } else {
+                remaining.trim()
+            };
+
+            if tags.is_empty() {
+                continue;
+            }
+
+            for tag_content in tags {
+                match tag_content.chars().next() {
+                    Some(c) if c.is_numeric() => {
+                        // timestamps errors should be handle errors gracefully
+                        // we want to skip invalid timestamps instead of crashing because of a single wrong line for a better user experience
+                        if let Some((minutes, time_rest)) = tag_content.split_once(':') {
+                            if let Some((seconds, fractions_of_second)) = time_rest
+                                .split_once('.')
+                                .or_else(|| time_rest.split_once(':'))
+                            {
+                                // fractions of second can be up to 3 digits, truncate if longer
+                                let fractions_of_second = &fractions_of_second[..3.min(fractions_of_second.len())];
+                                
+                                // try to parse all components
+                                if let (Ok(minutes), Ok(seconds), Ok(fractions)) = (
+                                    minutes.parse::<u64>(),
+                                    seconds.parse::<u64>(),
+                                    fractions_of_second.parse::<u64>()
+                                ) {
+                                    let mut milis = 0;
+                                    milis += minutes * 60 * 1000;
+                                    milis += seconds * 1000;
+                                    milis += fractions * (10u64.pow(3 - u32::try_from(fractions_of_second.len()).unwrap_or(0)));
+
+                                    milis = match offset {
+                                        Some(offset) if offset > 0 => {
+                                            milis.saturating_sub(offset.unsigned_abs())
+                                        }
+                                        Some(offset) if offset < 0 => {
+                                            milis.saturating_add(offset.unsigned_abs())
+                                        }
+                                        _ => milis,
+                                    };
+
+                                    result.lines.push(LrcLine {
+                                        time: Duration::from_millis(milis),
+                                        content: lyrics_text.to_owned(),
+                                    });
+                                }
+                                // if parsing fails, skip this timestamp
+                            }
+                        }
+                    }
+                    Some(_) => {
+                        // parse metadata should also be handled errors gracefully
+                        if let Some((key, value)) = tag_content.split_once(':') {
+                            match key.trim() {
+                                "offset" => {
+                                    if let Ok(parsed_offset) = value.trim().parse::<i64>() {
+                                        offset = Some(parsed_offset);
+                                    }
+                                    // If parsing fails, ignore the offset
+                                }
+                                "ti" => result.title = Some(value.trim().to_owned()),
+                                "ar" => result.artist = Some(value.trim().to_owned()),
+                                "al" => result.album = Some(value.trim().to_owned()),
+                                "au" => result.author = Some(value.trim().to_owned()),
+                                "length" => {
+                                    if let Ok(parsed_length) = parse_length(value.trim()) {
+                                        result.length = Some(parsed_length);
+                                    }
+                                    // If parsing fails, ignore the length
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    None => {
+                        // Empty tag content, skip
+                    }
                 }
             }
         }
@@ -262,5 +329,387 @@ mod tests {
                 LrcLine { time: Duration::from_millis(30285), content: "line4".to_string() },
             ]
         });
+    }
+
+    #[test]
+    fn brackets_in_lyrics_text() {
+        let input = r"
+[ti: Song Name [Explicit]]
+[00:09.00]
+[00:10.00] [Drum Solo]
+[00:11.00]Some text [with brackets] in lyrics
+";
+
+        let result: Lrc = input.parse().unwrap();
+
+        assert_eq!(result, Lrc {
+            title: Some("Song Name [Explicit]".to_string()),
+            artist: None,
+            album: None,
+            author: None,
+            length: None,
+            lines: vec![
+                LrcLine { time: Duration::from_millis(9000), content: String::new() },
+                LrcLine { time: Duration::from_millis(10000), content: "[Drum Solo]".to_string() },
+                LrcLine { time: Duration::from_millis(11000), content: "Some text [with brackets] in lyrics".to_string() },
+            ]
+        });
+    }
+
+    #[test]
+    fn edge_case_empty_tags() {
+        let input = r"
+[ti:]
+[ar:]
+[al:]
+[00:10.00]lyrics after empty tags
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.title, Some(String::new()));
+        assert_eq!(result.artist, Some(String::new()));
+        assert_eq!(result.album, Some(String::new()));
+        assert_eq!(result.lines.len(), 1);
+    }
+
+    #[test]
+    fn edge_case_whitespace_handling() {
+        let input = r"
+[ti:  Title with spaces  ]
+[ar:	Artist with tabs	]
+[00:10.00]   lyrics with leading/trailing spaces   
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.title, Some("Title with spaces".to_string()));
+        assert_eq!(result.artist, Some("Artist with tabs".to_string()));
+        assert_eq!(result.lines[0].content, "lyrics with leading/trailing spaces");
+    }
+
+    #[test]
+    fn edge_case_mixed_timestamp_formats() {
+        let input = r"
+[00:01.5]single digit fraction
+[00:02.75]two digit fraction
+[00:03.123]three digit fraction
+[00:04.1234]four digit fraction (should truncate)
+[1:05.50]single digit minute
+[12:06.50]two digit minute
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 6);
+        assert_eq!(result.lines[0].time, Duration::from_millis(1500));
+        assert_eq!(result.lines[1].time, Duration::from_millis(2750));
+        assert_eq!(result.lines[2].time, Duration::from_millis(3123));
+        assert_eq!(result.lines[3].time, Duration::from_millis(4123)); // truncated
+        assert_eq!(result.lines[4].time, Duration::from_millis(65500));
+        assert_eq!(result.lines[5].time, Duration::from_millis(726_500));
+    }
+
+    #[test]
+    fn edge_case_colon_separator_in_timestamp() {
+        let input = r"
+[00:01:50]using colon instead of dot
+[00:02:123]colon with three digit fraction
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 2);
+        assert_eq!(result.lines[0].time, Duration::from_millis(1500));
+        assert_eq!(result.lines[1].time, Duration::from_millis(2123));
+    }
+
+    #[test]
+    fn edge_case_complex_brackets_in_lyrics() {
+        let input = r"
+[ti:Song [Feat. Artist] (Remix)]
+[00:10.00][Intro] Welcome to the [Show]
+[00:20.00]Lyrics with [multiple] [brackets] here
+[00:30.00]Even [nested [brackets] work] fine
+[00:40.00]And [some] text [with] [many] [brackets]
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.title, Some("Song [Feat. Artist] (Remix)".to_string()));
+        assert_eq!(result.lines[0].content, "[Intro] Welcome to the [Show]");
+        assert_eq!(result.lines[1].content, "Lyrics with [multiple] [brackets] here");
+        assert_eq!(result.lines[2].content, "Even [nested [brackets] work] fine");
+        assert_eq!(result.lines[3].content, "And [some] text [with] [many] [brackets]");
+    }
+
+    #[test]
+    fn edge_case_offset_variations() {
+        let input = r"
+[offset:+500]
+[00:01.00]offset positive no space
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines[0].time, Duration::from_millis(500));
+        
+        let input2 = r"
+[offset: -250]
+[00:01.00]offset negative with space
+";
+
+        let result2: Lrc = input2.parse().unwrap();
+        assert_eq!(result2.lines[0].time, Duration::from_millis(1250));
+    }
+
+    #[test]
+    fn edge_case_unknown_metadata_tags() {
+        let input = r"
+[ti:Title]
+[ar:Artist] 
+[custom:unknown tag]
+[version:1.0]
+[tool:rmpc]
+[00:10.00]lyrics
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.title, Some("Title".to_string()));
+        assert_eq!(result.artist, Some("Artist".to_string()));
+        assert_eq!(result.lines.len(), 1);
+        // Unknown tags should be ignored
+    }
+
+    #[test]
+    fn edge_case_multiple_consecutive_empty_lines() {
+        let input = r"
+[ti:Title]
+
+[00:10.00]first line
+
+[00:20.00]
+
+[00:30.00]third line
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 3);
+        assert_eq!(result.lines[0].content, "first line");
+        assert_eq!(result.lines[1].content, "");
+        assert_eq!(result.lines[2].content, "third line");
+    }
+
+    #[test]
+    fn edge_case_comments_and_invalid_lines() {
+        let input = r"
+# This is a comment
+[ti:Title]
+# Another comment
+[ar:Artist]
+invalid line without brackets
+[00:10.00]valid lyrics
+# End comment
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.title, Some("Title".to_string()));
+        assert_eq!(result.artist, Some("Artist".to_string()));
+        assert_eq!(result.lines.len(), 1);
+        assert_eq!(result.lines[0].content, "valid lyrics");
+    }
+
+    #[test]
+    fn edge_case_length_parsing_variations() {
+        let input = r"
+[length:3:45]
+[00:10.00]lyrics
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.length, Some(Duration::from_secs(225)));
+
+        let input2 = r"
+[length: 2:30 ]
+[00:10.00]lyrics
+";
+
+        let result2: Lrc = input2.parse().unwrap();
+        assert_eq!(result2.length, Some(Duration::from_secs(150)));
+    }
+
+    #[test]
+    fn edge_case_very_long_timestamps() {
+        let input = r"
+[99:59.99]very long timestamp
+[123:45.67]even longer
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 2);
+        assert_eq!(result.lines[0].time, Duration::from_millis(5_999_990));
+        assert_eq!(result.lines[1].time, Duration::from_millis(7_425_670));
+    }
+
+    #[test]
+    fn edge_case_zero_padding_timestamps() {
+        let input = r"
+[00:00.00]start
+[00:01.01]one second
+[01:00.00]one minute
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 3);
+        assert_eq!(result.lines[0].time, Duration::from_millis(0));
+        assert_eq!(result.lines[1].time, Duration::from_millis(1010));
+        assert_eq!(result.lines[2].time, Duration::from_millis(60000));
+    }
+
+    #[test]
+    fn edge_case_unicode_and_special_characters() {
+        let input = r"
+[ti:Café Münü 🎵]
+[ar:Artíst Namé]
+[00:10.00]Lyrics with émojis 🎶 and accénts
+[00:20.00]More unicode: 你好 世界
+[00:30.00]Special chars: @#$%^&*()
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.title, Some("Café Münü 🎵".to_string()));
+        assert_eq!(result.artist, Some("Artíst Namé".to_string()));
+        assert_eq!(result.lines[0].content, "Lyrics with émojis 🎶 and accénts");
+        assert_eq!(result.lines[1].content, "More unicode: 你好 世界");
+        assert_eq!(result.lines[2].content, "Special chars: @#$%^&*()");
+    }
+
+    #[test]
+    fn edge_case_malformed_brackets() {
+        let input = r"
+[ti:Title]
+[unclosed bracket
+[00:10.00]valid line
+]orphaned closing bracket
+[00:20.00]another valid line
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.title, Some("Title".to_string()));
+        assert_eq!(result.lines.len(), 2);
+        // Malformed lines should be ignored
+    }
+
+    #[test]
+    fn stress_test_many_consecutive_timestamps() {
+        let input = r"
+[00:01.00][00:02.00][00:03.00][00:04.00][00:05.00]repeated chorus
+[00:10.00][00:11.00][00:12.00]another repeated part
+";
+
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 8);
+        // First 5 lines should all have "repeated chorus"
+        for i in 0..5 {
+            assert_eq!(result.lines[i].content, "repeated chorus");
+        }
+        // Next 3 lines should have "another repeated part"
+        for i in 5..8 {
+            assert_eq!(result.lines[i].content, "another repeated part");
+        }
+    }
+
+    #[test]
+    fn error_handling_invalid_timestamp_format() {
+        let input = r"
+[invalid:timestamp]lyrics
+";
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 0); // Invalid timestamp should be ignored
+    }
+
+    #[test]
+    fn error_handling_invalid_minutes() {
+        let input = r"
+[ti:Title]
+[abc:30.00]invalid minutes
+[00:10.00]valid line
+";
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 1); // Only valid line should be parsed
+    }
+
+    #[test]
+    fn error_handling_invalid_seconds() {
+        let input = r"
+[ti:Title]
+[00:abc.00]invalid seconds
+[00:10.00]valid line
+";
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 1); // Only valid line should be parsed
+    }
+
+    #[test]
+    fn error_handling_invalid_fraction() {
+        let input = r"
+[ti:Title]
+[00:30.abc]invalid fraction
+[00:10.00]valid line
+";
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 1); // Only valid line should be parsed
+    }
+
+    #[test]
+    fn error_handling_invalid_offset() {
+        let input = r"
+[offset:invalid]
+[00:10.00]should work with invalid offset ignored
+";
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 1);
+        assert_eq!(result.lines[0].time, Duration::from_millis(10000)); // No offset applied
+    }
+
+    #[test]
+    fn error_handling_invalid_length() {
+        let input = r"
+[length:invalid]
+[00:10.00]should work with invalid length ignored
+";
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 1);
+        assert_eq!(result.length, None); // Length should be None due to invalid format
+    }
+
+    #[test]
+    fn robustness_test_empty_file() {
+        let input = "";
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 0);
+        assert_eq!(result.title, None);
+        assert_eq!(result.artist, None);
+    }
+
+    #[test]
+    fn robustness_test_whitespace_only() {
+        let input = "   \n\t\n  \n";
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 0);
+    }
+
+    #[test]
+    fn robustness_test_comments_only() {
+        let input = r"
+# Comment 1
+# Comment 2
+# Comment 3
+";
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 0);
+    }
+
+    #[test]
+    fn boundary_test_minimum_valid_lrc() {
+        let input = r"[00:00.00]";
+        let result: Lrc = input.parse().unwrap();
+        assert_eq!(result.lines.len(), 1);
+        assert_eq!(result.lines[0].time, Duration::from_millis(0));
+        assert_eq!(result.lines[0].content, "");
     }
 }

--- a/src/shared/lrc/lyrics.rs
+++ b/src/shared/lrc/lyrics.rs
@@ -116,7 +116,7 @@ impl FromStr for Lrc {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut offset: Option<i64> = None;
-        
+
         let metadata = parse_metadata_only(s);
         let mut result = Self {
             lines: Vec::new(),
@@ -239,7 +239,8 @@ impl FromStr for Lrc {
                         }
                     }
                     Some(_) => {
-                        // offset should be parsed since its not part of the metadata initially parsed
+                        // offset should be parsed since its not part of the metadata initially
+                        // parsed
                         if let Some((key, value)) = tag_content.split_once(':') {
                             if key.trim() == "offset" {
                                 if let Ok(parsed_offset) = value.trim().parse::<i64>() {

--- a/src/shared/lrc/lyrics.rs
+++ b/src/shared/lrc/lyrics.rs
@@ -1,6 +1,6 @@
 use std::{str::FromStr, time::Duration};
 
-use anyhow::{Result};
+use anyhow::Result;
 
 use super::parse_length;
 
@@ -54,7 +54,6 @@ impl FromStr for Lrc {
             let mut found_non_tag = false;
             let mut lyrics_start = 0;
             let mut offset_in_line = 1; // we skip the initial '[', so we want to include the first character after it in the offset
-                                        
 
             while !found_non_tag {
                 let mut bracket_count = 0;
@@ -96,11 +95,8 @@ impl FromStr for Lrc {
                 }
             }
 
-            let lyrics_text = if found_non_tag {
-                &line_content[lyrics_start..]
-            } else {
-                remaining.trim()
-            };
+            let lyrics_text =
+                if found_non_tag { &line_content[lyrics_start..] } else { remaining.trim() };
 
             if tags.is_empty() {
                 continue;
@@ -110,25 +106,30 @@ impl FromStr for Lrc {
                 match tag_content.chars().next() {
                     Some(c) if c.is_numeric() => {
                         // timestamps errors should be handle errors gracefully
-                        // we want to skip invalid timestamps instead of crashing because of a single wrong line for a better user experience
+                        // we want to skip invalid timestamps instead of crashing because of a
+                        // single wrong line for a better user experience
                         if let Some((minutes, time_rest)) = tag_content.split_once(':') {
-                            if let Some((seconds, fractions_of_second)) = time_rest
-                                .split_once('.')
-                                .or_else(|| time_rest.split_once(':'))
+                            if let Some((seconds, fractions_of_second)) =
+                                time_rest.split_once('.').or_else(|| time_rest.split_once(':'))
                             {
                                 // fractions of second can be up to 3 digits, truncate if longer
-                                let fractions_of_second = &fractions_of_second[..3.min(fractions_of_second.len())];
-                                
+                                let fractions_of_second =
+                                    &fractions_of_second[..3.min(fractions_of_second.len())];
+
                                 // try to parse all components
                                 if let (Ok(minutes), Ok(seconds), Ok(fractions)) = (
                                     minutes.parse::<u64>(),
                                     seconds.parse::<u64>(),
-                                    fractions_of_second.parse::<u64>()
+                                    fractions_of_second.parse::<u64>(),
                                 ) {
                                     let mut milis = 0;
                                     milis += minutes * 60 * 1000;
                                     milis += seconds * 1000;
-                                    milis += fractions * (10u64.pow(3 - u32::try_from(fractions_of_second.len()).unwrap_or(0)));
+                                    milis += fractions
+                                        * (10u64.pow(
+                                            3 - u32::try_from(fractions_of_second.len())
+                                                .unwrap_or(0),
+                                        ));
 
                                     milis = match offset {
                                         Some(offset) if offset > 0 => {
@@ -351,7 +352,10 @@ mod tests {
             lines: vec![
                 LrcLine { time: Duration::from_millis(9000), content: String::new() },
                 LrcLine { time: Duration::from_millis(10000), content: "[Drum Solo]".to_string() },
-                LrcLine { time: Duration::from_millis(11000), content: "Some text [with brackets] in lyrics".to_string() },
+                LrcLine {
+                    time: Duration::from_millis(11000),
+                    content: "Some text [with brackets] in lyrics".to_string()
+                },
             ]
         });
     }
@@ -447,7 +451,7 @@ mod tests {
 
         let result: Lrc = input.parse().unwrap();
         assert_eq!(result.lines[0].time, Duration::from_millis(500));
-        
+
         let input2 = r"
 [offset: -250]
 [00:01.00]offset negative with space

--- a/src/shared/lrc/mod.rs
+++ b/src/shared/lrc/mod.rs
@@ -5,7 +5,7 @@ use std::{path::PathBuf, time::Duration};
 
 use anyhow::{Context, Result, bail};
 pub use index::{LrcIndex, LrcIndexEntry};
-pub use lyrics::Lrc;
+pub use lyrics::{Lrc, parse_metadata_only};
 
 fn parse_length(input: &str) -> anyhow::Result<Duration> {
     let (minutes, seconds) = input.split_once(':').context("Invalid lrc length format")?;


### PR DESCRIPTION
## Description

This PR introduces a significant change in how the LRC parser handles errors and bracketed text inside lyrics.

**Key changes:**

* I made the parser more forgiving by having it skip over malformed lines, invalid timestamps, or bad metadata instead of failing or crashing. Since real-world `.lrc` files can be messy or inconsistent, I believe it’s better to show partial lyrics than none at all for a better ux, plus how its mentioned in the issue itself.

* I also fixed how the parser handles brackets inside lyrics. Previously, bracketed text like `[Drum Solo]` was mistakenly treated as metadata tags, causing those parts to be lost or leading to parsing failures. Now, the parser correctly distinguishes between actual tags (timestamps and metadata) and brackets that are part of the lyrics, and skip over comments.

* For more info you can look at the tests to see how the parser should behave like.

Since this changes fundamental parsing behavior, I’m looking for feedback on whether this forgiving approach aligns with the expectations or if a stricter error policy would be better.

I haven’t updated the docs or changelog yet, as I wanted to agree on the overall approach before proceeding.

### Related issues

fixes #519

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
