### PR TITLE
Support adding marked songs to a playlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ going to the next item
 - Scrollbars now represent the viewport position instead of the currently selected item position
 - Remote commands now check for `$PID` env variable, meaning `--pid` argument is no longer needed for
 remote commands inside scripts triggered by rmpc
+- `AddToPlaylist` binding handles marked songs rather than only the one under your cursor.
 
 ### Fixed
 

--- a/src/shared/mpd_query.rs
+++ b/src/shared/mpd_query.rs
@@ -92,6 +92,7 @@ pub(crate) enum MpdQueryResult {
     LsInfo { data: Vec<String>, origin_path: Option<Vec<String>> },
     DirOrSong { data: Vec<DirOrSong>, origin_path: Option<Vec<String>> },
     AddToPlaylist { playlists: Vec<String>, song_file: String },
+    AddToPlaylistMultiple { playlists: Vec<String>, song_files: Vec<String> },
     AlbumArt(Option<Vec<u8>>),
     Status { data: Status, source_event: Option<IdleEvent> },
     Queue(Option<Vec<Song>>),


### PR DESCRIPTION
## Description
Adds support for adding multiple songs to playlists from the queue. I referenced implementations for adding one song and deleting multiple, but I'm largely unfamiliar with Rust so I may have made some mistakes. Appears functional from my own testing, though.

Also unsure if I need to update documentation. The binding for `<Space>` is described as "useful for adding multiple songs to a playlist," (although that seemingly did not work from the queue prior to writing this PR) so I believe this functionality is already documented; However, you may want to modify the description for the queue binding for `a`.

### Related issues
None that I know of.

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
