### PR TITLE
feat: support kitty keyboard protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - New `Partition` status property to show rmpc's current partition
 - `PREV_SONG` and `PREV_ELAPSED` env variables in `on_song_change`
 - New `ContextMenu()` action
+- Support Kitty's keyboard protocol
 
 ### Changed
 

--- a/docs/src/content/docs/next/configuration/keybinds.mdx
+++ b/docs/src/content/docs/next/configuration/keybinds.mdx
@@ -20,7 +20,14 @@ Keybinds are configured in the config file. There are different keybinds for dif
 optional and do not have be specified in the config file. If omitted the default keybinds below are used. By default the
 keybinds are vim-like, but you can change them to whatever you want.
 
-**Note**: All configured keybinds can also be triggered remotely using the `rmpc remote keybind` command.
+Rmpc supports kitty's keyboard protocol, meaning you can use advanced key combinations like mixing
+modifier keys such as control and shift in one keybind. You must be running supported terminal.
+This does not work in tmux. See [kitty's site](https://sw.kovidgoyal.net/kitty/keyboard-protocol/)
+for more info.
+
+:::note
+All configured keybinds can also be triggered remotely using the `rmpc remote keybind` command.
+:::
 
 ## keybinds_map
 

--- a/src/config/keys/key.rs
+++ b/src/config/keys/key.rs
@@ -176,7 +176,11 @@ impl FromStr for Key {
                     modifiers |= KeyModifiers::SHIFT;
                 }
 
-                KeyCode::Char(key_part[0])
+                KeyCode::Char(if modifiers.contains(KeyModifiers::SHIFT) {
+                    key_part[0].to_ascii_uppercase()
+                } else {
+                    key_part[0]
+                })
             }
         };
 

--- a/src/config/keys/mod.rs
+++ b/src/config/keys/mod.rs
@@ -22,7 +22,7 @@ use actions::{
     PlaylistsActionsFile,
     QueueActionsFile,
 };
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyModifiers};
 pub use key::Key;
 use serde::{Deserialize, Serialize};
 
@@ -169,12 +169,6 @@ impl From<KeyConfigFile> for KeyConfig {
             logs: value.logs.into_iter().map(|(k, v)| (k, v.into())).collect(),
             queue: value.queue.into_iter().map(|(k, v)| (k, v.into())).collect(),
         }
