### PR TITLE
feat: Added an ability to specify relative/absolute theme path in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 - Config option for global lyrics offset - `lyrics_offset_ms`
 - add `exec_on_song_change_at_start` config option
 - Added `album_date_tags` config option to specify priority order of metadata tags for album dates
+- Added an ability to specify relative/absolute theme path in config file.
 
 ### Changed
 

--- a/docs/src/content/docs/next/configuration/index.mdx
+++ b/docs/src/content/docs/next/configuration/index.mdx
@@ -104,7 +104,7 @@ the previous track if not configured or set to `None`.
 
 <ConfigValue optional name="theme" type="string" />
 
-Theme file to use. The path may be specified as either relative or absolute, with or without a file extension. If set to `None` or absent, the default theme is used. More info at:
+Theme file to use. If set to `None` or absent, the default theme is used. More info at:
 
 <LinkCard
     title="Configuring themes"

--- a/docs/src/content/docs/next/configuration/index.mdx
+++ b/docs/src/content/docs/next/configuration/index.mdx
@@ -104,7 +104,7 @@ the previous track if not configured or set to `None`.
 
 <ConfigValue optional name="theme" type="string" />
 
-Theme file to use. If set to `None` or absent, the default theme is used. More info at:
+Theme file to use. The path may be specified as either relative or absolute, with or without a file extension. If set to `None` or absent, the default theme is used. More info at:
 
 <LinkCard
     title="Configuring themes"

--- a/docs/src/content/docs/next/configuration/theme.mdx
+++ b/docs/src/content/docs/next/configuration/theme.mdx
@@ -13,6 +13,14 @@ import { path } from "../data.ts";
 A theme determines the look of rmpc. You can customize it by creating a custom theme file placed in the themes
 directory and then configuring the `theme` property in the config file filename of the theme.
 
+The following paths are checked in order they are listed here:
+
+- `<rmpc config dir>/themes/<theme>.ron`
+- `<rmpc config dir>/<theme>.ron`
+- `<rmpc config dir>/<theme>`
+- `<theme>`
+- `Specific path specified by the --theme flag`
+
 ## Bootstrapping a theme file
 
 <Steps>

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -313,13 +313,13 @@ impl ConfigFile {
         self.theme.as_ref()
         .and_then(|theme| {
             let theme_paths = [
-                PathBuf::from(theme),
-                config_dir.join(theme),
+                config_dir.join("themes").join(format!("{theme}.ron")),
                 config_dir.join(format!("{theme}.ron")),
-                config_dir.join("themes").join(format!("{theme}.ron"))
+                config_dir.join(theme),
+                PathBuf::from(tilde_expand(theme).into_owned())
             ];
 
-            theme_paths.into_iter().rfind(|theme_path| theme_path.is_file())
+            theme_paths.into_iter().find(|theme_path| theme_path.is_file())
         })
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -310,8 +310,14 @@ impl ConfigFile {
     }
 
     pub fn theme_path(&self, config_dir: &Path) -> Option<PathBuf> {
-        self.theme.as_ref().map(|theme_name| {
-            PathBuf::from(config_dir).join("themes").join(format!("{theme_name}.ron"))
+        self.theme.as_ref()
+        .and_then(|theme| {
+            let theme_paths = [
+                config_dir.join(theme),
+                config_dir.join(format!("{theme}.ron"))
+            ];
+
+            theme_paths.into_iter().find(|theme_path| theme_path.is_file())
         })
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -310,15 +310,13 @@ impl ConfigFile {
     }
 
     pub fn theme_path(&self, config_dir: &Path) -> Option<PathBuf> {
-        self.theme.as_ref()
-        .and_then(|theme| {
+        self.theme.as_ref().and_then(|theme| {
             let theme_paths = [
                 config_dir.join("themes").join(format!("{theme}.ron")),
                 config_dir.join(format!("{theme}.ron")),
                 config_dir.join(theme),
-                PathBuf::from(tilde_expand(theme).into_owned())
+                PathBuf::from(tilde_expand(theme).into_owned()),
             ];
-
             theme_paths.into_iter().find(|theme_path| theme_path.is_file())
         })
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -313,11 +313,13 @@ impl ConfigFile {
         self.theme.as_ref()
         .and_then(|theme| {
             let theme_paths = [
+                PathBuf::from(theme),
                 config_dir.join(theme),
-                config_dir.join(format!("{theme}.ron"))
+                config_dir.join(format!("{theme}.ron")),
+                config_dir.join("themes").join(format!("{theme}.ron"))
             ];
 
-            theme_paths.into_iter().find(|theme_path| theme_path.is_file())
+            theme_paths.into_iter().rfind(|theme_path| theme_path.is_file())
         })
     }
 


### PR DESCRIPTION
## Description

Hi! I made a small feature pr for allowing user to specify a relative path to a theme.ron file.

### Related issues

Can't specify absolute/relative theme path in config file with file extension. Only a theme name with hard coded directory 'themes' are allowed.

### Check list
- [x] All tests passed
- [x] Support for relative paths
- [x] Support for absolute paths
- [x] Support for legacy theme paths
- [x] Update changelog
- [x] Update docs