### PR TITLE
fix: volume parse fail - change volume to u32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ remote commands inside scripts triggered by rmpc
 - Preview no longer disappears in search when returning to the search form while the results are
 scrolled down
 - Adding entries without album adding not intended songs when using split by date
+- Volume parsing if MPD's volume was set to higher value than 255 via external means
 
 ## [0.9.0] - 2025-06-23
 

--- a/src/mpd/commands/volume.rs
+++ b/src/mpd/commands/volume.rs
@@ -4,14 +4,14 @@ use serde::Serialize;
 use crate::mpd::{FromMpd, LineHandled, errors::MpdError};
 
 #[derive(Debug, Serialize, Default, PartialEq, AsRef, Clone, Copy)]
-pub struct Volume(u8);
+pub struct Volume(u32);
 
-impl Bound<u8> for Volume {
-    fn value(&self) -> &u8 {
+impl Bound<u32> for Volume {
+    fn value(&self) -> &u32 {
         &self.0
     }
 
-    fn set_value(&mut self, value: u8) -> &Self {
+    fn set_value(&mut self, value: u32) -> &Self {
         self.0 = value.clamp(0, 100);
         self
     }
@@ -23,7 +23,7 @@ impl Bound<u8> for Volume {
         self
     }
 
-    fn inc_by(&mut self, step: u8) -> &Self {
+    fn inc_by(&mut self, step: u32) -> &Self {
         self.0 = self.0.saturating_add(step).min(100);
         self
     }
@@ -35,22 +35,22 @@ impl Bound<u8> for Volume {
         self
     }
 
-    fn dec_by(&mut self, step: u8) -> &Self {
+    fn dec_by(&mut self, step: u32) -> &Self {
         self.0 = self.0.saturating_sub(step);
         self
     }
 }
 
 impl Volume {
-    pub fn new(value: u8) -> Self {
+    pub fn new(value: u32) -> Self {
         Self(value.clamp(0, 100))
     }
 }
 
 #[allow(dead_code)]
 pub trait Bound<T> {
-    fn value(&self) -> &u8;
-    fn set_value(&mut self, value: u8) -> &Self;
+    fn value(&self) -> &T;
+    fn set_value(&mut self, value: T) -> &Self;
     fn inc(&mut self) -> &Self;
     fn inc_by(&mut self, step: T) -> &Self;
     fn dec(&mut self) -> &Self;

--- a/src/tests/fixtures/mpd_client.rs
+++ b/src/tests/fixtures/mpd_client.rs
@@ -171,9 +171,9 @@ impl MpdClient for TestMpdClient {
 
     fn volume(&mut self, change: ValueChange) -> MpdResult<()> {
         match change {
-            ValueChange::Increase(val) => self.volume.inc_by(val as u8),
-            ValueChange::Decrease(val) => self.volume.dec_by(val as u8),
-            ValueChange::Set(val) => self.volume.set_value(val as u8),
+            ValueChange::Increase(val) => self.volume.inc_by(val),
+            ValueChange::Decrease(val) => self.volume.dec_by(val),
+            ValueChange::Set(val) => self.volume.set_value(val),
         };
         Ok(())
     }

--- a/src/ui/panes/volume.rs
+++ b/src/ui/panes/volume.rs
@@ -47,7 +47,7 @@ impl Pane for VolumePane {
         match &self.config {
             VolumeType::Slider(config) => {
                 let volume_slider = as_styled_volume_slider(config)
-                    .value(f32::from(*ctx.status.volume.value()) / 100.0);
+                    .value(f64::from(*ctx.status.volume.value()) / 100.0);
 
                 frame.render_widget(volume_slider, self.area);
             }

--- a/src/ui/widgets/volume.rs
+++ b/src/ui/widgets/volume.rs
@@ -46,7 +46,7 @@ impl<'a> Volume<'a> {
 }
 
 impl Volume<'_> {
-    pub fn get_str(value: u8) -> String {
+    pub fn get_str(value: u32) -> String {
         let i = std::cmp::min((value / 13) as usize, CHARS.len());
         format!("Volume: {:<7} {:>3}%", CHARS[0..i].join(""), value)
     }

--- a/src/ui/widgets/volume_slider.rs
+++ b/src/ui/widgets/volume_slider.rs
@@ -6,7 +6,7 @@ use ratatui::{
 
 #[derive(Clone)]
 pub struct VolumeSlider<'a> {
-    value: f32,
+    value: f64,
     start_char: &'a str,
     filled_char: &'a str,
     thumb_char: &'a str,
@@ -19,7 +19,7 @@ pub struct VolumeSlider<'a> {
 
 #[allow(dead_code)]
 impl<'a> VolumeSlider<'a> {
-    pub fn value(mut self, val: f32) -> Self {
+    pub fn value(mut self, val: f64) -> Self {
         self.value = val.clamp(0.0, 1.0);
         self
     }
@@ -91,7 +91,7 @@ impl Widget for VolumeSlider<'_> {
 
         buf.set_string(left, top, self.empty_char.repeat(len as usize), self.empty_style);
 
-        let filled_len = (len as f32 * self.value) as usize;
+        let filled_len = (f64::from(len) * self.value) as usize;
 
         if filled_len > 0 {
             buf.set_string(left, top, self.filled_char.repeat(filled_len), self.filled_style);


### PR DESCRIPTION
## Description

MPD ensures its volume does not get outside 0-100 but it can still be set to higher value via things
like pactl and rmpc would fail to start if higher than 255.

### Related issues

fixes #582

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
