### PR TITLE
feat/switch-tab-command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added `rmpc remote keybind` command to emulate key presses in running instances
+- Added `rmpc remote switch-tab` command to switch tabs directly without relying on keybinds
 - Added new `Volume` pane with mouse control support.
 - Added `Transform` properties and `Truncate` transformation
 - Added `sendmessage` cli command for inter client communication

--- a/docs/src/content/docs/next/guides/remote-commands.mdx
+++ b/docs/src/content/docs/next/guides/remote-commands.mdx
@@ -15,7 +15,9 @@ rmpc provides powerful remote command capabilities that allow you to control a r
 
 the remote command system allows you to:
 - **emulate key presses** (`keybind`) - trigger any keybind as if pressed in the interface
+- **switch tabs directly** (`switch-tab`) - change to a specific tab without relying on keybinds
 - **send status messages** - display custom messages in the status bar
+- **update configuration** - modify theme and other settings remotely
 - **target specific instances** - send commands to a particular rmpc process by pid
 
 ## usage
@@ -108,6 +110,45 @@ rmpc remote keybind "<S-CR>"   # Shift+Enter
 rmpc remote keybind "<A-h>"    # Alt+h
 ```
 
+## switch-tab command
+
+The `switch-tab` command provides a direct way to switch between tabs without relying on keybind configuration.
+
+### Syntax
+
+```bash
+rmpc remote switch-tab <tab-name>
+```
+
+### Examples
+
+```bash
+# Switch to specific tabs
+rmpc remote switch-tab "Queue"
+rmpc remote switch-tab "Directories"
+rmpc remote switch-tab "Artists"
+rmpc remote switch-tab "Albums"
+rmpc remote switch-tab "Playlists"
+rmpc remote switch-tab "Search"
+rmpc remote switch-tab "Lyrics"
+
+# Works with custom tab names too
+rmpc remote switch-tab "My Custom Tab"
+
+# Tab names are case-insensitive
+rmpc remote switch-tab "queue"     # same as "Queue"
+rmpc remote switch-tab "ARTISTS"   # same as "Artists"
+rmpc remote switch-tab "playlists" # same as "Playlists"
+```
+
+### Tab Name Validation
+
+The `switch-tab` command validates that the specified tab exists in your configuration using **case-insensitive matching**. This means you can use any capitalization you prefer - `queue`, `Queue`, `QUEUE`, etc. will all match the same tab.
+
+If you try to switch to a non-existent tab, the command will fail with an error message listing all available tabs.
+
+You can check your available tabs by looking at your configuration file or using `rmpc config` to see the configured tabs.
+
 ## Other Remote Commands
 
 Besides `keybind`, rmpc supports several other remote commands:
@@ -158,6 +199,7 @@ ps aux | grep rmpc
 
 # Send command to specific instance
 rmpc remote --pid 12345 keybind p
+rmpc remote --pid 12345 switch-tab "Queue"
 rmpc remote --pid 12345 status "Hello from specific instance"
 ```
 
@@ -167,9 +209,14 @@ Remote commands will fail silently if:
 - No rmpc instance is running
 - The specified PID doesn't exist
 - Invalid key format is provided
-- Tab name doesn't exist in your configuration (for tab switching keybinds)
+- Tab name doesn't exist in your configuration (for switch-tab commands)
 
-Check the rmpc logs for detailed error messages if commands aren't working as expected.
+**Note**: Command execution errors (like invalid tab names) are logged in the running rmpc instance at the warn level, not displayed to the CLI caller. Check the rmpc logs for detailed error messages if commands aren't working as expected.
+
+To see these errors, you can:
+- Run rmpc with debug logging: `RUST_LOG=debug rmpc`
+- Check rmpc's log output in your terminal
+- Look for "Socket command execution failed" messages
 
 ## Tips and Best Practices
 

--- a/docs/src/content/docs/next/overview.mdx
+++ b/docs/src/content/docs/next/overview.mdx
@@ -61,6 +61,10 @@ Rmpc also supports **remote commands** that allow you to control running instanc
 # Emulate pressing the play/pause key
 rmpc remote keybind p
 
