### PR TITLE
chore: rust 1.88, disable clippy cast lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "A beautiful and configurable TUI client for MPD"
 homepage = "https://mierak.github.io/rmpc/"
 repository = "https://github.com/mierak/rmpc"
 readme = "README.md"
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 exclude = ["/docs/**/*", "!/docs/src/content/docs/next/assets/example_theme.ron", "!/docs/src/content/docs/next/assets/example_config.ron"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -84,6 +84,10 @@ match_single_binding = "allow"
 struct_field_names = "allow"
 redundant_closure_for_method_calls = "allow"
 unwrap_used = "deny"
+cast_possible_truncation = "allow"
+cast_precision_loss = "allow"
+cast_lossless = "allow"
+cast_sign_loss = "allow"
 
 [lints.rust]
 unused_macros = "allow"

--- a/src/config/theme/cava.rs
+++ b/src/config/theme/cava.rs
@@ -1,9 +1,3 @@
-#![allow(
-    clippy::cast_possible_truncation,
-    clippy::cast_lossless,
-    clippy::cast_sign_loss,
-    clippy::cast_precision_loss
-)]
 use std::collections::HashMap;
 
 use anyhow::{Context, Result, ensure};

--- a/src/config/theme/queue_table.rs
+++ b/src/config/theme/queue_table.rs
@@ -31,7 +31,6 @@ pub enum PercentOrLength {
 }
 
 impl PercentOrLength {
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     pub fn into_constraint(self, parent_size: u16) -> Constraint {
         match self {
             PercentOrLength::Percent(val) => Constraint::Percentage(val),

--- a/src/shared/geometry.rs
+++ b/src/shared/geometry.rs
@@ -50,7 +50,6 @@ impl Geometry {
         Point { x: self.x, y: self.y }
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn take_chunk_horiz(&mut self, size_percent: Percent) -> Geometry {
         let size = ((u32::from(self.width) * 100) * u32::from(size_percent) / 10000) as u16;
 
@@ -60,7 +59,6 @@ impl Geometry {
         result
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn take_chunk_vert(&mut self, size_percent: Percent) -> Geometry {
         let size = ((u32::from(self.height) * 100) * u32::from(size_percent) / 10000) as u16;
 

--- a/src/shared/image.rs
+++ b/src/shared/image.rs
@@ -194,7 +194,6 @@ pub struct AlignedArea {
 /// provided by [`image_size`]. Constrains area by [`max_size_px`].
 /// Returns the input [`available_area`] and [`max_size_px`] if terminal's size
 /// cannot be determined properly. Also returns resulting area size in pixels.
-#[allow(clippy::cast_lossless, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 pub fn create_aligned_area(
     available_area: Rect,
     image_size: (u32, u32),

--- a/src/shared/mouse_event.rs
+++ b/src/shared/mouse_event.rs
@@ -144,11 +144,6 @@ pub fn calculate_scrollbar_index(
         content_len.saturating_sub(1)
     } else {
         let position_ratio = f64::from(clicked_y) / f64::from(scrollbar_height.saturating_sub(1));
-        #[allow(
-            clippy::cast_precision_loss,
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss
-        )]
         let target = (position_ratio * (content_len.saturating_sub(1)) as f64).round() as usize;
         target.min(content_len.saturating_sub(1))
     };

--- a/src/tests/fixtures/mpd_client.rs
+++ b/src/tests/fixtures/mpd_client.rs
@@ -108,7 +108,6 @@ impl TestMpdClient {
 }
 
 type MpdResult<T> = Result<T, MpdError>;
-#[allow(clippy::cast_possible_truncation)]
 impl MpdClient for TestMpdClient {
     fn version(&mut self) -> crate::mpd::version::Version {
         todo!("Not yet implemented")

--- a/src/ui/image/block.rs
+++ b/src/ui/image/block.rs
@@ -123,7 +123,6 @@ impl Block {
 const UPPER_HALF_BLOCK: &str = "\u{2580}";
 const LOWER_HALF_BLOCK: &str = "\u{2584}";
 
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn display(
     w: &mut impl Write,
     img: &DynamicImage,

--- a/src/ui/image/ueberzug.rs
+++ b/src/ui/image/ueberzug.rs
@@ -199,7 +199,6 @@ impl UeberzugDaemon {
         socket.remove_image(pid)
     }
 
-    #[allow(clippy::cast_sign_loss)]
     fn is_daemon_running(pid: Pid) -> bool {
         let mut system = System::new();
         let infopid = sysinfo::Pid::from_u32(pid.0 as u32);

--- a/src/ui/modals/decoders.rs
+++ b/src/ui/modals/decoders.rs
@@ -54,7 +54,6 @@ impl DecodersModal {
         result
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn row<'a>(
         name: &'a str,
         name_width: u16,

--- a/src/ui/modals/info_list_modal.rs
+++ b/src/ui/modals/info_list_modal.rs
@@ -67,7 +67,6 @@ impl InfoListModal {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     fn row<'a>(
         key: &'a str,
         key_width: u16,

--- a/src/ui/modals/keybinds.rs
+++ b/src/ui/modals/keybinds.rs
@@ -146,7 +146,6 @@ fn row_header<'a>(
     }
 }
 
-#[allow(clippy::cast_possible_truncation)]
 fn row<'a>(
     keys: &'a [(String, String, Cow<'a, str>)],
     key_width: u16,

--- a/src/ui/modals/menu/list_section.rs
+++ b/src/ui/modals/menu/list_section.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::cast_possible_truncation)]
 use anyhow::Result;
 use ratatui::{
     buffer::Buffer,

--- a/src/ui/modals/menu/modal.rs
+++ b/src/ui/modals/menu/modal.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::cast_possible_truncation)]
-
 use std::borrow::Cow;
 
 use anyhow::Result;

--- a/src/ui/modals/menu/multi_action_section.rs
+++ b/src/ui/modals/menu/multi_action_section.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::cast_possible_truncation)]
 use anyhow::Result;
 use ratatui::{
     buffer::Buffer,

--- a/src/ui/panes/cava.rs
+++ b/src/ui/panes/cava.rs
@@ -82,7 +82,6 @@ impl CavaPane {
         Ok(())
     }
 
-    #[allow(clippy::cast_possible_truncation, clippy::cast_lossless)]
     #[inline]
     pub fn read_cava_data(
         height: u16,
@@ -106,7 +105,6 @@ impl CavaPane {
         Ok(())
     }
 
-    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     #[inline]
     pub fn render_cava(
         writer: &TtyWriter,

--- a/src/ui/panes/search.rs
+++ b/src/ui/panes/search.rs
@@ -975,11 +975,6 @@ mod tests {
         } else {
             let position_ratio =
                 f64::from(clicked_y) / f64::from(scrollbar_height.saturating_sub(1));
-            #[allow(
-                clippy::cast_possible_truncation,
-                clippy::cast_sign_loss,
-                clippy::cast_precision_loss
-            )]
             ((position_ratio * (total_items.saturating_sub(1)) as f64) as usize)
                 .min(total_items.saturating_sub(1))
         };
@@ -988,11 +983,6 @@ mod tests {
 
         let clicked_y = 0;
         let position_ratio = f64::from(clicked_y) / f64::from(scrollbar_height.saturating_sub(1));
-        #[allow(
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss,
-            clippy::cast_precision_loss
-        )]
         let target_idx = ((position_ratio * (total_items.saturating_sub(1)) as f64) as usize)
             .min(total_items.saturating_sub(1));
 
@@ -1000,11 +990,6 @@ mod tests {
 
         let clicked_y = 5;
         let position_ratio = f64::from(clicked_y) / f64::from(scrollbar_height.saturating_sub(1));
-        #[allow(
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss,
-            clippy::cast_precision_loss
-        )]
         let target_idx = ((position_ratio * (total_items.saturating_sub(1)) as f64) as usize)
             .min(total_items.saturating_sub(1));
 

--- a/src/ui/panes/volume.rs
+++ b/src/ui/panes/volume.rs
@@ -76,7 +76,6 @@ impl Pane for VolumePane {
                     f32::from(event.x.saturating_sub(self.area.x)) / f32::from(self.area.width);
 
                 // Safe conversion: clamped to 0-100 range and rounded, so cast is always valid
-                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                 let new_volume = (volume_ratio * 100.0).clamp(0.0, 100.0).round() as u32;
 
                 ctx.command(move |client| {

--- a/src/ui/widgets/mod.rs
+++ b/src/ui/widgets/mod.rs
@@ -1,9 +1,3 @@
-#![allow(
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
-    clippy::cast_lossless,
-    clippy::cast_sign_loss
-)]
 use ratatui::prelude::Alignment;
 
 pub mod browser;


### PR DESCRIPTION
## Description

### Related issues

### Checklist

- [ ] All tests passed
- [ ] Code has been formatted with nightly
- [ ] Code has been checked with clippy (stable)
- [ ] Documentation has been updated (if needed)
- [ ] Changelog has been updated
