### PR TITLE
fix: adding non-album entries with split by date adding more than intended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ remote commands inside scripts triggered by rmpc
 - `ModalClosed` event now correctly gets dispatched only after all modals were closed
 - Preview no longer disappears in search when returning to the search form while the results are
 scrolled down
+- Adding entries without album adding not intended songs when using split by date
 
 ## [0.9.0] - 2025-06-23
 


### PR DESCRIPTION
## Description

Adding synthesised albums when using split by date was adding all songs from the given album and not just the subset of entries for the given date.

### Related issues
fixes #580

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
