### PR TITLE
docs: Add step for configuring Cava pane in layout

### DIFF
--- a/docs/src/content/docs/next/configuration/cava.mdx
+++ b/docs/src/content/docs/next/configuration/cava.mdx
@@ -64,6 +64,31 @@ After that you need to setup Cava, MPD and rmpc to talk to each other.
     ),
     ```
 
+3.  Configure the pane layout to include Cava. This goes in your `config.ron` under the tabs section. Below is
+    an example of how to add a Cava pane split alongside the queue and album art: 
+
+    ```rust
+    tabs: [
+        (
+            name: "Queue",
+            pane: Split(
+                direction: Horizontal,
+                panes: [
+                    (size: "40%", pane: Pane(AlbumArt)),
+                    (size: "60%", pane: Split(
+                        direction: Vertical,
+                        panes: [
+                            (size: "50%", pane: Pane(Queue)),
+                            (size: "50%", pane: Pane(Cava)),
+                        ],
+                    )),
+                ],
+            ),
+        ),
+    ],
+    ```
+    See <a href={path("configuration/tabs#panes")}>Panes documentation</a> for more information about configuring panes.
+
 </Steps>
 
 ## Theming


### PR DESCRIPTION
## Description

Just an extra step on the docs to show cava after configuring it on the pane layout

### Related issues

### Checklist

- [ ] All tests passed
- [ ] Code has been formatted with nightly
- [ ] Code has been checked with clippy (stable)
- [ ] Documentation has been updated (if needed)
- [ ] Changelog has been updated