+# Switch to Queue tab directly (case-insensitive)
+rmpc remote switch-tab "Queue"
+rmpc remote switch-tab "queue"    # same as above
+
 # Switch to Queue tab (number 1 key)
 rmpc remote keybind 1
 

--- a/docs/src/content/docs/next/reference/cli-command-mode.mdx
+++ b/docs/src/content/docs/next/reference/cli-command-mode.mdx
@@ -107,6 +107,9 @@ Options:
 # Emulate pressing 'p' (play/pause)
 rmpc remote keybind p
 
+# Switch to the Queue tab directly
+rmpc remote switch-tab "Queue"
+
 # Switch to the Queue tab (using number key)
 rmpc remote keybind 1
 

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -300,6 +300,9 @@ pub enum RemoteCmd {
     },
     /// Emulate a keybind press in the running rmpc instance
     Keybind { key: String },
+    /// Switch to a specific tab by name
+    #[clap(name = "switch-tab")]
+    SwitchTab { tab: String },
 }
 
 #[derive(Subcommand, Clone, Debug, PartialEq)]

--- a/src/shared/ipc/commands/mod.rs
+++ b/src/shared/ipc/commands/mod.rs
@@ -5,6 +5,7 @@ use index_lrc::IndexLrcCommand;
 use keybind::KeybindCommand;
 use set::SetIpcCommand;
 use status_message::StatusMessageCommand;
+use switch_tab::SwitchTabCommand;
 use tmux::TmuxHookCommand;
 
 use super::SocketCommand;
@@ -17,6 +18,7 @@ pub(super) mod index_lrc;
 pub mod keybind;
 pub(super) mod set;
 pub(super) mod status_message;
+pub mod switch_tab;
 pub(super) mod tmux;
 
 impl TryFrom<RemoteCmd> for SocketCommand {
@@ -65,6 +67,7 @@ impl TryFrom<RemoteCmd> for SocketCommand {
                 Ok(SocketCommand::Set(Box::new(SetIpcCommand::Theme(ron::de::from_reader(read)?))))
             }
             RemoteCmd::Keybind { key } => Ok(SocketCommand::Keybind(KeybindCommand { key })),
+            RemoteCmd::SwitchTab { tab } => Ok(SocketCommand::SwitchTab(SwitchTabCommand { tab })),
         }
     }
 }

