### PR TITLE
Feat/album separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Support for youtube playlists
 - Added configurable kebyind for adding items to the Queue - `AddOptions`
 - Multiple marked items can now be moved inside playlists
+- New `song_table_album_separator` theme property
 
 ### Changed
 

--- a/docs/src/content/docs/next/configuration/theme.mdx
+++ b/docs/src/content/docs/next/configuration/theme.mdx
@@ -64,6 +64,13 @@ Configures how the Cava music visualizer is displayed. More info on the <a href=
 
 If set to false, the header of the song table is not displayed. Default is `true`.
 
+### song_table_album_separator
+
+<ConfigValue name="song_table_album_separator" type={["None", "Underline"]} />
+
+Visually separate albums in the queue. A song is considered as being in another album when `albumartist`
+or `album` are different from the previous song. Defaults to `None`.
+
 ### draw_borders
 
 <ConfigValue name="draw_borders" type="boolean" />

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -207,8 +207,8 @@ impl Default for UiConfigFile {
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum AlbumSeparator {
-    None,
     #[default]
+    None,
     Underline,
 }
 

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -65,6 +65,7 @@ pub struct UiConfig {
     pub scrollbar: Option<ScrollbarConfig>,
     pub show_song_table_header: bool,
     pub song_table_format: Vec<SongTableColumn>,
+    pub song_table_album_separator: AlbumSeparator,
     pub header: HeaderConfig,
     #[debug("{}", default_album_art.len())]
     pub default_album_art: &'static [u8],
@@ -106,6 +107,8 @@ pub struct UiConfigFile {
     pub(super) highlight_border_style: Option<StyleFile>,
     pub(super) show_song_table_header: bool,
     pub(super) song_table_format: QueueTableColumnsFile,
+    #[serde(default)]
+    pub(super) song_table_album_separator: AlbumSeparator,
     pub(super) header: HeaderConfigFile,
     pub(super) default_album_art_path: Option<String>,
     #[serde(default)]
@@ -180,6 +183,7 @@ impl Default for UiConfigFile {
                 playlist_style: None,
             },
             song_table_format: QueueTableColumnsFile::default(),
+            song_table_album_separator: AlbumSeparator::default(),
             browser_song_format: SongFormatFile::default(),
             format_tag_separator: " | ".to_owned(),
             multiple_tag_resolution_strategy: TagResolutionStrategy::default(),
@@ -199,6 +203,13 @@ impl Default for UiConfigFile {
             cava: CavaThemeFile::default(),
         }
     }
+}
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum AlbumSeparator {
+    None,
+    #[default]
+    Underline,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -377,6 +388,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
             scrollbar: value.scrollbar.map(|sc| sc.into_config(fallback_border_fg)).transpose()?,
             progress_bar: value.progress_bar.into_config()?,
             song_table_format: TryInto::<QueueTableColumns>::try_into(value.song_table_format)?.0,
+            song_table_album_separator: value.song_table_album_separator,
             header: value.header.try_into()?,
             column_widths: [
                 value.browser_column_widths[0],

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -1045,18 +1045,8 @@ struct QueueRow {
 impl QueueRow {
     fn into_row<'a>(self, cells: impl Iterator<Item = Line<'a>>) -> Row<'a> {
         let mut row = if let Some(style) = self.cell_style {
-            // if self.underlined {
-            //     Row::new(cells.map(|column| column.patch_style(style.underlined())))
-            // } else {
-            //     Row::new(cells.map(|column| column.patch_style(style)))
-            // }
             Row::new(cells.map(|column| column.patch_style(style)))
         } else {
-            // if self.underlined {
-            //     Row::new(cells.map(|column|
-            // column.patch_style(Style::default().underlined()))) } else {
-            //     Row::new(cells)
-            // }
             Row::new(cells)
         };
 

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -22,9 +22,11 @@ use crate::{
             actions::{AddKind, AutoplayKind},
         },
         tabs::PaneType,
-        theme::properties::{Property, SongProperty},
+        theme::{
+            AlbumSeparator,
+            properties::{Property, SongProperty},
+        },
     },
-    context::AppContext,
     core::command::{create_env, run_external},
     ctx::Ctx,
     mpd::{QueuePosition, commands::Song, mpd_client::MpdClient},
@@ -203,18 +205,17 @@ impl Pane for QueuePane {
                 continue;
             }
 
-                let is_current = ctx
-                    .find_current_song_in_queue()
-                    .map(|(_, song)| song.id)
-                    .is_some_and(|v| v == song.id);
+            let is_current = ctx
+                .find_current_song_in_queue()
+                .map(|(_, song)| song.id)
+                .is_some_and(|v| v == song.id);
 
             let is_marked = self.scrolling_state.get_marked().contains(&idx);
             let columns = (0..formats.len()).map(|i| {
                 let mut max_len: usize = widths[i].width.into();
-                // We have to subtract marker symbol length from max len in
-                // order to make space for the marker
-                // symbol in case we are in the first column of the table
-                // and the song is marked.
+                // We have to subtract marker symbol length from max len in order to make space
+                // for the marker symbol in case we are in the first column of the table and the
+                // song is marked.
                 if is_marked && i == 0 {
                     max_len = max_len.saturating_sub(marker_symbol_len);
                 }
@@ -252,8 +253,7 @@ impl Pane for QueuePane {
                 row.cell_style = Some(config.theme.highlighted_item_style);
             }
 
-            if matches!(context.config.theme.song_table_album_separator, AlbumSeparator::Underline)
-            {
+            if matches!(ctx.config.theme.song_table_album_separator, AlbumSeparator::Underline) {
                 let is_new_album = if let Some((_, next_song)) = table_iter.peek() {
                     next_song.metadata.get("album") != song.metadata.get("album")
                         || next_song.metadata.get("album_artist")


### PR DESCRIPTION
## Description

Enum is used for the configuration instead of a boolean to keep options open for different kinds of separators in the future.

### Related issues

https://github.com/mierak/rmpc/issues/502

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
