### PR TITLE
support originaldate tag when browsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 - Support Kitty's keyboard protocol
 - Remote query command
 - Config option for global lyrics offset - `lyrics_offset_ms`
+- Added `album_date_tags` config option to specify priority order of metadata tags for album dates
 
 ### Changed
 

--- a/docs/src/content/docs/next/assets/example_config.ron
+++ b/docs/src/content/docs/next/assets/example_config.ron
@@ -120,7 +120,7 @@
     artists: (
         album_display_mode: SplitByDate,
         album_sort_by: Date,
-        album_date_tags: [OriginalDate, Date],
+        album_date_tags: [Date],
     ),
     tabs: [
         (

--- a/docs/src/content/docs/next/assets/example_config.ron
+++ b/docs/src/content/docs/next/assets/example_config.ron
@@ -120,7 +120,7 @@
     artists: (
         album_display_mode: SplitByDate,
         album_sort_by: Date,
-        album_date_tags: ["date"],
+        album_date_tags: [OriginalDate, Date],
     ),
     tabs: [
         (

--- a/docs/src/content/docs/next/assets/example_config.ron
+++ b/docs/src/content/docs/next/assets/example_config.ron
@@ -120,6 +120,7 @@
     artists: (
         album_display_mode: SplitByDate,
         album_sort_by: Date,
+        album_date_tags: ["date"],
     ),
     tabs: [
         (

--- a/docs/src/content/docs/next/configuration/index.mdx
+++ b/docs/src/content/docs/next/configuration/index.mdx
@@ -237,6 +237,7 @@ Default:
 artists: (
     album_display_mode: SplitByDate,
     album_sort_by: Date,
+    album_date_tags: [Date],
 ),
 ```
 
@@ -255,9 +256,14 @@ Can be one of the following:
 - `Name` - albums are sorted by their name first and date second if their names are identical
 - `Date` - albums will be simply sorted by date.
 
+#### album_date_tags
+
+List of metadata tags to search for album dates, in order of preference. Can be one of `Date` or `OriginalDate`.
+When determining an album's date, rmpc will check each tag in order and use the first one found.
+
 :::caution
 
-Rmpc does not do any processing on the `date` metadata tag on the song. It gets sorted lexicographically.
+Rmpc does not do any processing on the date metadata tags. They get sorted lexicographically.
 
 :::
 

--- a/src/config/artists.rs
+++ b/src/config/artists.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 pub struct Artists {
     pub album_display_mode: AlbumDisplayMode,
     pub album_sort_by: AlbumSortMode,
-    pub album_date_tags: Vec<String>,
+    pub album_date_tags: Vec<AlbumDateTag>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -13,8 +13,8 @@ pub struct ArtistsFile {
     pub album_display_mode: AlbumDisplayMode,
     #[serde(default)]
     pub album_sort_by: AlbumSortMode,
-    #[serde(default = "default_album_date_tags")]
-    pub album_date_tags: Vec<String>,
+    #[serde(default)]
+    pub album_date_tags: Vec<AlbumDateTag>,
 }
 
 impl Default for ArtistsFile {
@@ -22,7 +22,7 @@ impl Default for ArtistsFile {
         Self {
             album_display_mode: AlbumDisplayMode::default(),
             album_sort_by: AlbumSortMode::default(),
-            album_date_tags: default_album_date_tags(),
+            album_date_tags: vec![AlbumDateTag::Date],
         }
     }
 }
@@ -41,17 +41,19 @@ pub enum AlbumSortMode {
     Date,
 }
 
-fn default_album_date_tags() -> Vec<String> {
-    vec!["date".to_string()]
+#[derive(
+    Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, strum::IntoStaticStr,
+)]
+#[strum(serialize_all = "lowercase")]
+pub enum AlbumDateTag {
+    #[default]
+    Date,
+    OriginalDate,
 }
 
 impl Default for Artists {
     fn default() -> Self {
-        Self {
-            album_display_mode: AlbumDisplayMode::default(),
-            album_sort_by: AlbumSortMode::default(),
-            album_date_tags: default_album_date_tags(),
-        }
+        ArtistsFile::default().into()
     }
 }
 

--- a/src/config/artists.rs
+++ b/src/config/artists.rs
@@ -13,8 +13,12 @@ pub struct ArtistsFile {
     pub album_display_mode: AlbumDisplayMode,
     #[serde(default)]
     pub album_sort_by: AlbumSortMode,
-    #[serde(default)]
+    #[serde(default = "default_album_date_tags")]
     pub album_date_tags: Vec<AlbumDateTag>,
+}
+
+fn default_album_date_tags() -> Vec<AlbumDateTag> {
+    vec![AlbumDateTag::Date]
 }
 
 impl Default for ArtistsFile {
@@ -22,7 +26,7 @@ impl Default for ArtistsFile {
         Self {
             album_display_mode: AlbumDisplayMode::default(),
             album_sort_by: AlbumSortMode::default(),
-            album_date_tags: vec![AlbumDateTag::Date],
+            album_date_tags: default_album_date_tags(),
         }
     }
 }

--- a/src/config/artists.rs
+++ b/src/config/artists.rs
@@ -1,17 +1,30 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct Artists {
     pub album_display_mode: AlbumDisplayMode,
     pub album_sort_by: AlbumSortMode,
+    pub album_date_tags: Vec<String>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ArtistsFile {
     #[serde(default)]
     pub album_display_mode: AlbumDisplayMode,
     #[serde(default)]
     pub album_sort_by: AlbumSortMode,
+    #[serde(default = "default_album_date_tags")]
+    pub album_date_tags: Vec<String>,
+}
+
+impl Default for ArtistsFile {
+    fn default() -> Self {
+        Self {
+            album_display_mode: AlbumDisplayMode::default(),
+            album_sort_by: AlbumSortMode::default(),
+            album_date_tags: default_album_date_tags(),
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -28,8 +41,26 @@ pub enum AlbumSortMode {
     Date,
 }
 
+fn default_album_date_tags() -> Vec<String> {
+    vec!["date".to_string()]
+}
+
+impl Default for Artists {
+    fn default() -> Self {
+        Self {
+            album_display_mode: AlbumDisplayMode::default(),
+            album_sort_by: AlbumSortMode::default(),
+            album_date_tags: default_album_date_tags(),
+        }
+    }
+}
+
 impl From<ArtistsFile> for Artists {
     fn from(value: ArtistsFile) -> Self {
-        Self { album_display_mode: value.album_display_mode, album_sort_by: value.album_sort_by }
+        Self {
+            album_display_mode: value.album_display_mode,
+            album_sort_by: value.album_sort_by,
+            album_date_tags: value.album_date_tags,
+        }
     }
 }

--- a/src/ui/panes/tag_browser.rs
+++ b/src/ui/panes/tag_browser.rs
@@ -204,7 +204,11 @@ impl TagBrowserPane {
                     .artists
                     .album_date_tags
                     .iter()
-                    .find_map(|tag| song.metadata.get(tag).map(|v| v.last().to_string()))
+                    .find_map(|tag| {
+                        song.metadata
+                            .get(Into::<&'static str>::into(tag))
+                            .map(|v| v.last().to_string())
+                    })
                     .unwrap_or_else(|| "<no date>".to_string());
                 let original_album = song.metadata.get("album").last().map(|v| v.to_owned());
 
@@ -666,7 +670,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        config::Config,
+        config::{Config, artists::AlbumDateTag},
         tests::fixtures::{config, ctx},
     };
 
@@ -799,7 +803,7 @@ mod tests {
     fn albums_single_configured_tag(mut ctx: Ctx, mut config: Config) {
         config.artists.album_display_mode = AlbumDisplayMode::SplitByDate;
         config.artists.album_sort_by = AlbumSortMode::Date;
-        config.artists.album_date_tags = vec!["originaldate".to_string()];
+        config.artists.album_date_tags = vec![AlbumDateTag::OriginalDate];
         ctx.config = std::sync::Arc::new(config);
         let mut pane = TagBrowserPane::new(Tag::Artist, PaneType::Artists, None, &ctx);
         let artist = String::from("artist");
@@ -821,7 +825,7 @@ mod tests {
     fn albums_tag_fallback(mut ctx: Ctx, mut config: Config) {
         config.artists.album_display_mode = AlbumDisplayMode::SplitByDate;
         config.artists.album_sort_by = AlbumSortMode::Date;
-        config.artists.album_date_tags = vec!["originaldate".to_string(), "date".to_string()];
+        config.artists.album_date_tags = vec![AlbumDateTag::OriginalDate, AlbumDateTag::Date];
         ctx.config = std::sync::Arc::new(config);
         let mut pane = TagBrowserPane::new(Tag::Artist, PaneType::Artists, None, &ctx);
         let artist = String::from("artist");
@@ -841,8 +845,7 @@ mod tests {
     fn albums_no_matching_tags(mut ctx: Ctx, mut config: Config) {
         config.artists.album_display_mode = AlbumDisplayMode::SplitByDate;
         config.artists.album_sort_by = AlbumSortMode::Date;
-        config.artists.album_date_tags =
-            vec!["originaldate".to_string(), "releasedate".to_string()];
+        config.artists.album_date_tags = vec![AlbumDateTag::OriginalDate];
         ctx.config = std::sync::Arc::new(config);
         let mut pane = TagBrowserPane::new(Tag::Artist, PaneType::Artists, None, &ctx);
         let artist = String::from("artist");

--- a/src/ui/panes/tag_browser.rs
+++ b/src/ui/panes/tag_browser.rs
@@ -199,7 +199,10 @@ impl TagBrowserPane {
                 let album = song.metadata.get("album").map_or("<no album>".to_string(), |v| {
                     v.join(&ctx.config.theme.format_tag_separator).to_string()
                 });
-                let song_date = ctx.config.artists.album_date_tags
+                let song_date = ctx
+                    .config
+                    .artists
+                    .album_date_tags
                     .iter()
                     .find_map(|tag| song.metadata.get(tag).map(|v| v.last().to_string()))
                     .unwrap_or_else(|| "<no date>".to_string());
@@ -801,8 +804,10 @@ mod tests {
         let mut pane = TagBrowserPane::new(Tag::Artist, PaneType::Artists, None, &ctx);
         let artist = String::from("artist");
         let songs = vec![
-            song_with_originaldate("album_a", "1987", "1969"), // remastered in 1987, original from 1969
-            song_with_originaldate("album_b", "1990", "1970"), // remastered in 1990, original from 1970
+            song_with_originaldate("album_a", "1987", "1969"), /* remastered in 1987, original
+                                                                * from 1969 */
+            song_with_originaldate("album_b", "1990", "1970"), /* remastered in 1990, original
+                                                                * from 1970 */
         ];
 
         let CachedRootTag(result) = pane.process_songs(artist, songs, &ctx);
@@ -822,7 +827,7 @@ mod tests {
         let artist = String::from("artist");
         let songs = vec![
             song_with_originaldate("album_a", "1987", "1969"), // Has both originaldate and date
-            song("album_b", "1990"), // Only has date, not originaldate
+            song("album_b", "1990"),                           // Only has date, not originaldate
         ];
 
         let CachedRootTag(result) = pane.process_songs(artist, songs, &ctx);
@@ -836,7 +841,8 @@ mod tests {
     fn albums_no_matching_tags(mut ctx: Ctx, mut config: Config) {
         config.artists.album_display_mode = AlbumDisplayMode::SplitByDate;
         config.artists.album_sort_by = AlbumSortMode::Date;
-        config.artists.album_date_tags = vec!["originaldate".to_string(), "releasedate".to_string()];
+        config.artists.album_date_tags =
+            vec!["originaldate".to_string(), "releasedate".to_string()];
         ctx.config = std::sync::Arc::new(config);
         let mut pane = TagBrowserPane::new(Tag::Artist, PaneType::Artists, None, &ctx);
         let artist = String::from("artist");

--- a/src/ui/panes/tag_browser.rs
+++ b/src/ui/panes/tag_browser.rs
@@ -199,10 +199,13 @@ impl TagBrowserPane {
                 let album = song.metadata.get("album").map_or("<no album>".to_string(), |v| {
                     v.join(&ctx.config.theme.format_tag_separator).to_string()
                 });
-                let song_date = song.metadata.get("date").map_or("<no date>", |v| v.last());
+                let song_date = ctx.config.artists.album_date_tags
+                    .iter()
+                    .find_map(|tag| song.metadata.get(tag).map(|v| v.last().to_string()))
+                    .unwrap_or_else(|| "<no date>".to_string());
                 let original_album = song.metadata.get("album").last().map(|v| v.to_owned());
 
-                (album, song_date.to_string(), original_album)
+                (album, song_date, original_album)
             })
             .into_iter()
             .sorted_by(|((album_a, date_a, _), _), ((album_b, date_b, _), _)| match sort_mode {
@@ -682,6 +685,26 @@ mod tests {
         }
     }
 
+    fn song_with_originaldate(
+        album: impl Into<String> + std::fmt::Debug,
+        date: impl Into<String> + std::fmt::Debug,
+        original_date: impl Into<String> + std::fmt::Debug,
+    ) -> Song {
+        Song {
+            id: 0,
+            file: format!("{date:?} {album:?}"),
+            duration: None,
+            metadata: HashMap::from([
+                ("album".to_string(), Into::<String>::into(album).into()),
+                ("date".to_string(), Into::<String>::into(date).into()),
+                ("originaldate".to_string(), Into::<String>::into(original_date).into()),
+            ]),
+            stickers: None,
+            last_modified: chrono::Utc::now(),
+            added: None,
+        }
+    }
+
     #[rstest]
     fn albums_no_date_sort_name(mut ctx: Ctx, mut config: Config) {
         config.artists.album_display_mode = AlbumDisplayMode::NameOnly;
@@ -767,5 +790,63 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].name, "album_b");
         assert_eq!(result[1].name, "album_a");
+    }
+
+    #[rstest]
+    fn albums_single_configured_tag(mut ctx: Ctx, mut config: Config) {
+        config.artists.album_display_mode = AlbumDisplayMode::SplitByDate;
+        config.artists.album_sort_by = AlbumSortMode::Date;
+        config.artists.album_date_tags = vec!["originaldate".to_string()];
+        ctx.config = std::sync::Arc::new(config);
+        let mut pane = TagBrowserPane::new(Tag::Artist, PaneType::Artists, None, &ctx);
+        let artist = String::from("artist");
+        let songs = vec![
+            song_with_originaldate("album_a", "1987", "1969"), // remastered in 1987, original from 1969
+            song_with_originaldate("album_b", "1990", "1970"), // remastered in 1990, original from 1970
+        ];
+
+        let CachedRootTag(result) = pane.process_songs(artist, songs, &ctx);
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].name, "(1969) album_a"); // Uses originaldate, not date
+        assert_eq!(result[1].name, "(1970) album_b"); // Uses originaldate, not date
+    }
+
+    #[rstest]
+    fn albums_tag_fallback(mut ctx: Ctx, mut config: Config) {
+        config.artists.album_display_mode = AlbumDisplayMode::SplitByDate;
+        config.artists.album_sort_by = AlbumSortMode::Date;
+        config.artists.album_date_tags = vec!["originaldate".to_string(), "date".to_string()];
+        ctx.config = std::sync::Arc::new(config);
+        let mut pane = TagBrowserPane::new(Tag::Artist, PaneType::Artists, None, &ctx);
+        let artist = String::from("artist");
+        let songs = vec![
+            song_with_originaldate("album_a", "1987", "1969"), // Has both originaldate and date
+            song("album_b", "1990"), // Only has date, not originaldate
+        ];
+
+        let CachedRootTag(result) = pane.process_songs(artist, songs, &ctx);
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].name, "(1969) album_a"); // Uses originaldate (first in list)
+        assert_eq!(result[1].name, "(1990) album_b"); // Falls back to date (second in list)
+    }
+
+    #[rstest]
+    fn albums_no_matching_tags(mut ctx: Ctx, mut config: Config) {
+        config.artists.album_display_mode = AlbumDisplayMode::SplitByDate;
+        config.artists.album_sort_by = AlbumSortMode::Date;
+        config.artists.album_date_tags = vec!["originaldate".to_string(), "releasedate".to_string()];
+        ctx.config = std::sync::Arc::new(config);
+        let mut pane = TagBrowserPane::new(Tag::Artist, PaneType::Artists, None, &ctx);
+        let artist = String::from("artist");
+        let songs = vec![
+            song("album_a", "1987"), // Only has "date", not in our list
+        ];
+
+        let CachedRootTag(result) = pane.process_songs(artist, songs, &ctx);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "(<no date>) album_a"); // Falls back to default
     }
 }


### PR DESCRIPTION
## Description
Allow album artists + artist + genre panes to support configurable date tags with fallback behavior.

In my `config.ron` to use this I have:

```
    artists: (
        album_display_mode: SplitByDate,
        album_sort_by: Date,
        album_date_tags: [OriginalDate, Date], // changed during PR to not be strings
    ),
```

### Related issues
https://github.com/mierak/rmpc/issues/568

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