-    }
-}
-
-impl From<KeyEvent> for Key {
-    fn from(value: KeyEvent) -> Self {
-        Self { key: value.code, modifiers: value.modifiers }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,7 +292,6 @@ fn main() -> Result<()> {
                 event_tx.clone(),
                 Arc::clone(&ctx.config),
             )?;
-            core::input::init(event_tx.clone())?;
             let _sock_guard =
                 core::socket::init(event_tx.clone(), worker_tx.clone(), Arc::clone(&ctx.config))
                     .context("Failed to initialize socket listener")?;
@@ -309,6 +308,7 @@ fn main() -> Result<()> {
             let enable_mouse = ctx.config.enable_mouse;
             let terminal =
                 shared::terminal::setup(enable_mouse).context("Failed to setup terminal")?;
+            core::input::init(event_tx.clone())?;
 
             let event_loop_handle = core::event_loop::init(ctx, event_rx, terminal)?;
 

--- a/src/shared/key_event.rs
+++ b/src/shared/key_event.rs
@@ -1,9 +1,9 @@
-use crossterm::event::{KeyCode, KeyEvent as CKeyEvent};
+use crossterm::event::{KeyCode, KeyEvent as CKeyEvent, KeyModifiers};
 
 #[cfg(debug_assertions)]
 use crate::config::keys::LogsActions;
 use crate::{
-    config::keys::{CommonAction, GlobalAction, QueueActions},
+    config::keys::{CommonAction, GlobalAction, Key, QueueActions},
     ctx::Ctx,
 };
 
@@ -16,6 +16,29 @@ pub struct KeyEvent {
 impl From<CKeyEvent> for KeyEvent {
     fn from(value: CKeyEvent) -> Self {
         Self { inner: value, already_handled: false }
+    }
+}
+
+impl From<CKeyEvent> for Key {
+    fn from(value: CKeyEvent) -> Self {
+        let should_insert_shift = matches!(value.code, KeyCode::Char(c) if c.is_uppercase());
+
+        let mut modifiers = value.modifiers;
+        if should_insert_shift {
+            modifiers.insert(KeyModifiers::SHIFT);
+        }
+
+        let key = if modifiers.contains(KeyModifiers::SHIFT) {
+            if let KeyCode::Char(c) = value.code {
+                KeyCode::Char(c.to_ascii_uppercase())
+            } else {
+                value.code
+            }
+        } else {
+            value.code
+        };
+
+        Self { key, modifiers }
     }
 }
 

--- a/src/shared/terminal.rs
+++ b/src/shared/terminal.rs
@@ -25,7 +25,7 @@ use ratatui::{
     prelude::{Backend, CrosstermBackend},
 };
 
-use crate::shared::tmux::{IS_TMUX, tmux_write};
+use crate::shared::tmux::IS_TMUX;
 
 #[allow(dead_code)]
 pub struct Terminal {

--- a/src/shared/terminal.rs
+++ b/src/shared/terminal.rs
@@ -1,11 +1,20 @@
 use std::{
     io::{BufWriter, Read, Stdout, Write},
-    sync::{Arc, LazyLock},
+    sync::{
+        Arc,
+        LazyLock,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use anyhow::Result;
 use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture},
+    event::{
+        DisableMouseCapture,
+        EnableMouseCapture,
+        KeyboardEnhancementFlags,
+        PushKeyboardEnhancementFlags,
+    },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -15,6 +24,8 @@ use ratatui::{
     layout::Position,
     prelude::{Backend, CrosstermBackend},
 };
+
+use crate::shared::tmux::{IS_TMUX, tmux_write};
 
 #[allow(dead_code)]
 pub struct Terminal {
@@ -136,26 +147,96 @@ impl Backend for CrosstermLockingBackend {
     }
 }
 
+static KITTY_KEYBOARD_PROTO_SUPPORTED: AtomicBool = AtomicBool::new(false);
+
 pub fn restore<B: Backend + std::io::Write>(
     terminal: &mut ratatui::Terminal<B>,
     enable_mouse: bool,
 ) -> Result<()> {
+    let mut writer = TERMINAL.writer();
     if enable_mouse {
-        execute!(std::io::stdout(), DisableMouseCapture)?;
+        execute!(writer, DisableMouseCapture)?;
+    }
+    if KITTY_KEYBOARD_PROTO_SUPPORTED.load(Ordering::Relaxed) {
+        execute!(
+            writer,
+            PushKeyboardEnhancementFlags(
+                KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                    | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS,
+            )
+        )?;
     }
     disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    execute!(writer, LeaveAlternateScreen)?;
     Ok(terminal.show_cursor()?)
 }
 
 pub fn setup(enable_mouse: bool) -> Result<ratatui::Terminal<CrosstermLockingBackend>> {
+    let is_kitty_keyboard_proto_supported =
+        if *IS_TMUX { false } else { query_device_attrs("\x1b[?u")?.contains("\x1b[?0u") };
+
+    KITTY_KEYBOARD_PROTO_SUPPORTED.store(is_kitty_keyboard_proto_supported, Ordering::Relaxed);
+    log::debug!(is_kitty_keyboard_proto_supported:?; "Kitty keyboard protocol support");
+
     enable_raw_mode()?;
     let mut writer = TERMINAL.writer();
     execute!(writer, EnterAlternateScreen)?;
     if enable_mouse {
         execute!(writer, EnableMouseCapture)?;
     }
+    if is_kitty_keyboard_proto_supported {
+        execute!(
+            writer,
+            PushKeyboardEnhancementFlags(
+                KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                    | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS,
+            )
+        )?;
+    }
     let mut terminal = ratatui::Terminal::new(CrosstermLockingBackend::new(writer))?;
     terminal.clear()?;
     Ok(terminal)
+}
+
+pub fn query_device_attrs(query: &str) -> Result<String> {
+    let query = if *IS_TMUX {
+        format!("\x1bPtmux;{}\x1b\x1b[0c\x1b\\", query.replace('\x1b', "\x1b\x1b"))
+    } else {
+        format!("{query}\x1b[0c")
+    };
+
+    let stdin = rustix::stdio::stdin();
+    let termios_orig = rustix::termios::tcgetattr(stdin)?;
+    let mut termios = termios_orig.clone();
+
+    termios.local_modes &= !rustix::termios::LocalModes::ICANON;
+    termios.local_modes &= !rustix::termios::LocalModes::ECHO;
+    termios.special_codes[rustix::termios::SpecialCodeIndex::VTIME] = 1;
+    termios.special_codes[rustix::termios::SpecialCodeIndex::VMIN] = 0;
+
+    rustix::termios::tcsetattr(stdin, rustix::termios::OptionalActions::Drain, &termios)?;
+
+    rustix::io::write(rustix::stdio::stdout(), query.as_bytes())?;
+
+    let mut buf: String = String::new();
+    loop {
+        let mut charbuffer = [0; 1];
+        rustix::io::read(stdin, &mut charbuffer)?;
+
+        buf.push(charbuffer[0].into());
+
+        if charbuffer[0] == b'c'
+            && buf.contains('\x1b')
+            && buf.rsplit('\x1b').next().is_some_and(|s| s.starts_with("[?"))
+            || charbuffer[0] == b'\0'
+        {
+            break;
+        }
+    }
+
+    rustix::termios::tcsetattr(stdin, rustix::termios::OptionalActions::Now, &termios_orig)?;
+
+    log::debug!(buf:?; "devattr response");
+
+    Ok(buf)
 }


### PR DESCRIPTION
## Description

Adds support for [kitty's keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/).
This allows for more keybind combinations in supported terminals, for example combining CTRL and SHIFT on one keybind.

Hopefully this does not break anything. Unfortunatelly no support in tmux, its blocked upstream.

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
