### PR TITLE
feat: ipc query command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - `PREV_SONG` and `PREV_ELAPSED` env variables in `on_song_change`
 - New `ContextMenu()` action
 - Support Kitty's keyboard protocol
+- Remote query command
 
 ### Changed
 
@@ -37,6 +38,8 @@ continue to work.
 - Scrolling behavior to be more natural - scrolling now actually scrolls the area instead of simply
 going to the next item
 - Scrollbars now represent the viewport position instead of the currently selected item position
+- Remote commands now check for `$PID` env variable, meaning `--pid` argument is no longer needed for
+remote commands inside scripts triggered by rmpc
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ base64 = "0.22.1"
 crossterm = { version = "0.28.1", features = ["serde"] }
 image = "0.25.6"
 ratatui = { version = "0.29.0", features = ["all-widgets"] }
-serde = { version = "1.0.219", features = ["derive"] }
 strum = { workspace = true }
 flate2 = { version = "1.1.2" }
 itertools = "0.14.0"
@@ -31,6 +30,7 @@ bitflags = { version = "2.9.1", features = ["serde"] }
 log = { version = "0.4.27", features = ["kv"] }
 flexi_logger = "0.31.1"
 chrono = { version = "0.4.41", features = ["serde"] }
+serde = { workspace = true }
 serde_with = "3.13.0"
 either = "1.15.0"
 walkdir = "2.5.0"
@@ -55,6 +55,7 @@ unicode-segmentation = "1.12.0"
 [build-dependencies]
 clap = { workspace = true }
 strum = { workspace = true }
+serde = { workspace = true }
 clap_complete = "4.5.54"
 clap_mangen = "0.2.27"
 vergen-gitcl = { version = "1.0.8", features = ["build"] }
@@ -67,6 +68,7 @@ test-case = "3.3.1"
 [workspace.dependencies]
 clap = { version = "4.5.40", features = ["derive", "cargo", "string" ] }
 strum = { version = "0.27.1", features = ["derive"] }
+serde = { version = "1.0.219", features = ["derive"] }
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/docs/src/content/docs/next/guides/remote-commands.mdx
+++ b/docs/src/content/docs/next/guides/remote-commands.mdx
@@ -230,9 +230,8 @@ rmpc remote --pid 12345 status "Hello from specific instance"
 
 Remote commands will fail silently if:
 
-- No rmpc instance is running
+- If no PID was specified and no rmpc instance is running
 - The specified PID doesn't exist
-- Invalid key format is provided
 - Tab name doesn't exist in your configuration (for switch-tab commands)
 
 **Note**: Command execution errors (like invalid tab names) are logged in the running rmpc instance at the warn level, not displayed to the CLI caller. Check the rmpc logs for detailed error messages if commands aren't working as expected.

--- a/docs/src/content/docs/next/guides/remote-commands.mdx
+++ b/docs/src/content/docs/next/guides/remote-commands.mdx
@@ -20,6 +20,7 @@ the remote command system allows you to:
 - **send status messages** - display custom messages in the status bar
 - **update configuration** - modify theme and other settings remotely
 - **target specific instances** - send commands to a particular rmpc process by pid
+- **query rmpc's state** - check which tab is currently active and more in the future
 
 ## usage
 
@@ -29,11 +30,12 @@ all remote commands follow this pattern:
 rmpc remote [--pid <pid>] <command> <args>
 ```
 
-if `--pid` is not specified, the command will be sent to all running rmpc instances.
+If `--pid` is not specified and `$PID` environment variable(usually set by rmpc in triggered scripts)
+is not found, the command will be sent to all running rmpc instances.
 
 ## keybind command
 
-the `keybind` command emulates pressing a key combination in the running rmpc interface.
+The `keybind` command emulates pressing a key combination in the running rmpc interface.
 
 ### syntax
 
@@ -149,6 +151,26 @@ The `switch-tab` command validates that the specified tab exists in your configu
 If you try to switch to a non-existent tab, the command will fail with an error message listing all available tabs.
 
 You can check your available tabs by looking at your configuration file or using `rmpc config` to see the configured tabs.
+
+## query command
+
+The `query` command gets information from a running rmpc instance and prints it as a result. You
+can specify more than one thing to query and the result will be concatenation of all the responses.
+
+Response is in a `key: value` format where key is the thing that was queried.
+
+### Queryable information
+
+#### active-tab
+
+Query rmpc's currently active tab name.
+
+```bash
+rmpc remote query active-tab
+
+# which responnds with
+active-tab: Queue
+```
 
 ## Other Remote Commands
 

--- a/docs/src/content/docs/next/reference/cli-command-mode.mdx
+++ b/docs/src/content/docs/next/reference/cli-command-mode.mdx
@@ -81,6 +81,7 @@ Options:
 ## Remote Commands
 
 The `remote` command allows you to control a running rmpc instance from external scripts or other terminal sessions. This is particularly useful for:
+
 - Window manager integration
 - Media key bindings
 - Automation scripts
@@ -92,13 +93,17 @@ The `remote` command allows you to control a running rmpc instance from external
 rmpc remote <COMMAND>
 
 Commands:
-  keybind   Emulate a keybind press in the running rmpc instance
-  status    Display a message in the status bar
-  set       Sets a value in running rmpc instance
-  indexlrc  Notify rmpc that a new lyrics file has been added
+  indexlrc    Notify rmpc that a new lyrics file has been added
+  status      Display a message in the status bar
+  set         Sets a value in running rmpc instance
+  keybind     Emulate a keybind press in the running rmpc instance
+  switch-tab  Switch to a specific tab by name
+  query       Query the currently active tab name
+  help        Print this message or the help of the given subcommand(s)
 
 Options:
-  --pid <PID>  Target a specific rmpc instance by process ID
+      --pid <PID>  PID of the rmpc instance to send the remote command to. If not provided, rmpc will try to notify all the running instances
+  -h, --help       Print help
 ```
 
 ### Examples

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -271,8 +271,9 @@ pub enum Command {
     },
 }
 
