### PR TITLE
Add addyt --name to search by song title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added youtube song by name support: `addyt --name "query"` (uses first YouTube result; TUI supported).
 - Added interactive scrollbar support to browser panes and search pane results:
 - Added `rmpc remote keybind` command to emulate key presses in running instances
 - Added `rmpc remote switch-tab` command to switch tabs directly without relying on keybinds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Added youtube song by name support: `addyt --name "query"` (uses first YouTube result; TUI supported).
+- Added youtube song by name support: `searchyt "query"` (uses first YouTube result; TUI supported).
 - Added interactive scrollbar support to browser panes and search pane results:
 - Added `rmpc remote keybind` command to emulate key presses in running instances
 - Added `rmpc remote switch-tab` command to switch tabs directly without relying on keybinds

--- a/docs/src/content/docs/next/guides/youtube.mdx
+++ b/docs/src/content/docs/next/guides/youtube.mdx
@@ -20,7 +20,12 @@ and cannot be stopped except by terminating rmpc.
     2. Install [yt-dlp's dependencies](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#dependencies): ffmpeg, ffprobe, python3 and python's mutagen library.
     3. Configure rmpc's cache directory <a href={path("configuration/#cache_dir")}>in your config file</a>
     4. Connect to MPD with a local socket and not IP address.
-    5. Execute `rmpc addyt <youtube-url>` or in tui `addyt <youtube-url>` to add a song to the queue.
+    5. Add music to the queue:
+       <ul>
+         <li><strong>From a URL:</strong> <code>rmpc addyt &lt;youtube-url&gt;</code> (TUI: <code>addyt &lt;youtube-url&gt;</code>)</li>
+         <li><strong>By name (search first result):</strong> <code>rmpc addyt --name "search terms"</code> (TUI: <code>addyt --name "search terms"</code>)</li>
+         <li><strong>Optional position:</strong> <code>--position &lt;n|+n|-n&gt;</code> to enqueue at an absolute or relative position</li>
+       </ul>
 
 </Steps>
 

--- a/docs/src/content/docs/next/guides/youtube.mdx
+++ b/docs/src/content/docs/next/guides/youtube.mdx
@@ -22,9 +22,9 @@ and cannot be stopped except by terminating rmpc.
     4. Connect to MPD with a local socket and not IP address.
     5. Add music to the queue:
        <ul>
-         <li><strong>From a URL:</strong> <code>rmpc addyt &lt;youtube-url&gt;</code> (TUI: <code>addyt &lt;youtube-url&gt;</code>)</li>
-         <li><strong>By name (search first result):</strong> <code>rmpc addyt --name "search terms"</code> (TUI: <code>addyt --name "search terms"</code>)</li>
-         <li><strong>Optional position:</strong> <code>--position &lt;n|+n|-n&gt;</code> to enqueue at an absolute or relative position</li>
+          <li><strong>From a URL:</strong> <code>rmpc addyt &lt;youtube-url&gt;</code> (TUI: <code>addyt &lt;youtube-url&gt;</code>)</li>
+          <li><strong>Search by name (first result):</strong> <code>rmpc searchyt "search terms"</code> (TUI: <code>searchyt "search terms"</code>)</li>
+          <li><strong>Optional position:</strong> add <code>--position &lt;n|+n|-n&gt;</code> to enqueue at an absolute or relative position</li>
        </ul>
 
 </Steps>

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -201,12 +201,24 @@ pub enum Command {
     },
     /// Add a song from youtube to the current queue.
     AddYt {
-        url: String,
+        #[arg(
+            required_unless_present = "name",
+            value_parser = clap::builder::NonEmptyStringValueParser::new()
+        )]
+        url: Option<String>,
         /// If provided, queue the new item at this position instead of the end
         /// of the queue. Allowed positions are <number> (absolute) and
         /// +<number> or -<number> (relative)
         #[arg(short, long, allow_negative_numbers = true)]
         position: Option<QueuePosition>,
+        /// If provided search by name and use the first result
+        #[arg(
+            short = 'n',
+            long = "name",
+            conflicts_with = "url",
+            value_parser = clap::builder::NonEmptyStringValueParser::new()
+        )]
+        name: Option<String>,
     },
     /// List MPD outputs
     Outputs,

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -444,4 +444,87 @@ impl Args {
         path.push("config.ron");
         path
     }
