### PR TITLE
feat: ignore diacritics

### DIFF
--- a/docs/src/content/docs/next/assets/example_config.ron
+++ b/docs/src/content/docs/next/assets/example_config.ron
@@ -106,6 +106,7 @@
     ),
     search: (
         case_sensitive: false,
+        ignore_diacritics: false,
         mode: Contains,
         tags: [
             (value: "any",         label: "Any Tag"),

--- a/docs/src/content/docs/next/configuration/search.mdx
+++ b/docs/src/content/docs/next/configuration/search.mdx
@@ -14,6 +14,24 @@ import { path } from "../data.ts";
 
 Whether the filter should be case sensitive by default. Default is `false`.
 
+:::note
+Cannot be enabled at the same time as [ignore_diacritics](#ignore_diacritics).
+:::
+
+## ignore_diacritics
+
+<ConfigValue name="ignore_diacritics" type="bool" />
+
+Whether the filter should ignore diacritics by default. Default is `false`.
+
+:::note
+Cannot be enabled at the same time as [case_sensitive](#case_sensitive).
+:::
+
+:::note
+This option requires MPD version 0.25.0 and newer to work
+:::
+
 ## mode
 
 <ConfigValue name="mode" type={["Exact", "StartsWith", "Contains", "Regex"]} />

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -395,7 +395,7 @@ impl ConfigFile {
             keybinds: self.keybinds.into(),
             select_current_song_on_change: self.select_current_song_on_change,
             center_current_song_on_change: self.center_current_song_on_change,
-            search: self.search.into(),
+            search: self.search.try_into()?,
             artists: self.artists.into(),
             album_art: self.album_art.into(),
             on_song_change: self.on_song_change.map(|arr| {

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -25,6 +25,7 @@ use crate::{
         client::Client,
         commands::{Song, State, Status},
         mpd_client::MpdClient,
+        version::Version,
     },
     shared::{
         events::ClientRequest,
@@ -38,6 +39,7 @@ use crate::{
 
 #[derive(derive_more::Debug)]
 pub struct Ctx {
+    pub(crate) mpd_version: Version,
     pub(crate) config: std::sync::Arc<Config>,
     pub(crate) status: Status,
     pub(crate) queue: Vec<Song>,
@@ -95,6 +97,7 @@ impl Ctx {
         let active_tab = config.tabs.names.first().context("Expected at least one tab")?.clone();
         scheduler.start();
         Ok(Self {
+            mpd_version: client.version(),
             lrc_index: LrcIndex::default(),
             config: std::sync::Arc::new(config),
             status,

--- a/src/mpd/proto_client.rs
+++ b/src/mpd/proto_client.rs
@@ -258,12 +258,15 @@ impl<T: SocketClient> ProtoClient for T {
         }
 
         if line.starts_with("OK") || line.starts_with("list_OK") {
+            log::trace!(line = line.as_str().trim(); "Read MPD line OK");
             return Ok(MpdLine::Ok);
         }
         if line.starts_with("ACK") {
+            log::error!(line = line.as_str(); "Read MPD line with error");
             return Err(MpdError::Mpd(MpdFailureResponse::from_str(&line)?));
         }
         line.pop(); // pop the new line
+        log::trace!(line = line.as_str(); "Read MPD line");
         Ok(MpdLine::Value(line))
     }
 }

--- a/src/tests/fixtures/mod.rs
+++ b/src/tests/fixtures/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     config::{Config, ConfigFile, tabs::TabName},
     core::scheduler::Scheduler,
     ctx::Ctx,
-    mpd::commands::Status,
+    mpd::{commands::Status, version::Version},
     shared::{
         events::{ClientRequest, WorkRequest},
         ipc::ipc_stream::IpcStream,
@@ -53,6 +53,7 @@ pub fn ctx(
     let chan1 = Box::leak(Box::new(chan1));
     let scheduler = Scheduler::new((chan1.0.clone(), unbounded().0));
     Ctx {
+        mpd_version: Version::new(1, 0, 0),
         status: Status::default(),
         config: std::sync::Arc::new(config),
         queue: Vec::default(),

--- a/src/tests/fixtures/mpd_client.rs
+++ b/src/tests/fixtures/mpd_client.rs
@@ -28,7 +28,15 @@ use crate::mpd::{
         volume::Bound,
     },
     errors::MpdError,
-    mpd_client::{Filter, MpdClient, SaveMode, SingleOrRange, Tag, ValueChange},
+    mpd_client::{
+        Filter,
+        MpdClient,
+        SaveMode,
+        SingleOrRange,
+        StringNormalizationFeature,
+        Tag,
+        ValueChange,
+    },
     proto_client::SocketClient,
     version::Version,
 };
@@ -349,7 +357,7 @@ impl MpdClient for TestMpdClient {
             .collect())
     }
 
-    fn search(&mut self, filter: &[Filter<'_>]) -> MpdResult<Vec<Song>> {
+    fn search(&mut self, filter: &[Filter<'_>], _ignore_diacritics: bool) -> MpdResult<Vec<Song>> {
         Ok(self
             .songs
             .iter()
@@ -645,6 +653,28 @@ impl MpdClient for TestMpdClient {
     }
 
     fn clear_playlist(&mut self, _name: &str) -> MpdResult<()> {
+        todo!("Not yet implemented")
+    }
+
+    fn string_normalization_enable(
+        &mut self,
+        _features: &[StringNormalizationFeature],
+    ) -> MpdResult<()> {
+        todo!("Not yet implemented")
+    }
+
+    fn string_normalization_disable(
+        &mut self,
+        _features: &[StringNormalizationFeature],
+    ) -> MpdResult<()> {
+        todo!("Not yet implemented")
+    }
+
+    fn string_normalization_all(&mut self) -> MpdResult<()> {
+        todo!("Not yet implemented")
+    }
+
+    fn string_normalization_clear(&mut self) -> MpdResult<()> {
         todo!("Not yet implemented")
     }
 }


### PR DESCRIPTION
## Description

Adds option to ignore diacritics when using search. Case sensitivity cannot be enabled at the same
time because case sensitive query uses a different protocol command than case insensitive: `find`
vs `search`.

The setting in config will have no effect and the option in TUI will not appear if MPD is not version
0.25.0 or higher (which is currently not released).

### Related issues

Fixes https://github.com/mierak/rmpc/issues/359
Supersedes https://github.com/mierak/rmpc/pull/498

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
