### PR TITLE
fix: attempt fix of yt-dlp cache on non-linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ scrolled down
 - Adding entries without album adding not intended songs when using split by date
 - Volume parsing if MPD's volume was set to higher value than 255 via external means
 - Fix improper handling of remote theme change
+- Attempted to fix yt-dlp cache on non linux platforms
 
 ## [0.9.0] - 2025-06-23
 


### PR DESCRIPTION
## Description

Change the code which handles searching inside the yt-dlp cache directory to hopefully better handle
platforms other than linux.

### Related issues

https://github.com/mierak/rmpc/issues/591

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