+
+    /// Split a shell-like command line into tokens (argv).
+    ///
+    /// Supports single `'...'` and double `"..."` quotes and backslash escapes.
+    ///
+    /// # Errors
+    /// Returns `Err` if the input contains an **unclosed quote** or a **dangling backslash**
+    /// escape at the end of the string.
+    ///
+    /// # Examples
+    /// ```
+    /// let v = Args::split_command_line(r#"addyt --name "rick astley""#).unwrap();
+    /// assert_eq!(v, ["addyt", "--name", "rick astley"]);
+    /// ```
+    fn split_command_line(s: &str) -> Result<Vec<String>, &'static str> {
+        let mut args = Vec::new();
+        let mut token = String::new();
+        let mut in_single_quote = false;
+        let mut in_double_quote = false;
+        let mut escaped = false;
+
+        for ch in s.chars() {
+            if escaped {
+                token.push(ch);
+                escaped = false;
+                continue;
+            }
+            match ch {
+                '\\' if !in_single_quote => escaped = true,
+                '\'' if !in_double_quote => in_single_quote = !in_single_quote,
+                '"' if !in_single_quote => in_double_quote = !in_double_quote,
+                c if c.is_whitespace() && !in_single_quote && !in_double_quote => {
+                    if !token.is_empty() {
+                        args.push(std::mem::take(&mut token));
+                    }
+                }
+                c => token.push(c),
+            }
+        }
+
+        if escaped {
+            return Err("dangling backslash");
+        }
+        if in_single_quote || in_double_quote {
+            return Err("unclosed quote");
+        }
+        if !token.is_empty() {
+            args.push(token);
+        }
+        Ok(args)
+    }
+
+    /// Parse a command-line string into [`Args`] as if typed in the terminal.
+    ///
+    /// This function tokenizes `s` like a shell, prepends a synthetic `argv[0]`
+    /// (`"rmpc"`), and invokes Clap’s non-exiting parser.
+    ///
+    /// # Errors
+    /// Returns a [`clap::Error`] when:
+    /// - tokenization fails (e.g., **unclosed quote**, **dangling backslash**),
+    /// - the input is **empty**,
+    /// - or Clap rejects the arguments (e.g., unknown subcommand/flag, missing required args).
+    ///
+    /// # Examples
+    /// ```
+    /// let a = Args::parse_cli_line(r#"addyt --name "rick astley""#).unwrap();
+    /// match a.command {
+    ///     Some(Command::AddYt { name, url, .. }) => { assert!(name.is_some()); assert!(url.is_none()); }
+    ///     _ => unreachable!(),
+    /// }
+    /// ```
+    pub fn parse_cli_line(s: &str) -> Result<Self, clap::Error> {
+        let mut argv = Self::split_command_line(s)
+            .map_err(|e| clap::Error::raw(clap::error::ErrorKind::InvalidValue, e))?;
+        if argv.is_empty() {
+            return Err(clap::Error::raw(
+                clap::error::ErrorKind::MissingRequiredArgument,
+                "empty command",
+            ));
+        }
+        argv.insert(0, "rmpc".to_string()); // clap expects argv[0]
+        <Self as Parser>::try_parse_from(argv)
+    }
 }

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -201,24 +201,19 @@ pub enum Command {
     },
     /// Add a song from youtube to the current queue.
     AddYt {
-        #[arg(
-            required_unless_present = "name",
-            value_parser = clap::builder::NonEmptyStringValueParser::new()
-        )]
-        url: Option<String>,
+        url: String,
         /// If provided, queue the new item at this position instead of the end
         /// of the queue. Allowed positions are <number> (absolute) and
         /// +<number> or -<number> (relative)
         #[arg(short, long, allow_negative_numbers = true)]
         position: Option<QueuePosition>,
-        /// If provided search by name and use the first result
-        #[arg(
-            short = 'n',
-            long = "name",
-            conflicts_with = "url",
-            value_parser = clap::builder::NonEmptyStringValueParser::new()
-        )]
-        name: Option<String>,
+    },
+    SearchYt {
+        /// Search query (song/artist/title…)
+        #[arg(value_name = "QUERY")]
+        query: String,
+        #[arg(short, long, allow_negative_numbers = true)]
+        position: Option<QueuePosition>,
     },
     /// List MPD outputs
     Outputs,