-#[derive(Subcommand, Clone, Debug, PartialEq)]
+#[derive(Subcommand, Clone, Debug, PartialEq, strum::EnumDiscriminants, strum::Display)]
 #[clap(rename_all = "lower")]
+#[strum(serialize_all = "lowercase")]
 pub enum RemoteCmd {
     /// Notify rmpc that a new lyrics file has been added
     IndexLrc {
@@ -304,7 +305,6 @@ pub enum RemoteCmd {
     /// Switch to a specific tab by name
     #[clap(name = "switch-tab")]
     SwitchTab { tab: String },
-
     /// Query the currently active tab name
     Query { targets: Vec<RemoteCommandQuery> },
 }

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -306,7 +306,10 @@ pub enum RemoteCmd {
     #[clap(name = "switch-tab")]
     SwitchTab { tab: String },
     /// Query the currently active tab name
-    Query { targets: Vec<RemoteCommandQuery> },
+    Query {
+        #[arg(required = true)]
+        targets: Vec<RemoteCommandQuery>,
+    },
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Serialize, Deserialize, strum::Display)]

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -313,7 +313,7 @@ pub enum RemoteCmd {
 #[strum(serialize_all = "kebab-case")]
 pub enum RemoteCommandQuery {
     /// Query the currently active tab name
-    Tab,
+    ActiveTab,
 }
 
 #[derive(Subcommand, Clone, Debug, PartialEq)]

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -5,6 +5,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueEnum, ValueHint};
+use serde::{Deserialize, Serialize};
 use strum::IntoStaticStr;
 
 use crate::mpd::QueuePosition;
@@ -303,6 +304,16 @@ pub enum RemoteCmd {
     /// Switch to a specific tab by name
     #[clap(name = "switch-tab")]
     SwitchTab { tab: String },
+
+    /// Query the currently active tab name
+    Query { targets: Vec<RemoteCommandQuery> },
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Serialize, Deserialize, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
+pub enum RemoteCommandQuery {
+    /// Query the currently active tab name
+    Tab,
 }
 
 #[derive(Subcommand, Clone, Debug, PartialEq)]

--- a/src/core/event_loop.rs
+++ b/src/core/event_loop.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashSet,
-    io::Write,
     ops::Sub,
     sync::{Arc, LazyLock},
     time::{Duration, Instant},
@@ -483,10 +482,10 @@ fn main_task<B: Backend + std::io::Write>(
                     for target in targets {
                         match target {
                             RemoteCommandQuery::Tab => {
-                                stream.write_all(ctx.active_tab.as_bytes()).unwrap();
+                                stream
+                                    .append_response_line(format!("{target}: {}", ctx.active_tab));
                             }
                         }
-                        stream.write_all(b"\n").unwrap();
                     }
                 }
                 AppEvent::Reconnected => {

--- a/src/core/event_loop.rs
+++ b/src/core/event_loop.rs
@@ -481,7 +481,7 @@ fn main_task<B: Backend + std::io::Write>(
                 AppEvent::IpcQuery { mut stream, targets } => {
                     for target in targets {
                         match target {
-                            RemoteCommandQuery::Tab => {
+                            RemoteCommandQuery::ActiveTab => {
                                 stream
                                     .append_response_line(format!("{target}: {}", ctx.active_tab));
                             }

--- a/src/core/socket.rs
+++ b/src/core/socket.rs
@@ -32,7 +32,7 @@ pub(crate) fn init(
     std::thread::spawn(move || {
         for stream in listener.incoming() {
             let stream = try_cont!(stream, "Failed to connect to socket client");
-            let mut reader = BufReader::new(stream);
+            let mut reader = BufReader::new(&stream);
 
             let mut buf = String::new();
             try_cont!(reader.read_line(&mut buf), "Failed to read from socket client");
@@ -41,7 +41,7 @@ pub(crate) fn init(
 
             log::debug!(command:?, addr:?; "Got command from unix socket");
             try_skip!(
-                command.execute(&event_tx, &work_tx, &config),
+                command.execute(&event_tx, &work_tx, stream.into(), &config),
                 "Socket command execution failed"
             );
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,14 +7,13 @@ use std::{
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use config::{DeserError, cli::RemoteCmd, cli_config::CliConfigFile};
+use config::{DeserError, cli_config::CliConfigFile};
 use crossbeam::channel::unbounded;
 use ctx::Ctx;
 use log::info;
 use rustix::path::Arg;
 use shared::{
     dependencies::CAVA,
-    ipc::{get_socket_path, list_all_socket_paths},
     macros::{status_warn, try_skip},
 };
 
@@ -158,27 +157,17 @@ fn main() -> Result<()> {
             );
         }
         Some(Command::Remote { command, pid }) => {
-            if matches!(command, RemoteCmd::Query { .. })
-                && pid.is_none()
-                && list_all_socket_paths()?.count() > 1
-            {
-                eprintln!("Remote query requires a PID to be specified.");
-                std::process::exit(1);
-            }
+            let pid = pid.or_else(|| {
+                std::env::var("PID")
+                    .context("Failed to read PID from environment variable 'PID'")
+                    .and_then(|p| {
+                        p.parse().context("Failed to parse PID from environment variable 'PID'")
+                    })
+                    .ok()
+            });
 
-            if let Some(pid) = pid {
-                let path = get_socket_path(pid);
-                command.write_to_socket(&path)?;
-                eprintln!("Successfully sent remote command to {}", path.display());
-            } else {
-                for path in list_all_socket_paths()? {
-                    if let Err(err) = command.clone().write_to_socket(&path) {
-                        eprintln!("Failed to send remote command. Error: '{err:?}'");
-                        continue;
-                    }
-                    eprintln!("Successfully sent remote command to {}", path.display());
-                }
-            }
+            let exit_code = command.handle(pid);
+            std::process::exit(exit_code.into());
         }
         Some(cmd) => {
             logging::init_console().expect("Logger to initialize");

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use config::{DeserError, cli_config::CliConfigFile};
+use config::{DeserError, cli::RemoteCmd, cli_config::CliConfigFile};
 use crossbeam::channel::unbounded;
 use ctx::Ctx;
 use log::info;
@@ -158,6 +158,14 @@ fn main() -> Result<()> {
             );
         }
         Some(Command::Remote { command, pid }) => {
+            if matches!(command, RemoteCmd::Query { .. })
+                && pid.is_none()
+                && list_all_socket_paths()?.count() > 1
+            {
+                eprintln!("Remote query requires a PID to be specified.");
+                std::process::exit(1);
+            }
+
             if let Some(pid) = pid {
                 let path = get_socket_path(pid);
                 command.write_to_socket(&path)?;

--- a/src/shared/events.rs
+++ b/src/shared/events.rs
@@ -5,12 +5,19 @@ use crossterm::event::KeyEvent;
 use serde::{Deserialize, Serialize};
 
 use super::{
+    ipc::ipc_stream::IpcStream,
     lrc::{LrcIndex, LrcIndexEntry},
     mouse_event::MouseEvent,
     mpd_query::{MpdCommand, MpdQuery, MpdQueryResult, MpdQuerySync},
 };
 use crate::{
-    config::{Config, Size, cli::Command, tabs::PaneType, theme::UiConfig},
+    config::{
+        Config,
+        Size,
+        cli::{Command, RemoteCommandQuery},
+        tabs::PaneType,
+        theme::UiConfig,
+    },
     mpd::commands::IdleEvent,
     ui::UiAppEvent,
 };
@@ -86,6 +93,10 @@ pub(crate) enum AppEvent {
     },
     RemoteSwitchTab {
         tab_name: String,
+    },
+    IpcQuery {
+        stream: IpcStream,
+        targets: Vec<RemoteCommandQuery>,
     },
 }
 

--- a/src/shared/exit_code.rs
+++ b/src/shared/exit_code.rs
@@ -1,0 +1,121 @@
+use std::ops::{Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct ExitCode(u8);
+
+impl BitOr for ExitCode {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        ExitCode(self.0 | rhs.0)
+    }
+}
+
+impl BitOrAssign for ExitCode {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl BitAnd for ExitCode {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        ExitCode(self.0 & rhs.0)
+    }
+}
+
+impl BitAndAssign for ExitCode {
+    fn bitand_assign(&mut self, rhs: Self) {
+        self.0 &= rhs.0;
+    }
+}
+
+impl Add for ExitCode {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        ExitCode(self.0 + rhs.0)
+    }
+}
+
+impl AddAssign for ExitCode {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
+
+impl From<u8> for ExitCode {
+    fn from(value: u8) -> Self {
+        ExitCode(value)
+    }
+}
+
+impl From<ExitCode> for i32 {
+    fn from(value: ExitCode) -> Self {
+        value.0 as i32
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rstest::rstest;
+
+    use super::ExitCode;
+
+    #[rstest]
+    #[case(0b0000_0001, 0b0000_0000, 0b0000_0000)]
+    #[case(0b0000_0001, 0b0000_0001, 0b0000_0001)]
+    #[case(0b0000_0010, 0b0000_0001, 0b0000_0000)]
+    #[case(0b0000_0010, 0b0000_0010, 0b0000_0010)]
+    fn bit_and(#[case] a: u8, #[case] b: u8, #[case] expected: u8) {
+        assert_eq!(ExitCode::from(a) & ExitCode::from(b), ExitCode::from(expected));
+    }
+
+    #[rstest]
+    #[case(0b0000_0001, 0b0000_0000, 0b0000_0000)]
+    #[case(0b0000_0001, 0b0000_0001, 0b0000_0001)]
+    #[case(0b0000_0010, 0b0000_0001, 0b0000_0000)]
+    #[case(0b0000_0010, 0b0000_0010, 0b0000_0010)]
+    fn bit_and_assign(#[case] a: u8, #[case] b: u8, #[case] expected: u8) {
+        let mut code_a = ExitCode::from(a);
+        code_a &= ExitCode::from(b);
+        assert_eq!(code_a, ExitCode::from(expected));
+    }
+
+    #[rstest]
+    #[case(0b0000_0001, 0b0000_0000, 0b0000_0001)]
+    #[case(0b0000_0001, 0b0000_0001, 0b0000_0001)]
+    #[case(0b0000_0010, 0b0000_0001, 0b0000_0011)]
+    #[case(0b0000_0010, 0b0000_0010, 0b0000_0010)]
+    fn bit_or(#[case] a: u8, #[case] b: u8, #[case] expected: u8) {
+        assert_eq!(ExitCode::from(a) | ExitCode::from(b), ExitCode::from(expected));
+    }
+
+    #[rstest]
+    #[case(0b0000_0001, 0b0000_0000, 0b0000_0001)]
+    #[case(0b0000_0001, 0b0000_0001, 0b0000_0001)]
+    #[case(0b0000_0010, 0b0000_0001, 0b0000_0011)]
+    #[case(0b0000_0010, 0b0000_0010, 0b0000_0010)]
+    fn bit_or_assign(#[case] a: u8, #[case] b: u8, #[case] expected: u8) {
+        let mut code_a = ExitCode::from(a);
+        code_a |= ExitCode::from(b);
+        assert_eq!(code_a, ExitCode::from(expected));
+    }
+
+    #[test]
+    fn add() {
+        use super::ExitCode;
+
+        let code1 = ExitCode::from(0);
+        let code2 = ExitCode::from(1);
+        let code3 = ExitCode::from(2);
+
+        assert_eq!(code1 + code1, ExitCode::from(0));
+        assert_eq!(code2 + code2, ExitCode::from(2));
+        assert_eq!(code3 + code3, ExitCode::from(4));
+        assert_eq!(code1 + code2, ExitCode::from(1));
+        assert_eq!(code1 + code3, ExitCode::from(2));
+        assert_eq!(code2 + code3, ExitCode::from(3));
+    }
+}

--- a/src/shared/ipc/commands/index_lrc.rs
+++ b/src/shared/ipc/commands/index_lrc.rs
@@ -4,7 +4,12 @@ use anyhow::Result;
 use crossbeam::channel::Sender;
 use serde::{Deserialize, Serialize};
 
-use crate::{AppEvent, WorkRequest, config::Config, shared::ipc::SocketCommandExecute};
+use crate::{
+    AppEvent,
+    WorkRequest,
+    config::Config,
+    shared::ipc::{IpcStream, SocketCommandExecute},
+};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct IndexLrcCommand {
@@ -16,6 +21,7 @@ impl SocketCommandExecute for IndexLrcCommand {
         self,
         _event_tx: &Sender<AppEvent>,
         work_tx: &Sender<WorkRequest>,
+        _stream: IpcStream,
         _config: &Config,
     ) -> Result<()> {
         work_tx.send(WorkRequest::IndexSingleLrc { path: self.path })?;

--- a/src/shared/ipc/commands/keybind.rs
+++ b/src/shared/ipc/commands/keybind.rs
@@ -7,7 +7,7 @@ use crate::{
     AppEvent,
     WorkRequest,
     config::{Config, keys::key::Key},
-    shared::ipc::SocketCommandExecute,
+    shared::ipc::{IpcStream, SocketCommandExecute},
 };
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -20,6 +20,7 @@ impl SocketCommandExecute for KeybindCommand {
         self,
         event_tx: &Sender<AppEvent>,
         _work_tx: &Sender<WorkRequest>,
+        _stream: IpcStream,
         _config: &Config,
     ) -> Result<()> {
         match self.key.parse::<Key>() {

--- a/src/shared/ipc/commands/keybind.rs
+++ b/src/shared/ipc/commands/keybind.rs
@@ -20,7 +20,7 @@ impl SocketCommandExecute for KeybindCommand {
         self,
         event_tx: &Sender<AppEvent>,
         _work_tx: &Sender<WorkRequest>,
-        _stream: IpcStream,
+        stream: IpcStream,
         _config: &Config,
     ) -> Result<()> {
         match self.key.parse::<Key>() {
@@ -29,8 +29,9 @@ impl SocketCommandExecute for KeybindCommand {
                 event_tx.send(AppEvent::UserKeyInput(crossterm_event))?;
             }
             Err(err) => {
-                log::error!("Failed to parse key '{}': {}", self.key, err);
-                return Err(anyhow::anyhow!("Failed to parse key '{}': {}", self.key, err));
+                let err = anyhow::anyhow!("Failed to parse key '{}': {}", self.key, err);
+                stream.error(err.to_string());
+                return Err(err);
             }
         }
         Ok(())

--- a/src/shared/ipc/commands/query_tab.rs
+++ b/src/shared/ipc/commands/query_tab.rs
@@ -5,24 +5,26 @@ use serde::{Deserialize, Serialize};
 use crate::{
     AppEvent,
     WorkRequest,
-    config::Config,
+    config::{Config, cli::RemoteCommandQuery},
     shared::ipc::{IpcStream, SocketCommandExecute},
 };
 
 #[derive(Debug, Deserialize, Serialize)]
-pub(crate) struct TmuxHookCommand {
-    pub(crate) hook: String,
+pub(crate) struct QueryCommand {
+    pub targets: Vec<RemoteCommandQuery>,
 }
 
-impl SocketCommandExecute for TmuxHookCommand {
+impl SocketCommandExecute for QueryCommand {
     fn execute(
         self,
         event_tx: &Sender<AppEvent>,
         _work_tx: &Sender<WorkRequest>,
-        _stream: IpcStream,
+        stream: IpcStream,
         _config: &Config,
     ) -> Result<()> {
-        event_tx.send(AppEvent::TmuxHook { hook: self.hook })?;
+        event_tx
+            .send(AppEvent::IpcQuery { stream, targets: self.targets })
+            .map_err(|err| anyhow::anyhow!("Failed to send QueryTab event: {}", err))?;
         Ok(())
     }
 }

--- a/src/shared/ipc/commands/set.rs
+++ b/src/shared/ipc/commands/set.rs
@@ -6,7 +6,7 @@ use crate::{
     AppEvent,
     WorkRequest,
     config::{Config, ConfigFile, theme::UiConfigFile},
-    shared::ipc::SocketCommandExecute,
+    shared::ipc::{IpcStream, SocketCommandExecute},
 };
 
 // Enum values only exist for the short time and are not constructed often, so
@@ -23,6 +23,7 @@ impl SocketCommandExecute for SetIpcCommand {
         self,
         event_tx: &Sender<AppEvent>,
         _work_tx: &Sender<WorkRequest>,
+        _stream: IpcStream,
         _config: &Config,
     ) -> Result<()> {
         match self {

--- a/src/shared/ipc/commands/status_message.rs
+++ b/src/shared/ipc/commands/status_message.rs
@@ -8,7 +8,10 @@ use crate::{
     AppEvent,
     WorkRequest,
     config::Config,
-    shared::{events::Level, ipc::SocketCommandExecute},
+    shared::{
+        events::Level,
+        ipc::{IpcStream, SocketCommandExecute},
+    },
 };
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -23,6 +26,7 @@ impl SocketCommandExecute for StatusMessageCommand {
         self,
         event_tx: &Sender<AppEvent>,
         _work_tx: &Sender<WorkRequest>,
+        _stream: IpcStream,
         _config: &Config,
     ) -> Result<()> {
         event_tx.send(AppEvent::Status(self.message, self.level, self.timeout))?;

--- a/src/shared/ipc/commands/switch_tab.rs
+++ b/src/shared/ipc/commands/switch_tab.rs
@@ -2,7 +2,12 @@ use anyhow::Result;
 use crossbeam::channel::Sender;
 use serde::{Deserialize, Serialize};
 
-use crate::{AppEvent, WorkRequest, config::Config, shared::ipc::SocketCommandExecute};
+use crate::{
+    AppEvent,
+    WorkRequest,
+    config::Config,
+    shared::ipc::{IpcStream, SocketCommandExecute},
+};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct SwitchTabCommand {
@@ -14,6 +19,7 @@ impl SocketCommandExecute for SwitchTabCommand {
         self,
         event_tx: &Sender<AppEvent>,
         _work_tx: &Sender<WorkRequest>,
+        _stream: IpcStream,
         _config: &Config,
     ) -> Result<()> {
         // Skipping validation here due to config hot reload, the config passed here

--- a/src/shared/ipc/in_flight_ipc.rs
+++ b/src/shared/ipc/in_flight_ipc.rs
@@ -152,9 +152,8 @@ mod test {
         let ipc_command = InFlightIpcCommand { stream };
 
         let response = ipc_command.read_response();
-        assert_eq!(
-            response.map_err(|err| err.to_string()),
-            Err("error: socket error, Resource temporarily unavailable (os error 11)".to_string())
-        );
+        assert!(response.map_err(|err| err.to_string()).is_err_and(|err| {
+            err.starts_with("error: socket error, Resource temporarily unavailable")
+        }));
     }
 }

--- a/src/shared/ipc/in_flight_ipc.rs
+++ b/src/shared/ipc/in_flight_ipc.rs
@@ -1,0 +1,160 @@
+use std::{
+    io::{BufRead, BufReader},
+    os::unix::net::UnixStream,
+};
+
+use thiserror::Error;
+
+use super::ipc_stream::{IPC_RESPONSE_ERROR, IPC_RESPONSE_SUCCESS};
+use crate::shared::string_util::StringExt;
+
+#[derive(Debug, Error)]
+pub(crate) enum IpcCommandError {
+    #[error("error: failed to serialize command, {0}")]
+    CommandSerialization(#[from] serde_json::Error),
+    #[error("error: failed to create command, {0}")]
+    CommandCreate(anyhow::Error),
+    #[error("error: socket error, {0}")]
+    SocketError(#[from] std::io::Error),
+    #[error("error: command failed, {0}")]
+    CommandFailure(String),
+}
+
+pub(crate) struct InFlightIpcCommand {
+    pub stream: UnixStream,
+}
+
+impl InFlightIpcCommand {
+    pub(crate) fn read_response(self) -> Result<Option<String>, IpcCommandError> {
+        let mut read = BufReader::new(&self.stream);
+        let mut buf = String::new();
+
+        read.read_line(&mut buf)?;
+        if buf.trim().starts_with(IPC_RESPONSE_ERROR) {
+            // trim "error: " from the start of the line end newline from the end
+            buf.drain(..IPC_RESPONSE_ERROR.len() + ": ".len());
+            buf.trim_end_in_place();
+            return Err(IpcCommandError::CommandFailure(buf));
+        }
+
+        if buf.trim() == IPC_RESPONSE_SUCCESS {
+            return Ok(None);
+        }
+
+        let mut line_buf = String::new();
+        loop {
+            line_buf.clear();
+            let bytes = read.read_line(&mut line_buf)?;
+
+            if bytes == 0 {
+                return Err(IpcCommandError::SocketError(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    format!("Unexpected end of IPC response, got '{}' so far", buf.trim()),
+                )));
+            }
+
+            if line_buf.trim() == IPC_RESPONSE_SUCCESS {
+                break;
+            }
+
+            buf.push_str(&line_buf);
+        }
+
+        buf.trim_end_in_place();
+        Ok(Some(buf))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod test {
+    use std::{io::Write, os::unix::net::UnixStream};
+
+    use crate::shared::ipc::in_flight_ipc::InFlightIpcCommand;
+
+    #[test]
+    fn reads_ok() {
+        let (stream, mut other) = UnixStream::pair().unwrap();
+        let ipc_command = InFlightIpcCommand { stream };
+
+        other.write_all(b"ok\n").unwrap();
+
+        let response = ipc_command.read_response();
+        assert_eq!(response.unwrap(), None);
+    }
+
+    #[test]
+    fn reads_response() {
+        let (stream, mut other) = UnixStream::pair().unwrap();
+        let ipc_command = InFlightIpcCommand { stream };
+
+        other.write_all(b"error: fluff you\n").unwrap();
+
+        let response = ipc_command.read_response();
+        assert_eq!(
+            response.map_err(|err| err.to_string()),
+            Err("error: command failed, fluff you".to_string())
+        );
+    }
+
+    #[test]
+    fn read_single_response() {
+        let (stream, mut other) = UnixStream::pair().unwrap();
+        let ipc_command = InFlightIpcCommand { stream };
+
+        other.write_all(b"first line response\n").unwrap();
+        other.write_all(b"ok\n").unwrap();
+
+        let response = ipc_command.read_response();
+        assert_eq!(response.unwrap(), Some("first line response".to_string()));
+    }
+
+    #[test]
+    fn read_multi_response() {
+        let (stream, mut other) = UnixStream::pair().unwrap();
+        let ipc_command = InFlightIpcCommand { stream };
+
+        other.write_all(b"first line response\n").unwrap();
+        other.write_all(b"second line response\n").unwrap();
+        other.write_all(b"third line response\n").unwrap();
+        other.write_all(b"ok\n").unwrap();
+
+        let response = ipc_command.read_response();
+        assert_eq!(
+            response.unwrap(),
+            Some("first line response\nsecond line response\nthird line response".to_string())
+        );
+    }
+
+    #[test]
+    fn read_multi_response_with_no_ok_ack() {
+        let (stream, mut other) = UnixStream::pair().unwrap();
+        let ipc_command = InFlightIpcCommand { stream };
+
+        other.write_all(b"first line response\n").unwrap();
+        other.write_all(b"second line response\n").unwrap();
+        other.write_all(b"third line response\n").unwrap();
+        other.shutdown(std::net::Shutdown::Both).unwrap();
+
+        let response = ipc_command.read_response();
+
+        assert_eq!(
+            response.map_err(|err| err.to_string()),
+            Err("error: socket error, Unexpected end of IPC response, got 'first line response\nsecond line response\nthird line response' so far"
+                .to_string())
+        );
+    }
+
+    #[test]
+    fn read_response_with_timeout() {
+        let (stream, _other) = UnixStream::pair().unwrap();
+        stream.set_read_timeout(Some(std::time::Duration::from_millis(10))).unwrap();
+        let ipc_command = InFlightIpcCommand { stream };
+
+        let response = ipc_command.read_response();
+        assert_eq!(
+            response.map_err(|err| err.to_string()),
+            Err("error: socket error, Resource temporarily unavailable (os error 11)".to_string())
+        );
+    }
+}

--- a/src/shared/ipc/ipc_stream.rs
+++ b/src/shared/ipc/ipc_stream.rs
@@ -1,0 +1,51 @@
+use std::{
+    io::{Read, Write},
+    os::unix::net::UnixStream,
+    time::Duration,
+};
+
+pub const IPC_RESPONSE_FINISH: &str = "ok";
+
+#[derive(Debug)]
+pub(crate) struct IpcStream(UnixStream);
+
+impl From<UnixStream> for IpcStream {
+    fn from(stream: UnixStream) -> Self {
+        IpcStream(stream)
+    }
+}
+
+impl Write for IpcStream {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.flush()
+    }
+}
+
+impl Read for IpcStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl Drop for IpcStream {
+    fn drop(&mut self) {
+        if let Err(err) = self.0.set_write_timeout(Some(Duration::from_secs(1))) {
+            log::error!(err:?; "Failed to set write timeout on IPC stream");
+            return;
+        }
+
+        if let Err(err) = self.0.write_all(IPC_RESPONSE_FINISH.as_bytes()) {
+            log::error!(err:?; "Failed to write response finisher to IPC stream on drop");
+            return;
+        }
+
+        if let Err(err) = self.0.write_all(b"\n") {
+            log::error!(err:?; "Failed to write newline to IPC stream on drop");
+            return;
+        }
+    }
+}

--- a/src/shared/ipc/ipc_stream.rs
+++ b/src/shared/ipc/ipc_stream.rs
@@ -4,48 +4,168 @@ use std::{
     time::Duration,
 };
 
-pub const IPC_RESPONSE_FINISH: &str = "ok";
+pub const IPC_RESPONSE_SUCCESS: &str = "ok";
+pub const IPC_RESPONSE_ERROR: &str = "error";
 
+/// Wrapper around a [`UnixStream`] that handles IPC communication on the
+/// "server" side. Automatically writes a well formed IPC response when dropped.
 #[derive(Debug)]
-pub(crate) struct IpcStream(UnixStream);
+pub(crate) struct IpcStream {
+    inner: UnixStream,
+    response: Vec<String>,
+    error: Option<String>,
+}
+
+impl IpcStream {
+    /// Consumes the stream as an error, meaning a [`IPC_RESPONSE_ERROR`]
+    /// followed by an error messarge will be sent. If no error is reported, a
+    /// [`Self::response`] followed by [`IPC_RESPONSE_SUCCESS`] will be sent
+    /// instead.
+    pub fn error(mut self, error: String) {
+        self.error = Some(error);
+    }
+
+    pub fn append_response_line(&mut self, response: String) {
+        self.response.push(response);
+    }
+}
 
 impl From<UnixStream> for IpcStream {
     fn from(stream: UnixStream) -> Self {
-        IpcStream(stream)
+        IpcStream { inner: stream, response: Vec::new(), error: None }
     }
 }
 
 impl Write for IpcStream {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0.write(buf)
+        self.inner.write(buf)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        self.0.flush()
+        self.inner.flush()
     }
 }
 
 impl Read for IpcStream {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        self.0.read(buf)
+        self.inner.read(buf)
     }
 }
 
 impl Drop for IpcStream {
     fn drop(&mut self) {
-        if let Err(err) = self.0.set_write_timeout(Some(Duration::from_secs(1))) {
+        if let Err(err) = self.inner.set_write_timeout(Some(Duration::from_secs(1))) {
             log::error!(err:?; "Failed to set write timeout on IPC stream");
             return;
         }
 
-        if let Err(err) = self.0.write_all(IPC_RESPONSE_FINISH.as_bytes()) {
-            log::error!(err:?; "Failed to write response finisher to IPC stream on drop");
-            return;
+        if let Some(err) = &self.error {
+            if let Err(err) = self.inner.write_all(b"error: ") {
+                log::error!(err:?; "Failed to error response start to IPC stream on drop");
+                return;
+            }
+            if let Err(err) = self.inner.write_all(err.as_bytes()) {
+                log::error!(err:?; "Failed to error response to IPC stream on drop");
+                return;
+            }
+        } else {
+            for response in &self.response {
+                if let Err(err) = self.inner.write_all(response.as_bytes()) {
+                    log::error!(err:?; "Failed to write response to IPC stream on drop");
+                    return;
+                }
+                if let Err(err) = self.inner.write_all(b"\n") {
+                    log::error!(err:?; "Failed to write newline to IPC stream on drop");
+                    return;
+                }
+            }
+            if let Err(err) = self.inner.write_all(IPC_RESPONSE_SUCCESS.as_bytes()) {
+                log::error!(err:?; "Failed to write response finisher to IPC stream on drop");
+                return;
+            }
         }
 
-        if let Err(err) = self.0.write_all(b"\n") {
+        if let Err(err) = self.inner.write_all(b"\n") {
             log::error!(err:?; "Failed to write newline to IPC stream on drop");
             return;
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod test {
+    use std::{
+        io::{BufRead, BufReader, Read},
+        os::unix::net::UnixStream,
+    };
+
+    use crate::shared::ipc::ipc_stream::{IPC_RESPONSE_SUCCESS, IpcStream};
+
+    #[test]
+    fn prints_ok_on_drop() {
+        let mut stream = UnixStream::pair().expect("Failed to create UnixStream pair");
+        let ipc_stream = IpcStream::from(stream.0);
+
+        drop(ipc_stream);
+        let mut buf = String::new();
+        stream.1.read_to_string(&mut buf).unwrap();
+
+        assert_eq!(buf.trim(), IPC_RESPONSE_SUCCESS);
+    }
+
+    #[test]
+    fn prints_success_responses_on_drop() {
+        let stream = UnixStream::pair().expect("Failed to create UnixStream pair");
+        let mut ipc_stream = IpcStream::from(stream.0);
+
+        ipc_stream.append_response_line("Hello".to_string());
+        ipc_stream.append_response_line("World".to_string());
+
+        drop(ipc_stream);
+
+        let mut buf = String::new();
+        let mut reader = BufReader::new(stream.1);
+
+        reader.read_line(&mut buf).unwrap();
+        assert_eq!(buf.trim(), "Hello");
+
+        buf.clear();
+        reader.read_line(&mut buf).unwrap();
+        assert_eq!(buf.trim(), "World");
+
+        buf.clear();
+        reader.read_line(&mut buf).unwrap();
+        assert_eq!(buf.trim(), IPC_RESPONSE_SUCCESS);
+    }
+
+    #[test]
+    fn prints_error_on_drop() {
+        let stream = UnixStream::pair().expect("Failed to create UnixStream pair");
+        let mut ipc_stream = IpcStream::from(stream.0);
+
+        ipc_stream.append_response_line("Hello".to_string());
+        ipc_stream.append_response_line("World".to_string());
+        ipc_stream.error("An error occurred".to_string());
+
+        let mut buf = String::new();
+        let mut reader = BufReader::new(stream.1);
+
+        reader.read_line(&mut buf).unwrap();
+        assert_eq!(buf.trim(), "error: An error occurred");
+    }
+
+    #[test]
+    fn prints_error_on_drop_when_no_success_messages() {
+        let stream = UnixStream::pair().expect("Failed to create UnixStream pair");
+        let ipc_stream = IpcStream::from(stream.0);
+
+        ipc_stream.error("An error occurred".to_string());
+
+        let mut buf = String::new();
+        let mut reader = BufReader::new(stream.1);
+
+        reader.read_line(&mut buf).unwrap();
+        assert_eq!(buf.trim(), "error: An error occurred");
     }
 }

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,6 +1,7 @@
 pub mod dependencies;
 pub mod env;
 pub mod events;
+pub mod exit_code;
 pub mod ext;
 pub mod geometry;
 pub mod id;

--- a/src/shared/string_util.rs
+++ b/src/shared/string_util.rs
@@ -5,6 +5,7 @@ pub(crate) trait CharExt {
 pub(crate) trait StringExt {
     fn escape_regex_chars(&self) -> String;
     fn from_utf8_lossy_as_owned(v: Vec<u8>) -> String;
+    fn trim_end_in_place(&mut self);
 }
 
 impl StringExt for String {
@@ -26,6 +27,13 @@ impl StringExt for String {
             // SAFETY: `String::from_utf8_lossy`'s guaranteec valid utf8 when a borrowed
             // variant is returned. Owned value, meaning invalid utf8, is handled above.
             unsafe { String::from_utf8_unchecked(v) }
+        }
+    }
+
+    fn trim_end_in_place(&mut self) {
+        let trimmed_len = str::trim_end(self).len();
+        if trimmed_len < self.len() {
+            self.truncate(trimmed_len);
         }
     }
 }

--- a/src/tests/fixtures/mod.rs
+++ b/src/tests/fixtures/mod.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, collections::HashSet, time::Instant};
+use std::{cell::Cell, collections::HashSet, os::unix::net::UnixStream, time::Instant};
 
 use crossbeam::channel::{Receiver, Sender, unbounded};
 use ratatui::{Terminal, backend::TestBackend};
@@ -11,12 +11,19 @@ use crate::{
     mpd::commands::Status,
     shared::{
         events::{ClientRequest, WorkRequest},
+        ipc::ipc_stream::IpcStream,
         lrc::LrcIndex,
         ring_vec::RingVec,
     },
 };
 
 pub mod mpd_client;
+
+#[fixture]
+pub fn ipc_stream() -> IpcStream {
+    let pair = UnixStream::pair().expect("UnixStream pair should not fail");
+    pair.0.into()
+}
 
 #[fixture]
 pub fn status() -> Status {

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -739,9 +739,10 @@ mod scrollbar_tests {
             let event = MouseEvent { kind: MouseEventKind::LeftClick, x: 29, y: click_y };
             let result = calculate_scrollbar_position(event, scrollbar_area);
             assert!(result.is_some());
-            assert_eq!(
-                result.expect("scrollbar calculation should return a value"),
-                expected_target
+            assert!(
+                (result.expect("scrollbar calculation should return a value") - expected_target)
+                    .abs()
+                    < 0.0001
             );
         }
     }


### PR DESCRIPTION
## Description
Work in progress.

Adds a query command, currently allows to query only the active tab, allows to query multiple things
at once for any future extensibility. `rmpc remote query [TARGETS..]`

The whole IPC mechanism is now more robust with standardized way to propagate errors and response messages all the way up to the client side rmpc with very little space for possible mistakes during implementation of new ipc commands. One more pass on the already existing remote commands should be done in a separate PR to use the new functionality though.

Currently responds in format `key: value` (subject to change), ie.
```
active-tab: Queue
some-other-key: Value
...
```

### Related issues
finishes https://github.com/mierak/rmpc/issues/499

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