--- a/src/shared/ipc/commands/switch_tab.rs
+++ b/src/shared/ipc/commands/switch_tab.rs
@@ -29,14 +29,14 @@ impl SocketCommandExecute for SwitchTabCommand {
             .find(|name| name.as_str().eq_ignore_ascii_case(&self.tab))
             .cloned()
             .ok_or_else(|| {
-                let available = config.tabs.names.iter()
+                let available = config
+                    .tabs
+                    .names
+                    .iter()
                     .map(|name| name.as_str())
                     .collect::<Vec<_>>()
                     .join(", ");
-                anyhow::anyhow!(
-                    "Tab '{}' does not exist. Available tabs: {}", 
-                    self.tab, available
-                )
+                anyhow::anyhow!("Tab '{}' does not exist. Available tabs: {}", self.tab, available)
             })?;
 
         event_tx.send(AppEvent::UiEvent(UiAppEvent::ChangeTab(tab_name)))?;

--- a/src/shared/ipc/commands/switch_tab.rs
+++ b/src/shared/ipc/commands/switch_tab.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+use crossbeam::channel::Sender;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AppEvent,
+    WorkRequest,
+    config::Config,
+    shared::ipc::SocketCommandExecute,
+    ui::UiAppEvent,
+};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct SwitchTabCommand {
+    pub(crate) tab: String,
+}
+
+impl SocketCommandExecute for SwitchTabCommand {
+    fn execute(
+        self,
+        event_tx: &Sender<AppEvent>,
+        _work_tx: &Sender<WorkRequest>,
+        config: &Config,
+    ) -> Result<()> {
+        // tabs are case-insensitive matching
+        let target_tab_name = config
+            .tabs
+            .names
+            .iter()
+            .find(|name| name.to_lowercase() == self.tab.to_lowercase())
+            .cloned();
+
+        let tab_name = match target_tab_name {
+            Some(name) => name,
+            None => {
+                return Err(anyhow::anyhow!(
+                    "Tab '{}' does not exist in configuration. Available tabs: {}",
+                    self.tab,
+                    config
+                        .tabs
+                        .names
+                        .iter()
+                        .map(|name| name.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+        };
+
+        event_tx.send(AppEvent::UiEvent(UiAppEvent::ChangeTab(tab_name)))?;
+        Ok(())
+    }
+}

--- a/src/shared/ipc/mod.rs
+++ b/src/shared/ipc/mod.rs
@@ -14,6 +14,7 @@ use crate::{
         keybind::KeybindCommand,
         set::SetIpcCommand,
         status_message::StatusMessageCommand,
+        switch_tab::SwitchTabCommand,
         tmux::TmuxHookCommand,
     },
 };
@@ -63,6 +64,7 @@ pub(crate) enum SocketCommand {
     TmuxHook(TmuxHookCommand),
     Set(Box<SetIpcCommand>),
     Keybind(KeybindCommand),
+    SwitchTab(SwitchTabCommand),
 }
 
 impl SocketCommandExecute for SocketCommand {
@@ -78,6 +80,7 @@ impl SocketCommandExecute for SocketCommand {
             SocketCommand::TmuxHook(cmd) => cmd.execute(event_tx, work_tx, config),
             SocketCommand::Set(cmd) => cmd.execute(event_tx, work_tx, config),
             SocketCommand::Keybind(cmd) => cmd.execute(event_tx, work_tx, config),
+            SocketCommand::SwitchTab(cmd) => cmd.execute(event_tx, work_tx, config),
         }
     }
 }

--- a/src/tests/remote_ipc.rs
+++ b/src/tests/remote_ipc.rs
@@ -5,14 +5,25 @@ mod remote_ipc_tests {
 
     use crate::{
         AppEvent,
-        config::{Config, cli::RemoteCmd},
-        shared::ipc::{SocketCommand, SocketCommandExecute, commands::keybind::KeybindCommand},
+        config::{Config, ConfigFile, cli::RemoteCmd, tabs::TabName},
+        shared::ipc::{
+            SocketCommand,
+            SocketCommandExecute,
+            commands::{keybind::KeybindCommand, switch_tab::SwitchTabCommand},
+        },
+        ui::UiAppEvent,
     };
 
     #[test]
     fn test_keybind_command_creation() {
         let keybind_cmd = KeybindCommand { key: "p".to_string() };
         assert_eq!(keybind_cmd.key, "p");
+    }
+
+    #[test]
+    fn test_switch_tab_command_creation() {
+        let switch_tab_cmd = SwitchTabCommand { tab: "Queue".to_string() };
+        assert_eq!(switch_tab_cmd.tab, "Queue");
     }
 
     #[test]
@@ -38,6 +49,77 @@ mod remote_ipc_tests {
     }
 
     #[test]
+    fn test_switch_tab_command_execution() {
+        let (event_tx, event_rx) = channel::unbounded();
+        let (work_tx, _work_rx) = channel::unbounded();
+
+        let config_file = ConfigFile::default();
+        let config = config_file
+            .into_config(None, None, None, None, true)
+            .expect("Failed to create config from default config file");
+
+        let switch_tab_cmd = SwitchTabCommand { tab: "Queue".to_string() };
+
+        let result = switch_tab_cmd.execute(&event_tx, &work_tx, &config);
+        assert!(result.is_ok(), "SwitchTab command execution should succeed");
+
+        let received_event = event_rx.try_recv();
+        assert!(received_event.is_ok(), "Should have received an event");
+
+        match received_event.expect("Should have received an event") {
+            AppEvent::UiEvent(UiAppEvent::ChangeTab(tab_name)) => {
+                assert_eq!(tab_name, TabName::from("Queue".to_string()));
+            }
+            _ => panic!("Expected UiEvent::ChangeTab event"),
+        }
+    }
+
+    #[test]
+    fn test_switch_tab_case_insensitive() {
+        let (event_tx, event_rx) = channel::unbounded();
+        let (work_tx, _work_rx) = channel::unbounded();
+
+        let config_file = ConfigFile::default();
+        let config = config_file
+            .into_config(None, None, None, None, true)
+            .expect("Failed to create config from default config file");
+
+        let test_cases = vec!["queue", "QUEUE", "Queue", "QuEuE"];
+
+        for test_case in test_cases {
+            let switch_tab_cmd = SwitchTabCommand { tab: test_case.to_string() };
+            let result = switch_tab_cmd.execute(&event_tx, &work_tx, &config);
+            assert!(
+                result.is_ok(),
+                "Switch tab should work case-insensitively for '{test_case}'"
+            );
+
+            let received_event = event_rx.try_recv();
+            assert!(received_event.is_ok(), "Should have received an event for '{test_case}'");
+
+            match received_event.expect("Should have received an event") {
+                AppEvent::UiEvent(UiAppEvent::ChangeTab(tab_name)) => {
+                    // this should always resolve to the correct case "Queue"
+                    assert_eq!(tab_name, TabName::from("Queue".to_string()));
+                }
+                _ => panic!("Expected UiEvent::ChangeTab event for '{test_case}'"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_switch_tab_invalid_tab() {
+        let (event_tx, _event_rx) = channel::unbounded();
+        let (work_tx, _work_rx) = channel::unbounded();
+        let config = Config::default();
+
+        let switch_tab_cmd = SwitchTabCommand { tab: "NonExistentTab".to_string() };
+
+        let result = switch_tab_cmd.execute(&event_tx, &work_tx, &config);
+        assert!(result.is_err(), "Invalid tab name should fail");
+    }
+
+    #[test]
     fn test_invalid_keybind() {
         let (event_tx, _event_rx) = channel::unbounded();
         let (work_tx, _work_rx) = channel::unbounded();
@@ -60,6 +142,17 @@ mod remote_ipc_tests {
                 assert_eq!(cmd.key, "p");
             }
             _ => panic!("Expected Keybind socket command"),
+        }
+
+        let switch_tab_cmd = RemoteCmd::SwitchTab { tab: "Queue".to_string() };
+        let socket_cmd =
+            SocketCommand::try_from(switch_tab_cmd).expect("SwitchTab conversion should succeed");
+
+        match socket_cmd {
+            SocketCommand::SwitchTab(cmd) => {
+                assert_eq!(cmd.tab, "Queue");
+            }
+            _ => panic!("Expected SwitchTab socket command"),
         }
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -506,7 +506,10 @@ impl<'ui> Ui<'ui> {
                 self.on_event(UiEvent::ModalClosed, ctx)?;
                 ctx.render()?;
             }
-            UiAppEvent::ChangeTab(tab_name) => self.change_tab(tab_name, ctx)?,
+            UiAppEvent::ChangeTab(tab_name) => {
+                self.change_tab(tab_name, ctx)?;
+                ctx.render()?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Description

This PR is a follow up on the discussion in #533, it introduces the first new remote command which allows to switch tabs.

Examples:

```
# Switch to Queue tab
rmpc remote switch-tab Queue

# Case-insensitive matching works
rmpc remote switch-tab queue
rmpc remote switch-tab ARTISTS
rmpc remote switch-tab browser

# Invalid tab names are logged, not displayed to user
rmpc remote switch-tab InvalidTab  # Logs error internally, returns failure code
```

I made tab name matching case-insensitive to enhance the user experience, my thinking is that users should not type `Queue` as it would be cumbersome, or they might not remember the exact capitalization. 

For error handling, invalid tab names are logged internally internally rather than displaying to the user an error message, current implementation somehow seems like a "current fire-and-forget" socket communication design where commands are sent without waiting for execution results. 

I could've have "hacked" this by pre-validating tab names in the CLI using local config, but this would be inconsistent with other remote commands and can lead to race conditions if tab configuration changes between CLI validation and command execution. It seems to me like the proper solution would be to modify the socket protocol to support request-response communication, but that felt like a design decision that should be left to @mierak.

### Related issues

fixes #499

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
