### PR TITLE
Add link-time optimization directives to Cargo.toml, for smaller binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,4 +97,5 @@ unused_macros = "allow"
 [profile.release]
 strip = "symbols"
 lto = "fat"
+opt-level = "s"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,8 @@ cast_sign_loss = "allow"
 
 [lints.rust]
 unused_macros = "allow"
+
+[profile.release]
+strip = "symbols"
+lto = "fat"
+


### PR DESCRIPTION
## Description

Hi, this is my first time making a pull request here.  I really enjoy this music player, I want to help out with the issues I find with it.  I thought you might be interested in this, I don't know if you know about these.  [For reference.](https://doc.rust-lang.org/cargo/reference/profiles.html)

I added a few options to the `Cargo.toml` file, under the heading **`[profile.release]`** to allow **rmpc** to be built with a smaller binary size. These options are `strip = "symbols"` , `lto = "fat"` , and `opt-level = "s"`.

I did not mark "Changelog has been updated", as my change did not affect the behavior of the **rmpc** program itself. I do not feel it is necessary to add such a small change to the Changelog.

See the below screenshot.  The first command shows the file size of the **rmpc** binary on my system (`/usr/bin`), which was built with the current `Cargo.toml` on `master`.  The second command shows the file size of the binary built with my new **`[profile.release]`** optimizations.  The program works exactly the same way.

<img width="960" height="387" alt="binarysize" src="https://github.com/user-attachments/assets/9251a7cc-120a-4d93-bf79-39ddf31a2d84" />

### Related issues

### Checklist

- [X] All tests passed
- [X] Code has been formatted with nightly
- [X] Code has been checked with clippy (stable)
- [X] Documentation has been updated (if needed)
- [ ] Changelog has been updated

Thank you for your time.