@@ -450,8 +445,8 @@ impl Args {
     /// Supports single `'...'` and double `"..."` quotes and backslash escapes.
     ///
     /// # Errors
-    /// Returns `Err` if the input contains an **unclosed quote** or a **dangling backslash**
-    /// escape at the end of the string.
+    /// Returns `Err` if the input contains an **unclosed quote** or a
+    /// **dangling backslash** escape at the end of the string.
     ///
     /// # Examples
     /// ```
@@ -505,7 +500,8 @@ impl Args {
     /// Returns a [`clap::Error`] when:
     /// - tokenization fails (e.g., **unclosed quote**, **dangling backslash**),
     /// - the input is **empty**,
-    /// - or Clap rejects the arguments (e.g., unknown subcommand/flag, missing required args).
+    /// - or Clap rejects the arguments (e.g., unknown subcommand/flag, missing
+    ///   required args).
     ///
     /// # Examples
     /// ```

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -208,10 +208,15 @@ pub enum Command {
         #[arg(short, long, allow_negative_numbers = true)]
         position: Option<QueuePosition>,
     },
+    /// Search youtube song by name and add the first result to the current
+    /// queue.
     SearchYt {
         /// Search query (song/artist/title…)
         #[arg(value_name = "QUERY")]
         query: String,
+        /// If provided, queue the new item at this position instead of the end
+        /// of the queue. Allowed positions are <number> (absolute) and
+        /// +<number> or -<number> (relative)
         #[arg(short, long, allow_negative_numbers = true)]
         position: Option<QueuePosition>,
     },

--- a/src/core/command.rs
+++ b/src/core/command.rs
@@ -256,8 +256,13 @@ impl Command {
 
                 Ok(())
             })),
-            Command::AddYt { url, position } => {
-                let file_paths = YtDlp::init_and_download(config, &url)?;
+            Command::AddYt { url, position, name } => {
+                let chosen_url = match (url, name) {
+                    (Some(u), None) => u.trim().to_owned(),
+                    (None, Some(n)) => YtDlp::search_youtube_single(n.trim())?,
+                    _ => unreachable!("Clap enforces exactly one of URL or --name"),
+                };
+                let file_paths = YtDlp::init_and_download(config, &chosen_url)?;
                 Ok(Box::new(move |client| {
                     client.send_start_cmd_list()?;
                     for file in file_paths {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,8 +3,12 @@ use std::collections::HashMap;
 use anyhow::{Context, Result, anyhow};
 use itertools::Itertools;
 use modals::{
-    add_random_modal::AddRandomModal, decoders::DecodersModal, info_list_modal::InfoListModal,
-    input_modal::InputModal, keybinds::KeybindsModal, menu::modal::MenuModal,
+    add_random_modal::AddRandomModal,
+    decoders::DecodersModal,
+    info_list_modal::InfoListModal,
+    input_modal::InputModal,
+    keybinds::KeybindsModal,
+    menu::modal::MenuModal,
     outputs::OutputsModal,
 };
 use panes::{PaneContainer, Panes, pane_call};

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,12 +3,8 @@ use std::collections::HashMap;
 use anyhow::{Context, Result, anyhow};
 use itertools::Itertools;
 use modals::{
-    add_random_modal::AddRandomModal,
-    decoders::DecodersModal,
-    info_list_modal::InfoListModal,
-    input_modal::InputModal,
-    keybinds::KeybindsModal,
-    menu::modal::MenuModal,
+    add_random_modal::AddRandomModal, decoders::DecodersModal, info_list_modal::InfoListModal,
+    input_modal::InputModal, keybinds::KeybindsModal, menu::modal::MenuModal,
     outputs::OutputsModal,
 };
 use panes::{PaneContainer, Panes, pane_call};
@@ -312,13 +308,15 @@ impl<'ui> Ui<'ui> {
                             .title("Execute a command")
                             .confirm_label("Execute")
                             .on_confirm(|ctx, value| {
-                                let cmd = value.parse();
-                                log::debug!("executing {cmd:?}");
-
-                                if let Ok(Args { command: Some(cmd), .. }) = cmd
-                                    && ctx.work_sender.send(WorkRequest::Command(cmd)).is_err()
-                                {
-                                    log::error!("Failed to send command");
+                                match Args::parse_cli_line(value) {
+                                    Ok(Args { command: Some(cmd), .. }) => {
+                                        if ctx.work_sender.send(WorkRequest::Command(cmd)).is_err()
+                                        {
+                                            log::error!("Failed to send command");
+                                        }
+                                    }
+                                    Ok(_) => log::warn!("No subcommand provided"),
+                                    Err(e) => log::error!("Parse error: {e}"),
                                 }
                                 Ok(())
                             })


### PR DESCRIPTION
## Description
- Introduces --name to addyt to resolve the first YouTube match and enqueue via existing download pipeline.
- Works in CLI and TUI Command Mode (custom argv splitter, no extra deps).

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
