### PR TITLE
feat: rating system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Added `keep_state_on_song_change` and equivalent flag to cli
 - Added `ignore_leading_the` when sorting entries in browsers
 - More information about the system to debuginfo
+- Stickers are now usable in `browser_song_format`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ All notable changes to this project will be documented in this file.
 - Added `ignore_leading_the` when sorting entries in browsers
 - More information about the system to debuginfo
 - Stickers are now usable in `browser_song_format`
+- Rating support, rating can be set on a song. The rating can be displayed in the queue table and
+browser panes as well as searched for in the Search pane
 
 ### Changed
 

--- a/docs/src/content/docs/next/configuration/keybinds.mdx
+++ b/docs/src/content/docs/next/configuration/keybinds.mdx
@@ -152,12 +152,13 @@ list and controlling search mode.
 #### Rate
 
 A configurable keybind used to rate songs. Allows you to rate either the currently playing song or
-the song(s) under cursor in the browser panes.
+the song(s) under cursor in the browser panes and the queue.
 
 A modal window with options to select is displayed instead when no configuration is provided or if
 the keybind is directly configured to display a modal.
 
-Please check <a href={path("configuration/stickers#rating")}>stickers</a> page for more information.
+Must have stickers configured, please check <a href={path("configuration/stickers#rating")}>stickers</a>
+page for more information.
 
 :::note
 It is highly advised to keep ratings in the 0-10 range. Other MPD clients or some other rmpc
@@ -178,13 +179,13 @@ The rating is applied to the currently plaing song if any when `current` is set 
 
 - Set currently rating of the currently playing song to 6
 
-```rust
+```rust showLineNumbers=false
 Rate(kind: Value(6), current: true),
 ```
 
 - Set currently rating of song(s) under the cursor in either queue or the browesr panes to 3.
 
-```rust
+```rust showLineNumbers=false
 Rate(kind: Value(3), current: false),
 // or equivalent
 Rate(kind: Value(3)),
@@ -193,7 +194,7 @@ Rate(kind: Value(3)),
 - Open a modal which shows options to set rating (0-10) of the currently playing song as well as
   input a custom value or clear the rating completely.
 
-```rust
+```rust showLineNumbers=false
 Rate(kind: Modal(values: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], custom: true), current: false),
 // or equivalent
 Rate(kind: Modal(), current: false),
@@ -201,7 +202,7 @@ Rate(kind: Modal(), current: false),
 
 - Open a modal which shows only text input for rating
 
-```rust
+```rust showLineNumbers=false
 Rate(kind: Modal(values: [], custom: true), current: false),
 ```
 
@@ -243,33 +244,33 @@ Possible values for `all`:
 
 - Add a single item or the marked items at the end of the queue
 
-```rust
+```rust showLineNumbers=false
 AddOptions(kind: Action(all: false, autoplay: None, position: EndOfQueue))
 ```
 
 - Add a single item or the marked items at the start of the queue and start playing from the hovered
   item
 
-```rust
+```rust showLineNumbers=false
 AddOptions(kind: Action(all: false, autoplay: Hovered, position: StartOfQueue))
 ```
 
 - Add a single item or the marked items after the current and start playing from the hovered item
   or from the first item if no item was hovered.
 
-```rust
+```rust showLineNumbers=false
 AddOptions(kind: Action(all: false, autoplay: HoveredOrFirst, position: AfterCurrentSong))
 ```
 
 - Open a modal window with the default configuration
 
-```rust
+```rust showLineNumbers=false
 AddOptions()
 ```
 
 - Open a modal window with the configured options
 
-```rust
+```rust showLineNumbers=false
 AddOptions(kind: Modal([
     ("End of queue and play", (all: false, autoplay: First, position: EndOfQueue),
     ("After the current song", (all: false, autoplay: None, position: AfterCurrentSong),

--- a/docs/src/content/docs/next/configuration/keybinds.mdx
+++ b/docs/src/content/docs/next/configuration/keybinds.mdx
@@ -168,12 +168,14 @@ attempts to stop you.
 
 #### Syntax
 
-`Rate(kind: <kind>, current: <bool>)`
+`Rate(kind: <kind>, current: <bool>, min_rating: <number>, max_rating: <number>)`
 
 Possible values for the action `<kind>` are either a `Modal` or `Value`. Where modal takes a list
 of values to show for rating selector and whether to show a text input for custom rating.
 
 The rating is applied to the currently playing song if any when `current` is set to true.
+
+Min and max rating are 0 and 10 respectively by default if not provided.
 
 ##### Examples
 
@@ -204,6 +206,12 @@ Rate(kind: Modal(), current: false),
 
 ```rust showLineNumbers=false
 Rate(kind: Modal(values: [], custom: true), current: false),
+```
+
+- Open a modal which shows only text input for rating and allows you to set rating up to 100
+
+```rust showLineNumbers=false
+Rate(kind: Modal(values: [], custom: true), current: false, max_rating: 100),
 ```
 
 #### AddOptions

--- a/docs/src/content/docs/next/configuration/keybinds.mdx
+++ b/docs/src/content/docs/next/configuration/keybinds.mdx
@@ -7,6 +7,7 @@ sidebar:
 
 import { LinkCard, CardGrid } from "@astrojs/starlight/components";
 import ConfigValue from "../../../../components/ConfigValue.tsx";
+import { path } from "../data.ts";
 
 ## Keybinds
 
@@ -117,35 +118,92 @@ These keybinds are used to navigate the different tabs and to interact with the 
 some more advanced ones like moving the cursor up or down half a page, moving the cursor to the top or bottom of the
 list and controlling search mode.
 
-|   Default Key   | Action          | Info                                                                                                                               |
-| :-------------: | --------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `<C-c>` / `Esc` | Close           | Close/Stop whatever action is currently going on. Cancel filter, close a modal, etc.                                               |
-|       `k`       | Up              | Up                                                                                                                                 |
-|       `l`       | Right           | Right                                                                                                                              |
-|    `<Space>`    | Select          | Mark current item as selected in the browser, useful for example when you want to add multiple songs to a playlist                 |
-|   `<C-Space>`   | InvertSelection | Inverts the current selected items                                                                                                 |
-|     `Enter`     | Confirm         | Confirm whatever action is currently going on. In browser panes it either enters a directory or adds and plays a song under cursor |
-|       `K`       | MoveUp          | Move current item up, for example song in a queue                                                                                  |
-|       `J`       | MoveDown        | Move current item down, for example song in a queue                                                                                |
-|       `g`       | Top             | Jump all the way to the top                                                                                                        |
-|       `G`       | Bottom          | Jump all the way to the bottom                                                                                                     |
-|     `<C-n>`     | NextResult      | When a filter is active, jump to the next result                                                                                   |
-|       `N`       | PreviousResult  | When a filter is active, jump to the previous result                                                                               |
-|       `j`       | Down            | Down                                                                                                                               |
-|       `D`       | Delete          | Delete. For example a playlist, song from a playlist or wipe the current queue.                                                    |
-|     `<C-u>`     | UpHalf          | Jump by half a screen up                                                                                                           |
-|     `<C-d>`     | DownHalf        | Jump by half a screen down                                                                                                         |
-|                 | PageUp          | Jump a screen up                                                                                                                   |
-|                 | PageDown        | Jump a screen down                                                                                                                 |
-|       `i`       | FocusInput      | Focuses textbox if any is on the screen and is not focused                                                                         |
-|       `/`       | EnterSearch     | Enter search mode                                                                                                                  |
-|       `h`       | Left            | Left                                                                                                                               |
-|       `r`       | Rename          | Rename. Currently only for playlists                                                                                               |
-|       `a`       | Add             | Add item to queue                                                                                                                  |
-|       `A`       | AddAll          | Add all items to queue                                                                                                             |
-|       `B`       | ShowInfo        | Show info about the item under cursor in a modal popup                                                                             |
-|                 | AddOptions()    | Add item(s) to the queue with specified options. More info [in its section](#addoptions)                                           |
-|                 | ContextMenu()   | Show a context menu with select few actions that can be done on the current item(s)                                                |
+|   Default Key   | Action                      | Info                                                                                                                               |
+| :-------------: | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `<C-c>` / `Esc` | Close                       | Close/Stop whatever action is currently going on. Cancel filter, close a modal, etc.                                               |
+|       `k`       | Up                          | Up                                                                                                                                 |
+|       `l`       | Right                       | Right                                                                                                                              |
+|    `<Space>`    | Select                      | Mark current item as selected in the browser, useful for example when you want to add multiple songs to a playlist                 |
+|   `<C-Space>`   | InvertSelection             | Inverts the current selected items                                                                                                 |
+|     `Enter`     | Confirm                     | Confirm whatever action is currently going on. In browser panes it either enters a directory or adds and plays a song under cursor |
+|       `K`       | MoveUp                      | Move current item up, for example song in a queue                                                                                  |
+|       `J`       | MoveDown                    | Move current item down, for example song in a queue                                                                                |
+|       `g`       | Top                         | Jump all the way to the top                                                                                                        |
+|       `G`       | Bottom                      | Jump all the way to the bottom                                                                                                     |
+|     `<C-n>`     | NextResult                  | When a filter is active, jump to the next result                                                                                   |
+|       `N`       | PreviousResult              | When a filter is active, jump to the previous result                                                                               |
+|       `j`       | Down                        | Down                                                                                                                               |
+|       `D`       | Delete                      | Delete. For example a playlist, song from a playlist or wipe the current queue.                                                    |
+|     `<C-u>`     | UpHalf                      | Jump by half a screen up                                                                                                           |
+|     `<C-d>`     | DownHalf                    | Jump by half a screen down                                                                                                         |
+|                 | PageUp                      | Jump a screen up                                                                                                                   |
+|                 | PageDown                    | Jump a screen down                                                                                                                 |
+|       `i`       | FocusInput                  | Focuses textbox if any is on the screen and is not focused                                                                         |
+|       `/`       | EnterSearch                 | Enter search mode                                                                                                                  |
+|       `h`       | Left                        | Left                                                                                                                               |
+|       `r`       | Rename                      | Rename. Currently only for playlists                                                                                               |
+|       `a`       | Add                         | Add item to queue                                                                                                                  |
+|       `A`       | AddAll                      | Add all items to queue                                                                                                             |
+|       `B`       | ShowInfo                    | Show info about the item under cursor in a modal popup                                                                             |
+|                 | [AddOptions()](#addoptions) | Add item(s) to the queue with specified options. More info [in its section](#addoptions)                                           |
+|                 | ContextMenu()               | Show a context menu with select few actions that can be done on the current item(s)                                                |
+|                 | [Rate()](#rate)             | Set song rating, must have <a href={path("configuration/stickers#rating")}>stickers</a> configured                                 |
+
+#### Rate
+
+A configurable keybind used to rate songs. Allows you to rate either the currently playing song or
+the song(s) under cursor in the browser panes.
+
+A modal window with options to select is displayed instead when no configuration is provided or if
+the keybind is directly configured to display a modal.
+
+Please check <a href={path("configuration/stickers#rating")}>stickers</a> page for more information.
+
+:::note
+It is highly advised to keep ratings in the 0-10 range. Other MPD clients or some other rmpc
+functionality might assume that this is the case and will not work otherwise but rmpc will make no
+attempts to stop you.
+:::
+
+#### Syntax
+
+`Rate(kind: <kind>, current: <bool>)`
+
+Possible values for the action `<kind>` are either a `Modal` or `Value`. Where modal takes a list
+of values to show for rating selector and whether to show a text input for custom rating.
+
+The rating is applied to the currently plaing song if any when `current` is set to true.
+
+##### Examples
+
+- Set currently rating of the currently playing song to 6
+
+```rust
+Rate(kind: Value(6), current: true),
+```
+
+- Set currently rating of song(s) under the cursor in either queue or the browesr panes to 3.
+
+```rust
+Rate(kind: Value(3), current: false),
+// or equivalent
+Rate(kind: Value(3)),
+```
+
+- Open a modal which shows options to set rating (0-10) of the currently playing song as well as
+  input a custom value or clear the rating completely.
+
+```rust
+Rate(kind: Modal(values: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], custom: true), current: false),
+// or equivalent
+Rate(kind: Modal(), current: false),
+```
+
+- Open a modal which shows only text input for rating
+
+```rust
+Rate(kind: Modal(values: [], custom: true), current: false),
+```
 
 #### AddOptions
 
@@ -158,7 +216,9 @@ the keybind is directly configured to display a modal.
 
 ##### Syntax
 
-Possible values for the action kind are either a `Modal` or `Action`. Where `Modal` takes a list of
+`AddOptions(kind: <kind>)`
+
+Possible values for the action `<kind>` are either a `Modal` or `Action`. Where `Modal` takes a list of
 tuples of a label and the action configuration and `Action` takes just a single action configuration.
 
 Possible `position`s are: `StartOfQueue`, `EndOfQueue`, `BeforeCurrentSong`, `AfterCurrentSong` and

--- a/docs/src/content/docs/next/configuration/keybinds.mdx
+++ b/docs/src/content/docs/next/configuration/keybinds.mdx
@@ -173,7 +173,7 @@ attempts to stop you.
 Possible values for the action `<kind>` are either a `Modal` or `Value`. Where modal takes a list
 of values to show for rating selector and whether to show a text input for custom rating.
 
-The rating is applied to the currently plaing song if any when `current` is set to true.
+The rating is applied to the currently playing song if any when `current` is set to true.
 
 ##### Examples
 
@@ -183,7 +183,7 @@ The rating is applied to the currently plaing song if any when `current` is set 
 Rate(kind: Value(6), current: true),
 ```
 
-- Set currently rating of song(s) under the cursor in either queue or the browesr panes to 3.
+- Set rating of song(s) under the cursor in either queue or the browser panes to 3.
 
 ```rust showLineNumbers=false
 Rate(kind: Value(3), current: false),

--- a/docs/src/content/docs/next/configuration/stickers.mdx
+++ b/docs/src/content/docs/next/configuration/stickers.mdx
@@ -12,9 +12,13 @@ in the future.
 
 These stickers are simple key-value pairs attached to songs and can be used to store arbitrary data.
 You must have [sticker_file](https://mpd.readthedocs.io/en/latest/mpd.conf.5.html#optional-parameters)
-set in your MPD's configuration to use this functinality.
+set in your MPD's configuration to use this functionality.
 
-| Sticker   | Description                                                                                                                                                                                                  |
+You can display these stickers using the `Sticker("<name>")` property.
+
+## Stickers used by rmpc
+
+| Name      | Description                                                                                                                                                                                                  |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | rating    | Used to store ratings. Has to be a valid positive integer in the 0-10 range. Numbers outside this range are permitted too if configured to do so but might not work in other MPD clients/rmpc functionality. |
 | playCount | How many times a song was played. Requires <a href={path("guides/on_song_change/#track-song-play-count")}>configuration</a>.                                                                                 |

--- a/docs/src/content/docs/next/configuration/stickers.mdx
+++ b/docs/src/content/docs/next/configuration/stickers.mdx
@@ -1,0 +1,20 @@
+---
+title: Stickers
+description: Overview of what stickers are used by rmpc
+sidebar:
+    order: 35
+---
+
+import { path } from "../data.ts";
+
+Rmpc uses MPD's stickers for some of its functionality like rating, liked status and might use more
+in the future.
+
+These stickers are simple key-value data attached to songs and can be used to store arbitrary data.
+You must have [sticker_file](https://mpd.readthedocs.io/en/latest/mpd.conf.5.html#optional-parameters)
+set in your MPD's configuration to use this functinality.
+
+| Sticker   | Description                                                                                                                                                                                                  |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| rating    | Used to store ratings. Has to be a valid positive integer in the 0-10 range. Numbers outside this range are permitted too if configured to do so but might not work in other MPD clients/rmpc functionality. |
+| playCount | How many times a song was played. Requires <a href={path("guides/on_song_change/#track-song-play-count")}>configuration</a>.                                                                                 |

--- a/docs/src/content/docs/next/configuration/stickers.mdx
+++ b/docs/src/content/docs/next/configuration/stickers.mdx
@@ -10,7 +10,7 @@ import { path } from "../data.ts";
 Rmpc uses MPD's stickers for some of its functionality like rating, liked status and might use more
 in the future.
 
-These stickers are simple key-value data attached to songs and can be used to store arbitrary data.
+These stickers are simple key-value pairs attached to songs and can be used to store arbitrary data.
 You must have [sticker_file](https://mpd.readthedocs.io/en/latest/mpd.conf.5.html#optional-parameters)
 set in your MPD's configuration to use this functinality.
 

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -26,6 +26,10 @@ pub fn u64<const V: u64>() -> u64 {
     V
 }
 
+pub fn i32<const V: i32>() -> i32 {
+    V
+}
+
 pub fn i64<const V: i64>() -> i64 {
     V
 }

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -154,3 +154,7 @@ pub fn default_error_color() -> StyleFile {
 pub fn default_status_bar_background_color() -> StyleFile {
     StyleFile { fg: Some("black".to_string()), bg: Some("black".to_string()), modifiers: None }
 }
+
+pub fn rating_options() -> Vec<i32> {
+    vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+}

--- a/src/config/keys/actions.rs
+++ b/src/config/keys/actions.rs
@@ -12,7 +12,7 @@ use crate::{
 
 // Global actions
 
-#[derive(Debug, Display, PartialEq, Eq, Hash, Clone, EnumDiscriminants)]
+#[derive(Debug, Display, Clone, EnumDiscriminants, PartialEq, Eq)]
 #[strum_discriminants(derive(VariantArray))]
 pub enum GlobalAction {
     Quit,
@@ -57,9 +57,7 @@ pub enum GlobalAction {
     },
 }
 
-#[derive(
-    Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash, Clone, Ord, PartialOrd,
-)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 pub enum GlobalActionFile {
     Quit,
     ShowHelp,
@@ -209,10 +207,10 @@ impl ToDescription for GlobalAction {
 
 // Albums actions
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub enum AlbumsActionsFile {}
 
-#[derive(Debug, Display, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, Display, Clone, Copy, PartialEq)]
 pub enum AlbumsActions {}
 
 impl From<AlbumsActionsFile> for AlbumsActions {
@@ -229,10 +227,10 @@ impl ToDescription for AlbumsActions {
 
 // Artists actions
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub enum ArtistsActionsFile {}
 
-#[derive(Debug, Display, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, Display, Clone, Copy, PartialEq)]
 pub enum ArtistsActions {}
 
 impl ToDescription for ArtistsActions {
@@ -249,10 +247,10 @@ impl From<ArtistsActionsFile> for ArtistsActions {
 
 // Directories actions
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub enum DirectoriesActionsFile {}
 
-#[derive(Debug, Display, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, Display, Clone, Copy, PartialEq)]
 pub enum DirectoriesActions {}
 
 impl ToDescription for DirectoriesActions {
@@ -269,7 +267,7 @@ impl From<DirectoriesActionsFile> for DirectoriesActions {
 
 // Logs actions
 #[cfg(debug_assertions)]
-#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 pub enum LogsActionsFile {
     Clear,
     ToggleScroll,
@@ -277,7 +275,7 @@ pub enum LogsActionsFile {
 
 #[cfg(debug_assertions)]
 #[allow(dead_code)]
-#[derive(Debug, Display, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, Display, Clone, Copy, PartialEq, Eq)]
 pub enum LogsActions {
     Clear,
     ToggleScroll,
@@ -306,7 +304,7 @@ impl ToDescription for LogsActions {
 
 // Queue actions
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
 pub enum QueueActionsFile {
     Delete,
     DeleteAll,
@@ -318,7 +316,7 @@ pub enum QueueActionsFile {
     Shuffle,
 }
 
-#[derive(Debug, Display, PartialEq, Eq, Hash, Clone, Copy, EnumDiscriminants)]
+#[derive(Debug, Display, Clone, Copy, EnumDiscriminants, PartialEq, Eq)]
 #[strum_discriminants(derive(VariantArray))]
 pub enum QueueActions {
     Delete,
@@ -372,7 +370,6 @@ impl ToDescription for QueueActions {
     serde::Deserialize,
     PartialEq,
     Eq,
-    Hash,
     Clone,
     Copy,
     Ord,
@@ -399,9 +396,7 @@ impl From<Position> for Option<QueuePosition> {
     }
 }
 
-#[derive(
-    Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash, Clone, Ord, PartialOrd,
-)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
 pub enum AddKind {
     Modal(Vec<(String, AddOpts)>),
     Action(AddOpts),
@@ -460,7 +455,6 @@ impl Default for AddKind {
     serde::Deserialize,
     PartialEq,
     Eq,
-    Hash,
     Clone,
     Copy,
     Ord,
@@ -474,9 +468,7 @@ pub enum AutoplayKind {
     None,
 }
 
-#[derive(
-    Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash, Clone, Copy, Ord, PartialOrd,
-)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, Copy, PartialEq, Eq)]
 pub struct AddOpts {
     #[serde(default)]
     pub autoplay: AutoplayKind,
@@ -506,11 +498,24 @@ impl AddOpts {
     }
 }
 
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq)]
+pub enum RatingKind {
+    Modal { values: Vec<f32>, custom: bool },
+    Value(f32),
+}
+
+impl Default for RatingKind {
+    fn default() -> Self {
+        RatingKind::Modal {
+            values: vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+            custom: true,
+        }
+    }
+}
+
 // Common actions
 
-#[derive(
-    Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash, Clone, Ord, PartialOrd,
-)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 pub enum CommonActionFile {
     Down,
     Up,
@@ -551,11 +556,12 @@ pub enum CommonActionFile {
     ShowInfo,
     ContextMenu {},
     Rating {
-        value: Option<u8>,
+        #[serde(default)]
+        kind: RatingKind,
     },
 }
 
-#[derive(Debug, Display, PartialEq, Eq, Hash, Clone, EnumDiscriminants)]
+#[derive(Debug, Display, Clone, EnumDiscriminants, PartialEq)]
 #[strum_discriminants(derive(VariantArray))]
 pub enum CommonAction {
     Down,
@@ -591,7 +597,7 @@ pub enum CommonAction {
     ShowInfo,
     ContextMenu,
     Rating {
-        value: Option<u8>,
+        kind: RatingKind,
     },
 }
 
@@ -661,7 +667,7 @@ impl ToDescription for CommonAction {
                             },
             CommonAction::ShowInfo => "Show info about item under cursor in a modal popup".into(),
             CommonAction::ContextMenu => "Show context menu".into(),
-            CommonAction::Rating { value } => "".into(), // TODO
+            CommonAction::Rating { kind } => "".into(), // TODO
         }
     }
 }
@@ -740,15 +746,15 @@ impl From<CommonActionFile> for CommonAction {
             CommonActionFile::ShowInfo => CommonAction::ShowInfo,
             CommonActionFile::AddOptions { kind } => CommonAction::AddOptions { kind },
             CommonActionFile::ContextMenu {} => CommonAction::ContextMenu,
-            CommonActionFile::Rating { value } => CommonAction::Rating { value },
+            CommonActionFile::Rating { kind } => CommonAction::Rating { kind },
         }
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub enum SearchActionsFile {}
 
-#[derive(Debug, Display, PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(Debug, Display, Clone, Copy, PartialEq, Eq)]
 pub enum SearchActions {}
 
 impl ToDescription for SearchActions {

--- a/src/config/keys/actions.rs
+++ b/src/config/keys/actions.rs
@@ -664,7 +664,8 @@ impl ToDescription for CommonAction {
                             },
             CommonAction::ShowInfo => "Show info about item under cursor in a modal popup".into(),
             CommonAction::ContextMenu => "Show context menu".into(),
-            CommonAction::Rating { kind } => "".into(), // TODO
+            CommonAction::Rating { kind: RatingKind::Value(val)  } => format!("Set song rating to {val}").into(),
+            CommonAction::Rating { kind: RatingKind::Modal { .. } } => "Open a modal popup with song rating options".into(),
         }
     }
 }

--- a/src/config/keys/actions.rs
+++ b/src/config/keys/actions.rs
@@ -500,7 +500,12 @@ impl AddOpts {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 pub enum RatingKind {
-    Modal { values: Vec<i32>, custom: bool },
+    Modal {
+        #[serde(default = "crate::config::defaults::rating_options")]
+        values: Vec<i32>,
+        #[serde(default = "crate::config::defaults::bool::<true>")]
+        custom: bool,
+    },
     Value(i32),
 }
 
@@ -552,7 +557,7 @@ pub enum CommonActionFile {
     },
     ShowInfo,
     ContextMenu {},
-    Rating {
+    Rate {
         #[serde(default)]
         kind: RatingKind,
         #[serde(default)]
@@ -595,7 +600,7 @@ pub enum CommonAction {
     },
     ShowInfo,
     ContextMenu,
-    Rating {
+    Rate {
         kind: RatingKind,
         current: bool,
     },
@@ -667,10 +672,10 @@ impl ToDescription for CommonAction {
                             },
             CommonAction::ShowInfo => "Show info about item under cursor in a modal popup".into(),
             CommonAction::ContextMenu => "Show context menu".into(),
-            CommonAction::Rating { kind: RatingKind::Value(val), current: false  } => format!("Set song rating to {val}").into(),
-            CommonAction::Rating { kind: RatingKind::Modal { .. }, current: false } => "Open a modal popup with song rating options".into(),
-            CommonAction::Rating { kind: RatingKind::Value(val), current: true  } => format!("Set currently plyaing song's rating to {val}").into(),
-            CommonAction::Rating { kind: RatingKind::Modal { .. }, current: true } => "Open a modal popup with song rating options for the currently playing song".into(),
+            CommonAction::Rate { kind: RatingKind::Value(val), current: false  } => format!("Set song rating to {val}").into(),
+            CommonAction::Rate { kind: RatingKind::Modal { .. }, current: false } => "Open a modal popup with song rating options".into(),
+            CommonAction::Rate { kind: RatingKind::Value(val), current: true  } => format!("Set currently plyaing song's rating to {val}").into(),
+            CommonAction::Rate { kind: RatingKind::Modal { .. }, current: true } => "Open a modal popup with song rating options for the currently playing song".into(),
         }
     }
 }
@@ -749,7 +754,7 @@ impl From<CommonActionFile> for CommonAction {
             CommonActionFile::ShowInfo => CommonAction::ShowInfo,
             CommonActionFile::AddOptions { kind } => CommonAction::AddOptions { kind },
             CommonActionFile::ContextMenu {} => CommonAction::ContextMenu,
-            CommonActionFile::Rating { kind, current } => CommonAction::Rating { kind, current },
+            CommonActionFile::Rate { kind, current } => CommonAction::Rate { kind, current },
         }
     }
 }

--- a/src/config/keys/actions.rs
+++ b/src/config/keys/actions.rs
@@ -555,6 +555,8 @@ pub enum CommonActionFile {
     Rating {
         #[serde(default)]
         kind: RatingKind,
+        #[serde(default)]
+        current: bool,
     },
 }
 
@@ -595,6 +597,7 @@ pub enum CommonAction {
     ContextMenu,
     Rating {
         kind: RatingKind,
+        current: bool,
     },
 }
 
@@ -664,8 +667,10 @@ impl ToDescription for CommonAction {
                             },
             CommonAction::ShowInfo => "Show info about item under cursor in a modal popup".into(),
             CommonAction::ContextMenu => "Show context menu".into(),
-            CommonAction::Rating { kind: RatingKind::Value(val)  } => format!("Set song rating to {val}").into(),
-            CommonAction::Rating { kind: RatingKind::Modal { .. } } => "Open a modal popup with song rating options".into(),
+            CommonAction::Rating { kind: RatingKind::Value(val), current: false  } => format!("Set song rating to {val}").into(),
+            CommonAction::Rating { kind: RatingKind::Modal { .. }, current: false } => "Open a modal popup with song rating options".into(),
+            CommonAction::Rating { kind: RatingKind::Value(val), current: true  } => format!("Set currently plyaing song's rating to {val}").into(),
+            CommonAction::Rating { kind: RatingKind::Modal { .. }, current: true } => "Open a modal popup with song rating options for the currently playing song".into(),
         }
     }
 }
@@ -744,7 +749,7 @@ impl From<CommonActionFile> for CommonAction {
             CommonActionFile::ShowInfo => CommonAction::ShowInfo,
             CommonActionFile::AddOptions { kind } => CommonAction::AddOptions { kind },
             CommonActionFile::ContextMenu {} => CommonAction::ContextMenu,
-            CommonActionFile::Rating { kind } => CommonAction::Rating { kind },
+            CommonActionFile::Rating { kind, current } => CommonAction::Rating { kind, current },
         }
     }
 }

--- a/src/config/keys/actions.rs
+++ b/src/config/keys/actions.rs
@@ -550,6 +550,9 @@ pub enum CommonActionFile {
     },
     ShowInfo,
     ContextMenu {},
+    Rating {
+        value: Option<u8>,
+    },
 }
 
 #[derive(Debug, Display, PartialEq, Eq, Hash, Clone, EnumDiscriminants)]
@@ -587,6 +590,9 @@ pub enum CommonAction {
     },
     ShowInfo,
     ContextMenu,
+    Rating {
+        value: Option<u8>,
+    },
 }
 
 impl ToDescription for CommonAction {
@@ -608,53 +614,54 @@ impl ToDescription for CommonAction {
             CommonAction::NextResult => "When a filter is active, jump to the next result".into(),
             CommonAction::PreviousResult => "When a filter is active, jump to the previous result".into(),
             CommonAction::Select => {
-                        "Mark current item as selected in the browser, useful for example when you want to add multiple songs to a playlist".into()
-                    }
+                                "Mark current item as selected in the browser, useful for example when you want to add multiple songs to a playlist".into()
+                            }
             CommonAction::InvertSelection => "Inverts the current selected items".into(),
             CommonAction::Delete => {
-                        "Delete. For example a playlist, song from a playlist or wipe the current queue".into()
-                    }
+                                "Delete. For example a playlist, song from a playlist or wipe the current queue".into()
+                            }
             CommonAction::Rename => "Rename. Currently only for playlists".into(),
             CommonAction::Close => {
-                        "Close/Stop whatever action is currently going on. Cancel filter, close a modal, etc.".into()
-                    }
+                                "Close/Stop whatever action is currently going on. Cancel filter, close a modal, etc.".into()
+                            }
             CommonAction::Confirm => {
-                        "Confirm whatever action is currently going on. In browser panes it either enters a directory or adds and plays a song under cursor".into()
-                    }
+                                "Confirm whatever action is currently going on. In browser panes it either enters a directory or adds and plays a song under cursor".into()
+                            }
             CommonAction::FocusInput => {
-                        "Focuses textbox if any is on the screen and is not focused".into()
-                    }
+                                "Focuses textbox if any is on the screen and is not focused".into()
+                            }
             CommonAction::PaneDown => "Focus the pane below the current one".into(),
             CommonAction::PaneUp => "Focus the pane above the current one".into(),
             CommonAction::PaneRight => "Focus the pane to the right of the current one".into(),
             CommonAction::PaneLeft => "Focus the pane to the left of the current one".into(),
             CommonAction::AddOptions { kind: AddKind::Modal(items) } => format!("Open add menu modal with {} options", items.len()).into(),
             CommonAction::AddOptions { kind: AddKind::Action(opts) } => {
-                        let mut buf = String::from("Add");
-                        if opts.all {
-                            buf.push_str(" all items");
-                        } else {
-                            buf.push_str(" item");
-                        }
-                        buf.push_str(match opts.position {
-                            Position::AfterCurrentSong => " after the current song",
-                            Position::BeforeCurrentSong => " before the current song",
-                            Position::StartOfQueue => " at the start of the queue",
-                            Position::EndOfQueue => " at the end of the queue",
-                            Position::Replace => " and replace the queue",
-                        });
+                                let mut buf = String::from("Add");
+                                if opts.all {
+                                    buf.push_str(" all items");
+                                } else {
+                                    buf.push_str(" item");
+                                }
+                                buf.push_str(match opts.position {
+                                    Position::AfterCurrentSong => " after the current song",
+                                    Position::BeforeCurrentSong => " before the current song",
+                                    Position::StartOfQueue => " at the start of the queue",
+                                    Position::EndOfQueue => " at the end of the queue",
+                                    Position::Replace => " and replace the queue",
+                                });
 
-                        buf.push_str(match opts.autoplay {
-                            AutoplayKind::First => " and play the first item",
-                            AutoplayKind::Hovered => " and play the hovered item",
-                            AutoplayKind::HoveredOrFirst => " and play hovered item or first if no song is hovered",
-                            AutoplayKind::None => "",
-                        });
+                                buf.push_str(match opts.autoplay {
+                                    AutoplayKind::First => " and play the first item",
+                                    AutoplayKind::Hovered => " and play the hovered item",
+                                    AutoplayKind::HoveredOrFirst => " and play hovered item or first if no song is hovered",
+                                    AutoplayKind::None => "",
+                                });
 
-                        buf.into()
-                    },
+                                buf.into()
+                            },
             CommonAction::ShowInfo => "Show info about item under cursor in a modal popup".into(),
             CommonAction::ContextMenu => "Show context menu".into(),
+            CommonAction::Rating { value } => "".into(), // TODO
         }
     }
 }
@@ -733,6 +740,7 @@ impl From<CommonActionFile> for CommonAction {
             CommonActionFile::ShowInfo => CommonAction::ShowInfo,
             CommonActionFile::AddOptions { kind } => CommonAction::AddOptions { kind },
             CommonActionFile::ContextMenu {} => CommonAction::ContextMenu,
+            CommonActionFile::Rating { value } => CommonAction::Rating { value },
         }
     }
 }

--- a/src/config/keys/actions.rs
+++ b/src/config/keys/actions.rs
@@ -500,16 +500,13 @@ impl AddOpts {
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 pub enum RatingKind {
-    Modal { values: Vec<f32>, custom: bool },
-    Value(f32),
+    Modal { values: Vec<i32>, custom: bool },
+    Value(i32),
 }
 
 impl Default for RatingKind {
     fn default() -> Self {
-        RatingKind::Modal {
-            values: vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
-            custom: true,
-        }
+        RatingKind::Modal { values: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], custom: true }
     }
 }
 

--- a/src/config/keys/mod.rs
+++ b/src/config/keys/mod.rs
@@ -41,7 +41,7 @@ pub struct KeyConfig {
     pub queue: HashMap<Key, QueueActions>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct KeyConfigFile {
     #[serde(default)]
     pub global: HashMap<Key, GlobalActionFile>,

--- a/src/config/keys/mod.rs
+++ b/src/config/keys/mod.rs
@@ -154,11 +154,17 @@ impl Default for KeyConfigFile {
     }
 }
 
-impl From<KeyConfigFile> for KeyConfig {
-    fn from(value: KeyConfigFile) -> Self {
-        KeyConfig {
+impl TryFrom<KeyConfigFile> for KeyConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(value: KeyConfigFile) -> Result<Self, Self::Error> {
+        Ok(KeyConfig {
             global: value.global.into_iter().map(|(k, v)| (k, v.into())).collect(),
-            navigation: value.navigation.into_iter().map(|(k, v)| (k, v.into())).collect(),
+            navigation: value
+                .navigation
+                .into_iter()
+                .map(|(k, v)| -> anyhow::Result<_> { Ok((k, v.try_into()?)) })
+                .collect::<anyhow::Result<_>>()?,
             albums: HashMap::new(),
             artists: HashMap::new(),
             directories: HashMap::new(),
@@ -166,7 +172,7 @@ impl From<KeyConfigFile> for KeyConfig {
             #[cfg(debug_assertions)]
             logs: value.logs.into_iter().map(|(k, v)| (k, v.into())).collect(),
             queue: value.queue.into_iter().map(|(k, v)| (k, v.into())).collect(),
-        }
+        })
     }
 }
 
@@ -175,6 +181,7 @@ pub trait ToDescription {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use std::collections::HashMap;
 
@@ -224,7 +231,7 @@ mod tests {
                                        (Key { key: KeyCode::Char('b'), modifiers: KeyModifiers::SHIFT }, CommonAction::Up)]),
         };
 
-        let result: KeyConfig = input.into();
+        let result: KeyConfig = input.try_into().unwrap();
 
 
         assert_eq!(result, expected);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -410,7 +410,7 @@ impl ConfigFile {
             mpd_idle_read_timeout_ms: self.mpd_idle_read_timeout_ms.map(Duration::from_millis),
             enable_mouse: self.enable_mouse,
             enable_config_hot_reload: self.enable_config_hot_reload,
-            keybinds: self.keybinds.into(),
+            keybinds: self.keybinds.try_into()?,
             select_current_song_on_change: self.select_current_song_on_change,
             center_current_song_on_change: self.center_current_song_on_change,
             search: self.search.try_into()?,

--- a/src/core/command.rs
+++ b/src/core/command.rs
@@ -413,7 +413,7 @@ impl Command {
             })),
             Command::Sticker { cmd: StickerCmd::Find { uri, key } } => {
                 Ok(Box::new(move |client| {
-                    let stickers = client.find_stickers(&uri, &key)?;
+                    let stickers = client.find_stickers(&uri, &key, None)?;
                     println!("{}", serde_json::ser::to_string(&stickers)?);
                     Ok(())
                 }))

--- a/src/core/command.rs
+++ b/src/core/command.rs
@@ -100,7 +100,7 @@ impl Command {
                 }))
             }
             Command::Queue => Ok(Box::new(|client| {
-                let queue = client.playlist_info(false)?;
+                let queue = client.playlist_info()?;
                 if let Some(queue) = queue {
                     println!("{}", serde_json::ser::to_string(&queue)?);
                     Ok(())

--- a/src/core/event_loop.rs
+++ b/src/core/event_loop.rs
@@ -624,7 +624,7 @@ fn handle_idle_event(event: IdleEvent, ctx: &Ctx, result_ui_evs: &mut HashSet<Ui
             }
         }
         IdleEvent::Sticker => {
-            if ctx.should_fetch_stickers {
+            if ctx.stickers_supported {
                 let songs: Vec<_> = ctx.stickers.keys().cloned().collect();
                 ctx.query().id(GLOBAL_STICKERS_UPDATE).replace_id("global_stickers_update").query(
                     move |client| {

--- a/src/core/event_loop.rs
+++ b/src/core/event_loop.rs
@@ -262,7 +262,7 @@ fn main_task<B: Backend + std::io::Write>(
                     }
                     WorkDone::MpdCommandFinished { id, target, data } => match (id, target, data) {
                         (GLOBAL_STICKERS_UPDATE, None, MpdQueryResult::SongStickers(stickers)) => {
-                            ctx.stickers = stickers;
+                            ctx.set_stickers(stickers);
                             render_wanted = true;
                         }
                         (
@@ -625,7 +625,7 @@ fn handle_idle_event(event: IdleEvent, ctx: &Ctx, result_ui_evs: &mut HashSet<Ui
         }
         IdleEvent::Sticker => {
             if ctx.stickers_supported {
-                let songs: Vec<_> = ctx.stickers.keys().cloned().collect();
+                let songs: Vec<_> = ctx.stickers().keys().cloned().collect();
                 ctx.query().id(GLOBAL_STICKERS_UPDATE).replace_id("global_stickers_update").query(
                     move |client| {
                         Ok(MpdQueryResult::SongStickers(client.fetch_song_stickers(songs)?))

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -138,8 +138,9 @@ impl Ctx {
         self.needs_render.replace(false);
         self.rendered_frames.add_assign(1);
 
-        if !self.stickers_to_fetch.borrow().is_empty() {
-            let uris = self.stickers_to_fetch.take().into_iter().collect();
+        let stickers = self.stickers_to_fetch.take();
+        if !stickers.is_empty() {
+            let uris = stickers.into_iter().collect();
             log::debug!(uris:?; "Fetching stickers after frame");
             self.query().id(FETCH_SONG_STICKERS).query(|client| {
                 let stickers = client.fetch_song_stickers(uris)?;

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -236,7 +236,6 @@ impl Ctx {
 }
 
 impl Config {
-    // TODO get rid of this completely?
     fn sticker_support_needed(&self) -> bool {
         self.theme.song_table_format.iter().any(|column| column.prop.kind.contains_stickers())
             || self.theme.browser_song_format.0.iter().any(|prop| prop.kind.contains_stickers())

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -82,7 +82,7 @@ impl Ctx {
         client_request_sender: Sender<ClientRequest>,
         mut scheduler: Scheduler<(Sender<AppEvent>, Sender<ClientRequest>), DefaultTimeProvider>,
     ) -> Result<Self> {
-        let supported_commands: HashSet<String> = client.commands()?.0.into_iter().collect();
+        let supported_commands: HashSet<String> = client.supported_commands.clone();
         let stickers_supported = supported_commands.contains("sticker");
         log::info!(supported_commands:? = supported_commands; "Supported commands by server");
 

--- a/src/mpd/commands/current_song.rs
+++ b/src/mpd/commands/current_song.rs
@@ -13,7 +13,6 @@ pub struct Song {
     pub file: String,
     pub duration: Option<Duration>,
     pub metadata: HashMap<String, MetadataTag>,
-    pub stickers: Option<HashMap<String, String>>,
     pub last_modified: DateTime<Utc>,
     // Option because it is present from mpd 0.24 onwards
     pub added: Option<DateTime<Utc>>,

--- a/src/mpd/mpd_client.rs
+++ b/src/mpd/mpd_client.rs
@@ -1405,19 +1405,19 @@ impl<T: SocketClient> MpdCommand for T {
 
 /// Sticker operators for filtering stickers in `find_stickers`
 /// The *Int variants cast the sticker value to an integer before comparing.
-#[derive(Debug, PartialEq, Clone, Copy, strum::IntoStaticStr, strum::AsRefStr)]
-pub enum StickerFilter<'a> {
-    Equals(&'a str),
-    GreaterThan(&'a str),
-    LessThan(&'a str),
-    Contains(&'a str),
-    StartsWith(&'a str),
+#[derive(Debug, PartialEq, Clone, strum::IntoStaticStr, strum::AsRefStr)]
+pub enum StickerFilter {
+    Equals(String),
+    GreaterThan(String),
+    LessThan(String),
+    Contains(String),
+    StartsWith(String),
     EqualsInt(i32),
     GreaterThanInt(i32),
     LessThanInt(i32),
 }
 
-impl StickerFilter<'_> {
+impl StickerFilter {
     fn as_mpd_str(&self) -> String {
         match self {
             StickerFilter::Equals(value) => format!("= {}", value.quote_and_escape()),

--- a/src/mpd/mpd_client.rs
+++ b/src/mpd/mpd_client.rs
@@ -529,8 +529,9 @@ impl MpdClient for Client<'_> {
     /// Search the database for songs matching FILTER (see Filters).
     /// Parameters have the same meaning as for find, except that search is not
     /// case sensitive.
+    /// `ignore_diacritics` is ignored if not supported by MPD
     fn search(&mut self, filter: &[Filter<'_>], ignore_diacritics: bool) -> MpdResult<Vec<Song>> {
-        if ignore_diacritics {
+        if ignore_diacritics && self.supported_commands.contains("stringnormalization") {
             self.send_start_cmd_list()?;
             self.send_string_normalization_enable(&[StringNormalizationFeature::StripDiacritics])?;
             self.send_search(filter)?;

--- a/src/mpd/proto_client.rs
+++ b/src/mpd/proto_client.rs
@@ -262,11 +262,11 @@ impl<T: SocketClient> ProtoClient for T {
             return Ok(MpdLine::Ok);
         }
         if line.starts_with("ACK") {
-            log::error!(line = line.as_str(); "Read MPD line with error");
+            log::error!(line = line.as_str().trim(); "Read MPD line with error");
             return Err(MpdError::Mpd(MpdFailureResponse::from_str(&line)?));
         }
         line.pop(); // pop the new line
-        log::trace!(line = line.as_str(); "Read MPD line");
+        log::trace!(line = line.as_str().trim(); "Read MPD line");
         Ok(MpdLine::Value(line))
     }
 }

--- a/src/shared/lrc/index.rs
+++ b/src/shared/lrc/index.rs
@@ -252,7 +252,6 @@ mod tests {
             file: String::new(),
             duration,
             metadata,
-            stickers: None,
             last_modified: DateTime::default(),
             added: Some(DateTime::default()),
         }

--- a/src/shared/mpd_client_ext.rs
+++ b/src/shared/mpd_client_ext.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use itertools::Itertools;
 
@@ -6,7 +6,7 @@ use crate::{
     config::keys::actions::Position,
     mpd::{
         QueuePosition,
-        commands::{State, outputs::Outputs},
+        commands::{State, outputs::Outputs, stickers::Stickers},
         errors::{ErrorCode, MpdError, MpdFailureResponse},
         mpd_client::{Filter, FilterKind, MpdClient, MpdCommand, SingleOrRange, Tag},
         proto_client::ProtoClient,
@@ -36,6 +36,10 @@ pub trait MpdClientExt {
     fn create_playlist(&mut self, name: &str, items: Vec<String>) -> Result<(), MpdError>;
     fn next_keep_state(&mut self, keep: bool, state: State) -> Result<(), MpdError>;
     fn prev_keep_state(&mut self, keep: bool, state: State) -> Result<(), MpdError>;
+    fn fetch_song_stickers(
+        &mut self,
+        song_uris: Vec<String>,
+    ) -> Result<HashMap<String, HashMap<String, String>>, MpdError>;
 }
 
 #[derive(Debug, Clone)]
@@ -49,7 +53,6 @@ pub enum MpdDelete {
 pub enum Enqueue {
     File { path: String },
     Playlist { name: String },
-    Search { filter: Vec<(Tag, FilterKind, String)> },
     Find { filter: Vec<(Tag, FilterKind, String)> },
 }
 
@@ -187,13 +190,6 @@ impl<T: MpdClient + MpdCommand + ProtoClient> MpdClientExt for T {
             match item {
                 Enqueue::File { path } => self.send_add(&path, position),
                 Enqueue::Playlist { name } => self.send_load_playlist(&name, position),
-                Enqueue::Search { filter } => self.send_search_add(
-                    &filter
-                        .into_iter()
-                        .map(|(tag, kind, value)| Filter::new_with_kind(tag, value, kind))
-                        .collect_vec(),
-                    position,
-                ),
                 Enqueue::Find { filter } => self.send_find_add(
                     &filter
                         .into_iter()
@@ -400,6 +396,52 @@ impl<T: MpdClient + MpdCommand + ProtoClient> MpdClientExt for T {
                 self.read_ok()
             }
         }
+    }
+
+    fn fetch_song_stickers(
+        &mut self,
+        mut song_uris: Vec<String>,
+    ) -> Result<HashMap<String, HashMap<String, String>>, MpdError> {
+        if song_uris.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut list_ended_with_err = false;
+        let mut i = 0;
+        let mut result = HashMap::new();
+
+        while i < song_uris.len() {
+            self.send_start_cmd_list_ok()?;
+            for uri in &song_uris[i..] {
+                self.send_list_stickers(uri)?;
+            }
+            self.send_execute_cmd_list()?;
+
+            for uri in &mut song_uris[i..] {
+                let res: Result<Stickers, _> = self.read_response();
+                match res {
+                    Ok(stickers) => {
+                        list_ended_with_err = false;
+                        result.insert(std::mem::take(uri), stickers.0);
+                        i += 1;
+                    }
+                    Err(error) => {
+                        log::warn!(error:?, file = uri.as_str(); "Tried to find stickers but unexpected error occurred");
+                        list_ended_with_err = true;
+                        i += 1;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // In case the last sticker was fetched successfully we have to read an
+        // OK as an ack for the whole command list
+        if !list_ended_with_err {
+            self.read_ok()?;
+        }
+
+        Ok(result)
     }
 }
 

--- a/src/shared/mpd_query.rs
+++ b/src/shared/mpd_query.rs
@@ -72,14 +72,6 @@ impl PreviewGroup {
         Self { name, items: Vec::new(), header_style }
     }
 
-    pub fn from(
-        name: Option<&'static str>,
-        header_style: Option<Style>,
-        items: Vec<ListItem<'static>>,
-    ) -> Self {
-        Self { name, items, header_style }
-    }
-
     pub fn push(&mut self, item: ListItem<'static>) {
         self.items.push(item);
     }

--- a/src/shared/mpd_query.rs
+++ b/src/shared/mpd_query.rs
@@ -82,6 +82,7 @@ impl PreviewGroup {
 pub(crate) enum MpdQueryResult {
     SongsList { data: Vec<Song>, origin_path: Option<Vec<String>> },
     Song { data: Song, origin_path: Option<Vec<String>> },
+    SearchResult { data: Vec<Song> },
     LsInfo { data: Vec<String>, origin_path: Option<Vec<String>> },
     DirOrSong { data: Vec<DirOrSong>, origin_path: Option<Vec<String>> },
     AddToPlaylist { playlists: Vec<String>, song_file: String },

--- a/src/shared/mpd_query.rs
+++ b/src/shared/mpd_query.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, sync::Arc};
+use std::{any::Any, collections::HashMap, sync::Arc};
 
 use anyhow::Result;
 use bon::Builder;
@@ -21,6 +21,7 @@ pub const EXTERNAL_COMMAND: &str = "external_command";
 pub const GLOBAL_STATUS_UPDATE: &str = "global_status_update";
 pub const GLOBAL_VOLUME_UPDATE: &str = "global_volume_update";
 pub const GLOBAL_QUEUE_UPDATE: &str = "global_queue_update";
+pub const GLOBAL_STICKERS_UPDATE: &str = "global_stickers_update";
 
 #[derive(derive_more::Debug, Builder)]
 pub(crate) struct MpdQuery {
@@ -87,8 +88,8 @@ impl PreviewGroup {
 #[derive(Debug)]
 #[allow(unused, clippy::large_enum_variant)]
 pub(crate) enum MpdQueryResult {
-    Preview { data: Option<Vec<PreviewGroup>>, origin_path: Option<Vec<String>> },
     SongsList { data: Vec<Song>, origin_path: Option<Vec<String>> },
+    Song { data: Song, origin_path: Option<Vec<String>> },
     LsInfo { data: Vec<String>, origin_path: Option<Vec<String>> },
     DirOrSong { data: Vec<DirOrSong>, origin_path: Option<Vec<String>> },
     AddToPlaylist { playlists: Vec<String>, song_file: String },
@@ -100,6 +101,7 @@ pub(crate) enum MpdQueryResult {
     Outputs(Vec<PartitionedOutput>),
     Decoders(Vec<Decoder>),
     ExternalCommand(Arc<Vec<String>>, Vec<Song>),
+    SongStickers(HashMap<String, HashMap<String, String>>),
     Any(Box<dyn Any + Send + Sync>),
 }
 

--- a/src/tests/fixtures/mod.rs
+++ b/src/tests/fixtures/mod.rs
@@ -70,7 +70,7 @@ pub fn ctx(
         supported_commands: HashSet::new(),
         needs_render: Cell::new(false),
         lrc_index: LrcIndex::default(),
-        should_fetch_stickers: false,
+        stickers_supported: true,
         rendered_frames: 0,
         scheduler,
         db_update_start: None,

--- a/src/tests/fixtures/mod.rs
+++ b/src/tests/fixtures/mod.rs
@@ -1,4 +1,9 @@
-use std::{cell::Cell, collections::HashSet, os::unix::net::UnixStream, time::Instant};
+use std::{
+    cell::Cell,
+    collections::{HashMap, HashSet},
+    os::unix::net::UnixStream,
+    time::Instant,
+};
 
 use crossbeam::channel::{Receiver, Sender, unbounded};
 use ratatui::{Terminal, backend::TestBackend};
@@ -57,6 +62,7 @@ pub fn ctx(
         status: Status::default(),
         config: std::sync::Arc::new(config),
         queue: Vec::default(),
+        stickers: HashMap::new(),
         active_tab: TabName::from("test_tab"),
         app_event_sender: chan1.0.clone(),
         work_sender: work_request_channel.0.clone(),

--- a/src/tests/fixtures/mod.rs
+++ b/src/tests/fixtures/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    cell::Cell,
+    cell::{Cell, RefCell},
     collections::{HashMap, HashSet},
     os::unix::net::UnixStream,
     time::Instant,
@@ -69,6 +69,7 @@ pub fn ctx(
         client_request_sender: client_request_channel.0.clone(),
         supported_commands: HashSet::new(),
         needs_render: Cell::new(false),
+        stickers_to_fetch: RefCell::new(HashSet::new()),
         lrc_index: LrcIndex::default(),
         stickers_supported: true,
         rendered_frames: 0,

--- a/src/tests/fixtures/mpd_client.rs
+++ b/src/tests/fixtures/mpd_client.rs
@@ -63,7 +63,6 @@ pub fn client() -> TestMpdClient {
                     ("title".to_owned(), format!("{}_{}_file_{i}", *artist, *album).into()),
                 ]),
                 duration: Some(Duration::from_secs(i.into())),
-                stickers: None,
                 last_modified: chrono::Utc::now(),
                 added: None,
             })
@@ -306,7 +305,7 @@ impl MpdClient for TestMpdClient {
         todo!("Not yet implemented")
     }
 
-    fn playlist_info(&mut self, _: bool) -> MpdResult<Option<Vec<Song>>> {
+    fn playlist_info(&mut self) -> MpdResult<Option<Vec<Song>>> {
         Ok(Some(self.queue.iter().map(|idx| self.songs[*idx].clone()).collect_vec()))
     }
 
@@ -517,7 +516,6 @@ impl MpdClient for TestMpdClient {
                         id: *idx as u32,
                         duration: None,
                         metadata: HashMap::default(),
-                        stickers: None,
                         last_modified: chrono::Utc::now(),
                         added: None,
                     })

--- a/src/tests/fixtures/mpd_client.rs
+++ b/src/tests/fixtures/mpd_client.rs
@@ -33,6 +33,7 @@ use crate::mpd::{
         MpdClient,
         SaveMode,
         SingleOrRange,
+        StickerFilter,
         StringNormalizationFeature,
         Tag,
         ValueChange,
@@ -622,6 +623,7 @@ impl MpdClient for TestMpdClient {
         &mut self,
         _uri: &str,
         _name: &str,
+        _filter: Option<StickerFilter>,
     ) -> MpdResult<crate::mpd::commands::stickers::StickersWithFile> {
         todo!("Not yet implemented")
     }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -461,18 +461,18 @@ where
             CommonAction::ContextMenu => {
                 self.open_context_menu(ctx)?;
             }
-            CommonAction::Rating { kind: RatingKind::Value(value), current: false } => {
+            CommonAction::Rate { kind: RatingKind::Value(value), current: false } => {
                 let items = self.enqueue(self.items(false).map(|(_, i)| i)).0;
                 ctx.command(move |client| {
                     client.set_sticker_multiple("rating", value.to_string(), items)?;
                     Ok(())
                 });
             }
-            CommonAction::Rating { kind: RatingKind::Modal { values, custom }, current: false } => {
+            CommonAction::Rate { kind: RatingKind::Modal { values, custom }, current: false } => {
                 let items = self.enqueue(self.items(false).map(|(_, i)| i)).0;
                 modal!(ctx, create_rating_modal(items, values.as_slice(), custom, ctx));
             }
-            CommonAction::Rating { kind: _, current: true } => {
+            CommonAction::Rate { kind: _, current: true } => {
                 event.abandon();
             }
         }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -461,18 +461,38 @@ where
             CommonAction::ContextMenu => {
                 self.open_context_menu(ctx)?;
             }
-            CommonAction::Rate { kind: RatingKind::Value(value), current: false } => {
+            CommonAction::Rate {
+                kind: RatingKind::Value(value),
+                current: false,
+                min_rating: _,
+                max_rating: _,
+            } => {
                 let items = self.enqueue(self.items(false).map(|(_, i)| i)).0;
                 ctx.command(move |client| {
                     client.set_sticker_multiple("rating", value.to_string(), items)?;
                     Ok(())
                 });
             }
-            CommonAction::Rate { kind: RatingKind::Modal { values, custom }, current: false } => {
+            CommonAction::Rate {
+                kind: RatingKind::Modal { values, custom },
+                current: false,
+                min_rating,
+                max_rating,
+            } => {
                 let items = self.enqueue(self.items(false).map(|(_, i)| i)).0;
-                modal!(ctx, create_rating_modal(items, values.as_slice(), custom, ctx));
+                modal!(
+                    ctx,
+                    create_rating_modal(
+                        items,
+                        values.as_slice(),
+                        min_rating,
+                        max_rating,
+                        custom,
+                        ctx
+                    )
+                );
             }
-            CommonAction::Rate { kind: _, current: true } => {
+            CommonAction::Rate { kind: _, current: true, min_rating: _, max_rating: _ } => {
                 event.abandon();
             }
         }

--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -461,16 +461,19 @@ where
             CommonAction::ContextMenu => {
                 self.open_context_menu(ctx)?;
             }
-            CommonAction::Rating { kind: RatingKind::Value(value) } => {
+            CommonAction::Rating { kind: RatingKind::Value(value), current: false } => {
                 let items = self.enqueue(self.items(false).map(|(_, i)| i)).0;
                 ctx.command(move |client| {
                     client.set_sticker_multiple("rating", value.to_string(), items)?;
                     Ok(())
                 });
             }
-            CommonAction::Rating { kind: RatingKind::Modal { values, custom } } => {
+            CommonAction::Rating { kind: RatingKind::Modal { values, custom }, current: false } => {
                 let items = self.enqueue(self.items(false).map(|(_, i)| i)).0;
                 modal!(ctx, create_rating_modal(items, values.as_slice(), custom, ctx));
+            }
+            CommonAction::Rating { kind: _, current: true } => {
+                event.abandon();
             }
         }
 

--- a/src/ui/dir_or_song.rs
+++ b/src/ui/dir_or_song.rs
@@ -43,7 +43,7 @@ impl DirOrSong {
         }
     }
 
-    pub fn dir_name_or_file_name(&self) -> Cow<'_, str> {
+    pub fn dir_name_or_file(&self) -> Cow<'_, str> {
         match self {
             DirOrSong::Dir { name, .. } => Cow::Borrowed(name),
             DirOrSong::Song(song) => Cow::Borrowed(&song.file),
@@ -490,7 +490,6 @@ mod ordtest {
                 .iter()
                 .map(|(k, v)| ((*k).to_string(), MetadataTag::Single((*v).to_string())))
                 .collect(),
-            stickers: None,
             last_modified: mtime.parse().unwrap(),
             added: None,
         })
@@ -511,7 +510,7 @@ mod ordtest {
     fn assert_equivalent(actual: &[DirOrSong], expected: &[DirOrSong]) {
         assert_eq!(actual.len(), expected.len());
         for (a, b) in actual.iter().zip(expected.iter()) {
-            assert_eq!(a.dir_name_or_file_name(), b.dir_name_or_file_name());
+            assert_eq!(a.dir_name_or_file(), b.dir_name_or_file());
         }
     }
 

--- a/src/ui/dir_or_song.rs
+++ b/src/ui/dir_or_song.rs
@@ -213,7 +213,8 @@ impl Ord for DirOrSongCustomSort<'_, '_> {
                             }
                         }
                     }
-                    Ordering::Greater
+
+                    if matches!(a, DirOrSong::Song(_)) { Ordering::Greater } else { Ordering::Less }
                 }
             },
         };

--- a/src/ui/dirstack/dir.rs
+++ b/src/ui/dirstack/dir.rs
@@ -4,7 +4,7 @@ use log::error;
 use ratatui::widgets::{ListItem, ListState};
 
 use super::{DirStackItem, state::DirState};
-use crate::{config::Config, shared::macros::status_warn};
+use crate::{ctx::Ctx, shared::macros::status_warn};
 
 #[derive(Debug)]
 pub struct Dir<T: std::fmt::Debug + DirStackItem + Clone + Send> {
@@ -52,39 +52,39 @@ impl<T: std::fmt::Debug + DirStackItem + Clone + Send> Dir<T> {
         self.filter.as_deref()
     }
 
-    pub fn set_filter(&mut self, value: Option<String>, config: &Config) {
+    pub fn set_filter(&mut self, value: Option<String>, ctx: &Ctx) {
         self.matched_item_count = if let Some(ref filter) = value {
-            self.items.iter().filter(|item| item.matches(config, filter)).count()
+            self.items.iter().filter(|item| item.matches(ctx, filter)).count()
         } else {
             0
         };
         self.filter = value;
     }
 
-    pub fn push_filter(&mut self, char: char, config: &Config) {
+    pub fn push_filter(&mut self, char: char, ctx: &Ctx) {
         if let Some(ref mut filter) = self.filter {
             filter.push(char);
             self.matched_item_count =
-                self.items.iter().filter(|item| item.matches(config, filter)).count();
+                self.items.iter().filter(|item| item.matches(ctx, filter)).count();
         }
     }
 
-    pub fn pop_filter(&mut self, config: &Config) {
+    pub fn pop_filter(&mut self, ctx: &Ctx) {
         if let Some(ref mut filter) = self.filter {
             filter.pop();
             self.matched_item_count =
-                self.items.iter().filter(|item| item.matches(config, filter)).count();
+                self.items.iter().filter(|item| item.matches(ctx, filter)).count();
         }
     }
 
-    pub fn to_list_items<'a>(&self, config: &Config) -> Vec<ListItem<'a>> {
+    pub fn to_list_items<'a>(&self, ctx: &Ctx) -> Vec<ListItem<'a>> {
         let mut already_matched: u32 = 0;
         let current_item_idx = self.selected_with_idx().map(|(idx, _)| idx);
         self.items
             .iter()
             .enumerate()
             .map(|(i, item)| {
-                let matches = self.filter.as_ref().is_some_and(|v| item.matches(config, v));
+                let matches = self.filter.as_ref().is_some_and(|v| item.matches(ctx, v));
                 let is_current = current_item_idx.is_some_and(|idx| i == idx);
                 if matches {
                     already_matched = already_matched.saturating_add(1);
@@ -94,7 +94,7 @@ impl<T: std::fmt::Debug + DirStackItem + Clone + Send> Dir<T> {
                 } else {
                     None
                 };
-                item.to_list_item(config, self.marked().contains(&i), matches, content)
+                item.to_list_item(ctx, self.marked().contains(&i), matches, content)
             })
             .collect()
     }
@@ -211,7 +211,7 @@ impl<T: std::fmt::Debug + DirStackItem + Clone + Send> Dir<T> {
         self.state.first();
     }
 
-    pub fn jump_next_matching(&mut self, config: &Config) {
+    pub fn jump_next_matching(&mut self, ctx: &Ctx) {
         let Some(filter) = self.filter.as_ref() else {
             status_warn!("No filter set");
             return;
@@ -224,14 +224,14 @@ impl<T: std::fmt::Debug + DirStackItem + Clone + Send> Dir<T> {
         let length = self.items.len();
         for i in selected + 1..length + selected {
             let i = i % length;
-            if self.items[i].matches(config, filter) {
-                self.state.select(Some(i), config.scrolloff);
+            if self.items[i].matches(ctx, filter) {
+                self.state.select(Some(i), ctx.config.scrolloff);
                 break;
             }
         }
     }
 
-    pub fn jump_previous_matching(&mut self, config: &Config) {
+    pub fn jump_previous_matching(&mut self, ctx: &Ctx) {
         let Some(filter) = self.filter.as_ref() else {
             status_warn!("No filter set");
             return;
@@ -244,14 +244,14 @@ impl<T: std::fmt::Debug + DirStackItem + Clone + Send> Dir<T> {
         let length = self.items.len();
         for i in (0..length).rev() {
             let i = (i + selected) % length;
-            if self.items[i].matches(config, filter) {
-                self.state.select(Some(i), config.scrolloff);
+            if self.items[i].matches(ctx, filter) {
+                self.state.select(Some(i), ctx.config.scrolloff);
                 break;
             }
         }
     }
 
-    pub fn jump_first_matching(&mut self, config: &Config) {
+    pub fn jump_first_matching(&mut self, ctx: &Ctx) {
         let Some(filter) = self.filter.as_ref() else {
             status_warn!("No filter set");
             return;
@@ -260,15 +260,19 @@ impl<T: std::fmt::Debug + DirStackItem + Clone + Send> Dir<T> {
         self.items
             .iter()
             .enumerate()
-            .find(|(_, item)| item.matches(config, filter))
-            .inspect(|(idx, _)| self.state.select(Some(*idx), config.scrolloff));
+            .find(|(_, item)| item.matches(ctx, filter))
+            .inspect(|(idx, _)| self.state.select(Some(*idx), ctx.config.scrolloff));
     }
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+
+    use rstest::rstest;
+
     use super::{Dir, DirState};
+    use crate::{ctx::Ctx, tests::fixtures::ctx};
 
     fn create_subject() -> Dir<String> {
         let mut res = Dir {
@@ -433,10 +437,10 @@ mod tests {
     }
 
     mod jump_next_matching {
-        use crate::{config::Config, ui::dirstack::Dir};
+        use super::*;
 
-        #[test]
-        fn jumps_by_half_viewport() {
+        #[rstest]
+        fn jumps_by_half_viewport(ctx: Ctx) {
             let mut val: Dir<String> = Dir {
                 items: vec!["aa", "ab", "c", "ad"].into_iter().map(ToOwned::to_owned).collect(),
                 ..Default::default()
@@ -446,19 +450,19 @@ mod tests {
 
             val.filter = Some("a".to_string());
 
-            val.jump_next_matching(&Config::default());
+            val.jump_next_matching(&ctx);
             assert_eq!(val.state.get_selected(), Some(1));
 
-            val.jump_next_matching(&Config::default());
+            val.jump_next_matching(&ctx);
             assert_eq!(val.state.get_selected(), Some(3));
         }
     }
 
     mod jump_previous_matching {
-        use crate::{config::Config, ui::dirstack::Dir};
+        use super::*;
 
-        #[test]
-        fn jumps_by_half_viewport() {
+        #[rstest]
+        fn jumps_by_half_viewport(ctx: Ctx) {
             let mut val: Dir<String> = Dir {
                 items: vec!["aa", "ab", "c", "ad", "padding"]
                     .into_iter()
@@ -471,19 +475,19 @@ mod tests {
 
             val.filter = Some("a".to_string());
 
-            val.jump_previous_matching(&Config::default());
+            val.jump_previous_matching(&ctx);
             assert_eq!(val.state.get_selected(), Some(3));
 
-            val.jump_previous_matching(&Config::default());
+            val.jump_previous_matching(&ctx);
             assert_eq!(val.state.get_selected(), Some(1));
         }
     }
 
     mod matched_item_count {
-        use crate::{config::Config, ui::dirstack::Dir};
+        use super::*;
 
-        #[test]
-        fn filter_changes_recounts_matched_items() {
+        #[rstest]
+        fn filter_changes_recounts_matched_items(ctx: Ctx) {
             let mut val: Dir<String> = Dir {
                 items: vec!["aa", "ab", "c", "ad", "padding"]
                     .into_iter()
@@ -492,19 +496,19 @@ mod tests {
                 filter: None,
                 ..Default::default()
             };
-            val.set_filter(Some("a".to_string()), &Config::default());
+            val.set_filter(Some("a".to_string()), &ctx);
             assert_eq!(val.matched_item_count, 4);
 
-            val.push_filter('d', &Config::default());
+            val.push_filter('d', &ctx);
             assert_eq!(val.matched_item_count, 2);
 
-            val.pop_filter(&Config::default());
+            val.pop_filter(&ctx);
             assert_eq!(val.matched_item_count, 4);
 
-            val.pop_filter(&Config::default());
+            val.pop_filter(&ctx);
             assert_eq!(val.matched_item_count, 5);
 
-            val.set_filter(None, &Config::default());
+            val.set_filter(None, &ctx);
             assert_eq!(val.matched_item_count, 0);
         }
     }

--- a/src/ui/dirstack/mod.rs
+++ b/src/ui/dirstack/mod.rs
@@ -14,20 +14,20 @@ pub use stack::DirStack;
 pub use state::DirState;
 
 use super::dir_or_song::DirOrSong;
-use crate::{config::Config, mpd::commands::Song};
+use crate::{ctx::Ctx, mpd::commands::Song};
 
 pub trait DirStackItem {
     fn as_path(&self) -> &str;
-    fn matches(&self, config: &Config, filter: &str) -> bool;
+    fn matches(&self, ctx: &Ctx, filter: &str) -> bool;
     fn to_list_item<'a>(
         &self,
-        config: &Config,
+        ctx: &Ctx,
         is_marked: bool,
         matches_filter: bool,
         additional_content: Option<String>,
     ) -> ListItem<'a>;
-    fn to_list_item_simple<'a>(&self, config: &Config) -> ListItem<'a> {
-        self.to_list_item(config, false, false, None)
+    fn to_list_item_simple<'a>(&self, ctx: &Ctx) -> ListItem<'a> {
+        self.to_list_item(ctx, false, false, None)
     }
 }
 
@@ -39,79 +39,69 @@ impl DirStackItem for DirOrSong {
         }
     }
 
-    fn matches(&self, config: &Config, filter: &str) -> bool {
+    fn matches(&self, ctx: &Ctx, filter: &str) -> bool {
         match self {
             DirOrSong::Dir { name, .. } => if name.is_empty() { "Untitled" } else { name.as_str() }
                 .to_lowercase()
                 .contains(&filter.to_lowercase()),
-            DirOrSong::Song(s) => s.matches(config.theme.browser_song_format.0.as_slice(), filter),
+            DirOrSong::Song(s) => {
+                let stickers = ctx.stickers.get(&s.file);
+                s.matches(ctx.config.theme.browser_song_format.0.as_slice(), stickers, filter)
+            }
         }
     }
 
     fn to_list_item<'a>(
         &self,
-        config: &Config,
+        ctx: &Ctx,
         is_marked: bool,
         matches_filter: bool,
         additional_content: Option<String>,
     ) -> ListItem<'a> {
-        let marker_span = if is_marked {
-            Span::styled(config.theme.symbols.marker.clone(), config.theme.highlighted_item_style)
-        } else {
-            Span::from(" ".repeat(config.theme.symbols.marker.chars().count()))
-        };
-
-        let mut value = match self {
-            DirOrSong::Dir { name, playlist: is_playlist, .. } => Line::from(vec![
-                marker_span,
-                if *is_playlist {
+        match self {
+            DirOrSong::Dir { name, playlist: is_playlist, .. } => {
+                let config = &ctx.config;
+                let marker_span = if is_marked {
                     Span::styled(
-                        config.theme.symbols.playlist.clone(),
-                        config.theme.symbols.playlist_style.unwrap_or_default(),
+                        config.theme.symbols.marker.clone(),
+                        config.theme.highlighted_item_style,
                     )
                 } else {
-                    Span::styled(
-                        config.theme.symbols.dir.clone(),
-                        config.theme.symbols.dir_style.unwrap_or_default(),
-                    )
-                },
-                Span::from(" "),
-                Span::from(if name.is_empty() {
-                    Cow::Borrowed("Untitled")
-                } else {
-                    Cow::Owned(name.to_owned())
-                }),
-            ]),
-            DirOrSong::Song(s) => {
-                let spans = [
+                    Span::from(" ".repeat(config.theme.symbols.marker.chars().count()))
+                };
+                let mut value = Line::from(vec![
                     marker_span,
-                    Span::styled(
-                        config.theme.symbols.song.clone(),
-                        config.theme.symbols.song_style.unwrap_or_default(),
-                    ),
-                    Span::from(" "),
-                ]
-                .into_iter()
-                .chain(config.theme.browser_song_format.0.iter().map(|prop| {
-                    Span::from(
-                        prop.as_string(
-                            Some(s),
-                            &config.theme.format_tag_separator,
-                            config.theme.multiple_tag_resolution_strategy,
+                    if *is_playlist {
+                        Span::styled(
+                            config.theme.symbols.playlist.clone(),
+                            config.theme.symbols.playlist_style.unwrap_or_default(),
                         )
-                        .unwrap_or_default(),
-                    )
-                }));
-                Line::from(spans.collect_vec())
+                    } else {
+                        Span::styled(
+                            config.theme.symbols.dir.clone(),
+                            config.theme.symbols.dir_style.unwrap_or_default(),
+                        )
+                    },
+                    Span::from(" "),
+                    Span::from(if name.is_empty() {
+                        Cow::Borrowed("Untitled")
+                    } else {
+                        Cow::Owned(name.to_owned())
+                    }),
+                ]);
+
+                if let Some(content) = additional_content {
+                    value.push_span(Span::raw(content));
+                }
+                if matches_filter {
+                    ListItem::from(value).style(config.theme.highlighted_item_style)
+                } else {
+                    ListItem::from(value)
+                }
             }
-        };
-        if let Some(content) = additional_content {
-            value.push_span(Span::raw(content));
-        }
-        if matches_filter {
-            ListItem::from(value).style(config.theme.highlighted_item_style)
-        } else {
-            ListItem::from(value)
+            DirOrSong::Song(s) => {
+                s.to_list_item(ctx, is_marked, matches_filter, additional_content)
+            }
         }
     }
 }
@@ -121,41 +111,56 @@ impl DirStackItem for Song {
         &self.file
     }
 
-    fn matches(&self, config: &Config, filter: &str) -> bool {
-        self.matches(config.theme.browser_song_format.0.as_slice(), filter)
+    fn matches(&self, ctx: &Ctx, filter: &str) -> bool {
+        let song_stickers = ctx.stickers.get(&self.file);
+        self.matches(ctx.config.theme.browser_song_format.0.as_slice(), song_stickers, filter)
     }
 
     fn to_list_item<'a>(
         &self,
-        config: &Config,
+        ctx: &Ctx,
         is_marked: bool,
         matches_filter: bool,
         additional_content: Option<String>,
     ) -> ListItem<'a> {
+        let config = &ctx.config;
         let marker_span = if is_marked {
             Span::styled(config.theme.symbols.marker.clone(), config.theme.highlighted_item_style)
         } else {
             Span::from(" ".repeat(config.theme.symbols.marker.chars().count()))
         };
 
-        let title = self.title_str(&config.theme.format_tag_separator).into_owned();
-        let artist = self.artist_str(&config.theme.format_tag_separator).into_owned();
-        let separator_span = Span::from(" - ");
-        let icon_span = Span::styled(
-            format!("{} ", config.theme.symbols.song),
-            config.theme.symbols.song_style.unwrap_or_default(),
-        );
-        let mut result =
-            vec![marker_span, icon_span, Span::from(artist), separator_span, Span::from(title)];
-        if let Some(content) = additional_content {
-            result.push(Span::raw(content));
-        }
-        let mut result = ListItem::new(Line::from(result));
-        if matches_filter {
-            result = result.style(config.theme.highlighted_item_style);
-        }
+        let stickers = ctx.stickers.get(&self.file);
+        let spans = [
+            marker_span,
+            Span::styled(
+                config.theme.symbols.song.clone(),
+                config.theme.symbols.song_style.unwrap_or_default(),
+            ),
+            Span::from(" "),
+        ]
+        .into_iter()
+        .chain(config.theme.browser_song_format.0.iter().map(|prop| {
+            Span::from(
+                prop.as_string(
+                    Some(self),
+                    stickers,
+                    &config.theme.format_tag_separator,
+                    config.theme.multiple_tag_resolution_strategy,
+                )
+                .unwrap_or_default(),
+            )
+        }));
+        let mut value = Line::from(spans.collect_vec());
 
-        result
+        if let Some(content) = additional_content {
+            value.push_span(Span::raw(content));
+        }
+        if matches_filter {
+            ListItem::from(value).style(config.theme.highlighted_item_style)
+        } else {
+            ListItem::from(value)
+        }
     }
 }
 
@@ -208,17 +213,18 @@ impl DirStackItem for String {
         self
     }
 
-    fn matches(&self, _config: &Config, filter: &str) -> bool {
+    fn matches(&self, _ctx: &Ctx, filter: &str) -> bool {
         self.to_lowercase().contains(&filter.to_lowercase())
     }
 
     fn to_list_item<'a>(
         &self,
-        config: &Config,
+        ctx: &Ctx,
         is_marked: bool,
         matches_filter: bool,
         _additional_content: Option<String>,
     ) -> ListItem<'a> {
+        let config = &ctx.config;
         let marker_span = if is_marked {
             Span::styled(config.theme.symbols.marker.clone(), config.theme.highlighted_item_style)
         } else {

--- a/src/ui/dirstack/mod.rs
+++ b/src/ui/dirstack/mod.rs
@@ -61,8 +61,7 @@ impl DirStackItem for DirOrSong {
                 .to_lowercase()
                 .contains(&filter.to_lowercase()),
             DirOrSong::Song(s) => {
-                let stickers = ctx.stickers.get(&s.file);
-                s.matches(ctx.config.theme.browser_song_format.0.as_slice(), stickers, filter)
+                s.matches(ctx.config.theme.browser_song_format.0.as_slice(), filter, ctx)
             }
         }
     }
@@ -134,13 +133,11 @@ impl DirStackItem for Song {
     fn to_file_preview(&self, ctx: &Ctx) -> Vec<PreviewGroup> {
         let key_style = ctx.config.theme.preview_label_style;
         let group_style = ctx.config.theme.preview_metadata_group_style;
-        let stickers = ctx.stickers.get(&self.file);
-        self.to_preview(key_style, group_style, stickers)
+        self.to_preview(key_style, group_style, ctx)
     }
 
     fn matches(&self, ctx: &Ctx, filter: &str) -> bool {
-        let song_stickers = ctx.stickers.get(&self.file);
-        self.matches(ctx.config.theme.browser_song_format.0.as_slice(), song_stickers, filter)
+        self.matches(ctx.config.theme.browser_song_format.0.as_slice(), filter, ctx)
     }
 
     fn to_list_item<'a>(
@@ -157,7 +154,6 @@ impl DirStackItem for Song {
             Span::from(" ".repeat(config.theme.symbols.marker.chars().count()))
         };
 
-        let stickers = ctx.stickers.get(&self.file);
         let spans = [
             marker_span,
             Span::styled(
@@ -171,9 +167,9 @@ impl DirStackItem for Song {
             Span::from(
                 prop.as_string(
                     Some(self),
-                    stickers,
                     &config.theme.format_tag_separator,
                     config.theme.multiple_tag_resolution_strategy,
+                    ctx,
                 )
                 .unwrap_or_default(),
             )

--- a/src/ui/dirstack/stack.rs
+++ b/src/ui/dirstack/stack.rs
@@ -1,11 +1,10 @@
 use super::{DirStackItem, dir::Dir, state::DirState};
-use crate::shared::mpd_query::PreviewGroup;
 
 #[derive(Debug)]
 pub struct DirStack<T: std::fmt::Debug + DirStackItem + Clone + Send> {
     current: Dir<T>,
     others: Vec<Dir<T>>,
-    preview: Option<Vec<PreviewGroup>>,
+    preview: Option<Vec<T>>,
     path: Vec<String>,
 }
 
@@ -65,7 +64,7 @@ impl<T: std::fmt::Debug + DirStackItem + Clone + Send> DirStack<T> {
     }
 
     /// Returns the element at the second element from the top of the stack
-    pub fn preview(&self) -> Option<&Vec<PreviewGroup>> {
+    pub fn preview(&self) -> Option<&Vec<T>> {
         self.preview.as_ref()
     }
 
@@ -76,7 +75,7 @@ impl<T: std::fmt::Debug + DirStackItem + Clone + Send> DirStack<T> {
     }
 
     /// Returns the element at the second element from the top of the stack
-    pub fn set_preview(&mut self, preview: Option<Vec<PreviewGroup>>) -> &Self {
+    pub fn set_preview(&mut self, preview: Option<Vec<T>>) -> &Self {
         self.preview = preview;
         self
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -39,7 +39,7 @@ use crate::{
     mpd::{
         commands::{State, idle::IdleEvent},
         errors::{ErrorCode, MpdError, MpdFailureResponse},
-        mpd_client::{FilterKind, MpdClient, MpdCommand, ValueChange},
+        mpd_client::{MpdClient, MpdCommand, ValueChange},
         proto_client::ProtoClient,
         version::Version,
     },
@@ -845,40 +845,6 @@ impl Level {
             Level::Error => config.error,
             Level::Info => config.info,
         }
-    }
-}
-
-impl From<&FilterKind> for &'static str {
-    fn from(value: &FilterKind) -> Self {
-        match value {
-            FilterKind::Exact => "Exact match",
-            FilterKind::Contains => "Contains value",
-            FilterKind::StartsWith => "Starts with value",
-            FilterKind::Regex => "Regex",
-        }
-    }
-}
-
-impl std::fmt::Display for FilterKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            FilterKind::Exact => write!(f, "Exact match"),
-            FilterKind::Contains => write!(f, "Contains value"),
-            FilterKind::StartsWith => write!(f, "Starts with value"),
-            FilterKind::Regex => write!(f, "Regex"),
-        }
-    }
-}
-
-impl FilterKind {
-    fn cycle(&mut self) -> &mut Self {
-        *self = match self {
-            FilterKind::Exact => FilterKind::Contains,
-            FilterKind::Contains => FilterKind::StartsWith,
-            FilterKind::StartsWith => FilterKind::Regex,
-            FilterKind::Regex => FilterKind::Exact,
-        };
-        self
     }
 }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -81,6 +81,7 @@ pub struct Ui<'ui> {
 
 const OPEN_DECODERS_MODAL: &str = "open_decoders_modal";
 const OPEN_OUTPUTS_MODAL: &str = "open_outputs_modal";
+const FETCH_SONG_STICKERS: &str = "fetch_song_stickers";
 
 macro_rules! active_tab_call {
     ($self:ident, $ctx:ident, $fn:ident($($param:expr),+)) => {
@@ -752,6 +753,14 @@ impl<'ui> Ui<'ui> {
                 }
                 (OPEN_DECODERS_MODAL, MpdQueryResult::Decoders(decoders)) => {
                     modal!(ctx, DecodersModal::new(decoders));
+                }
+                (FETCH_SONG_STICKERS, MpdQueryResult::SongStickers(stickers)) => {
+                    for (k, v) in stickers {
+                        // Assume all stickers were fetched for each song so simple replace is
+                        // enough
+                        ctx.stickers.insert(k, v);
+                    }
+                    ctx.render()?;
                 }
                 (id, mut data) => {
                     // TODO a proper modal target

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -35,7 +35,7 @@ use crate::{
         command::{create_env, run_external},
         config_watcher::ERROR_CONFIG_MODAL_ID,
     },
-    ctx::Ctx,
+    ctx::{Ctx, FETCH_SONG_STICKERS},
     mpd::{
         commands::{State, idle::IdleEvent},
         errors::{ErrorCode, MpdError, MpdFailureResponse},
@@ -81,7 +81,6 @@ pub struct Ui<'ui> {
 
 const OPEN_DECODERS_MODAL: &str = "open_decoders_modal";
 const OPEN_OUTPUTS_MODAL: &str = "open_outputs_modal";
-const FETCH_SONG_STICKERS: &str = "fetch_song_stickers";
 
 macro_rules! active_tab_call {
     ($self:ident, $ctx:ident, $fn:ident($($param:expr),+)) => {
@@ -759,7 +758,7 @@ impl<'ui> Ui<'ui> {
                     for (k, v) in stickers {
                         // Assume all stickers were fetched for each song so simple replace is
                         // enough
-                        ctx.stickers.insert(k, v);
+                        ctx.set_song_stickers(k, v);
                     }
                     ctx.render()?;
                 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -278,7 +278,7 @@ impl<'ui> Ui<'ui> {
                             if any_non_default { Some(section) } else { None }
                         })
                         .input_section(ctx, "New partition:", |section| {
-                            section.action(|ctx, value| {
+                            let section = section.action(|ctx, value| {
                                 if !value.is_empty() {
                                     ctx.command(move |client| {
                                         client.send_start_cmd_list()?;
@@ -289,7 +289,8 @@ impl<'ui> Ui<'ui> {
                                         Ok(())
                                     });
                                 }
-                            })
+                            });
+                            Some(section)
                         })
                         .list_section(ctx, |section| Some(section.item("Cancel", |_ctx| Ok(()))))
                         .build();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -539,7 +539,7 @@ impl<'ui> Ui<'ui> {
                 reason = "Future expansion, remove when adding other actions"
             )]
             match action {
-                CommonAction::Rating { kind, current: true } => {
+                CommonAction::Rate { kind, current: true } => {
                     if let Some((_, song)) = ctx.find_current_song_in_queue() {
                         match kind {
                             RatingKind::Modal { values, custom } => {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -539,14 +539,21 @@ impl<'ui> Ui<'ui> {
                 reason = "Future expansion, remove when adding other actions"
             )]
             match action {
-                CommonAction::Rate { kind, current: true } => {
+                CommonAction::Rate { kind, current: true, min_rating, max_rating } => {
                     if let Some((_, song)) = ctx.find_current_song_in_queue() {
                         match kind {
                             RatingKind::Modal { values, custom } => {
                                 let items = vec![Enqueue::File { path: song.file.clone() }];
                                 modal!(
                                     ctx,
-                                    create_rating_modal(items, values.as_slice(), *custom, ctx)
+                                    create_rating_modal(
+                                        items,
+                                        values.as_slice(),
+                                        *min_rating,
+                                        *max_rating,
+                                        *custom,
+                                        ctx
+                                    )
                                 );
                             }
                             RatingKind::Value(value) => {

--- a/src/ui/modals/menu/mod.rs
+++ b/src/ui/modals/menu/mod.rs
@@ -171,6 +171,8 @@ impl Section for SectionType<'_> {
 pub fn create_rating_modal<'a>(
     items: Vec<Enqueue>,
     values: &[i32],
+    min_rating: i32,
+    max_rating: i32,
     custom: bool,
     ctx: &Ctx,
 ) -> MenuModal<'a> {
@@ -184,10 +186,20 @@ pub fn create_rating_modal<'a>(
             }
 
             let section = section.action(move |ctx, value| {
-                let Ok(_) = value.trim().parse::<i32>() else {
+                let Ok(v) = value.trim().parse::<i32>() else {
                     status_error!("Rating must be a valid number");
                     return;
                 };
+
+                if v < min_rating {
+                    status_error!("Rating must be at least {min_rating}");
+                    return;
+                }
+
+                if v > max_rating {
+                    status_error!("Rating must be at most {max_rating}");
+                    return;
+                }
 
                 if !value.trim().is_empty() {
                     ctx.command(move |client| {

--- a/src/ui/modals/menu/mod.rs
+++ b/src/ui/modals/menu/mod.rs
@@ -167,6 +167,64 @@ impl Section for SectionType<'_> {
     }
 }
 
+pub fn create_rating_modal<'a>(
+    items: Vec<Enqueue>,
+    values: &[f32],
+    custom: bool,
+    ctx: &Ctx,
+) -> MenuModal<'a> {
+    let clone = items.clone();
+    let clone2 = items.clone();
+    MenuModal::new(ctx)
+        .select_section(ctx, move |mut section| {
+            if values.is_empty() {
+                return None;
+            }
+
+            for i in values {
+                section.add_item(i.to_string(), i.to_string());
+            }
+
+            section.action(move |ctx, value| {
+                ctx.command(move |client| {
+                    client.set_sticker_multiple("rating", value, clone)?;
+                    Ok(())
+                });
+                Ok(())
+            });
+
+            Some(section)
+        })
+        .input_section(ctx, "Rating", move |section| {
+            if !custom {
+                return None;
+            }
+
+            let section = section.action(move |ctx, value| {
+                if !value.trim().is_empty() {
+                    ctx.command(move |client| {
+                        client.set_sticker_multiple("rating", value, clone2)?;
+                        Ok(())
+                    });
+                }
+            });
+
+            Some(section)
+        })
+        .list_section(ctx, |section| {
+            let section = section.item("Clear rating", |ctx| {
+                ctx.command(move |client| {
+                    client.delete_sticker_multiple("rating", items)?;
+                    Ok(())
+                });
+                Ok(())
+            });
+            let section = section.item("Cancel", |_ctx| Ok(()));
+            Some(section)
+        })
+        .build()
+}
+
 pub fn create_add_modal<'a>(
     opts: Vec<(String, AddOpts, (Vec<Enqueue>, Option<usize>))>,
     ctx: &Ctx,

--- a/src/ui/modals/menu/mod.rs
+++ b/src/ui/modals/menu/mod.rs
@@ -16,12 +16,14 @@ use crate::{
         key_event::KeyEvent,
         mpd_client_ext::{Enqueue, MpdClientExt as _},
     },
+    ui::modals::menu::select_section::SelectSection,
 };
 
 mod input_section;
 mod list_section;
 pub mod modal;
 mod multi_action_section;
+mod select_section;
 
 trait Section {
     fn down(&mut self) -> bool;
@@ -50,6 +52,7 @@ trait Section {
 #[derive(Debug)]
 enum SectionType<'a> {
     Menu(ListSection),
+    Select(SelectSection),
     Multi(MultiActionSection<'a>),
     Input(InputSection<'a>),
 }
@@ -60,6 +63,7 @@ impl Section for SectionType<'_> {
             SectionType::Menu(s) => s.down(),
             SectionType::Multi(s) => s.down(),
             SectionType::Input(s) => s.down(),
+            SectionType::Select(s) => s.down(),
         }
     }
 
@@ -68,6 +72,7 @@ impl Section for SectionType<'_> {
             SectionType::Menu(s) => s.up(),
             SectionType::Multi(s) => s.up(),
             SectionType::Input(s) => s.up(),
+            SectionType::Select(s) => s.up(),
         }
     }
 
@@ -76,6 +81,7 @@ impl Section for SectionType<'_> {
             SectionType::Menu(s) => s.right(),
             SectionType::Multi(s) => s.right(),
             SectionType::Input(s) => s.right(),
+            SectionType::Select(s) => s.right(),
         }
     }
 
@@ -84,6 +90,7 @@ impl Section for SectionType<'_> {
             SectionType::Menu(s) => s.left(),
             SectionType::Multi(s) => s.left(),
             SectionType::Input(s) => s.left(),
+            SectionType::Select(s) => s.left(),
         }
     }
 
@@ -92,6 +99,7 @@ impl Section for SectionType<'_> {
             SectionType::Menu(s) => s.unselect(),
             SectionType::Multi(s) => s.unselect(),
             SectionType::Input(s) => s.unselect(),
+            SectionType::Select(s) => s.unselect(),
         }
     }
 
@@ -100,6 +108,7 @@ impl Section for SectionType<'_> {
             SectionType::Menu(s) => s.unfocus(),
             SectionType::Multi(s) => s.unfocus(),
             SectionType::Input(s) => s.unfocus(),
+            SectionType::Select(s) => s.unfocus(),
         }
     }
 
@@ -108,6 +117,7 @@ impl Section for SectionType<'_> {
             SectionType::Menu(s) => s.confirm(ctx),
             SectionType::Multi(s) => s.confirm(ctx),
             SectionType::Input(s) => s.confirm(ctx),
+            SectionType::Select(s) => s.confirm(ctx),
         }
     }
 
@@ -116,6 +126,7 @@ impl Section for SectionType<'_> {
             SectionType::Menu(s) => s.len(),
             SectionType::Multi(s) => s.len(),
             SectionType::Input(s) => s.len(),
+            SectionType::Select(s) => s.len(),
         }
     }
 
@@ -124,6 +135,7 @@ impl Section for SectionType<'_> {
             SectionType::Menu(s) => Widget::render(s, area, buf),
             SectionType::Multi(s) => Widget::render(s, area, buf),
             SectionType::Input(s) => Widget::render(s, area, buf),
+            SectionType::Select(s) => Widget::render(s, area, buf),
         }
     }
 
@@ -132,6 +144,7 @@ impl Section for SectionType<'_> {
             SectionType::Menu(s) => s.key_input(key, ctx),
             SectionType::Multi(s) => s.key_input(key, ctx),
             SectionType::Input(s) => s.key_input(key, ctx),
+            SectionType::Select(s) => s.key_input(key, ctx),
         }
     }
 
@@ -140,6 +153,7 @@ impl Section for SectionType<'_> {
             SectionType::Menu(s) => s.left_click(pos),
             SectionType::Multi(s) => s.left_click(pos),
             SectionType::Input(s) => s.left_click(pos),
+            SectionType::Select(s) => s.left_click(pos),
         }
     }
 
@@ -148,6 +162,7 @@ impl Section for SectionType<'_> {
             SectionType::Menu(s) => s.double_click(pos, ctx),
             SectionType::Multi(s) => s.double_click(pos, ctx),
             SectionType::Input(s) => s.double_click(pos, ctx),
+            SectionType::Select(s) => s.double_click(pos, ctx),
         }
     }
 }

--- a/src/ui/modals/menu/mod.rs
+++ b/src/ui/modals/menu/mod.rs
@@ -169,7 +169,7 @@ impl Section for SectionType<'_> {
 
 pub fn create_rating_modal<'a>(
     items: Vec<Enqueue>,
-    values: &[f32],
+    values: &[i32],
     custom: bool,
     ctx: &Ctx,
 ) -> MenuModal<'a> {

--- a/src/ui/modals/menu/modal.rs
+++ b/src/ui/modals/menu/modal.rs
@@ -25,7 +25,7 @@ use crate::{
         key_event::KeyEvent,
         mouse_event::{MouseEvent, MouseEventKind},
     },
-    ui::modals::{Modal, RectExt as _},
+    ui::modals::{Modal, RectExt as _, menu::select_section::SelectSection},
 };
 
 #[derive(Debug)]
@@ -247,6 +247,20 @@ impl<'a> MenuModal<'a> {
         let section = cb(section);
         self.sections.push(SectionType::Input(section));
         self.areas.push(Rect::default());
+        self
+    }
+
+    pub fn select_section(
+        mut self,
+        ctx: &Ctx,
+        cb: impl FnOnce(SelectSection) -> Option<SelectSection>,
+    ) -> Self {
+        let section = SelectSection::new(ctx.config.theme.current_item_style);
+        let section = cb(section);
+        if let Some(section) = section {
+            self.sections.push(SectionType::Select(section));
+            self.areas.push(Rect::default());
+        }
         self
     }
 

--- a/src/ui/modals/menu/modal.rs
+++ b/src/ui/modals/menu/modal.rs
@@ -241,12 +241,14 @@ impl<'a> MenuModal<'a> {
         mut self,
         ctx: &Ctx,
         label: impl Into<Cow<'a, str>>,
-        cb: impl FnOnce(InputSection) -> InputSection<'_>,
+        cb: impl FnOnce(InputSection) -> Option<InputSection<'_>>,
     ) -> Self {
         let section = InputSection::new(label, ctx.config.theme.current_item_style);
         let section = cb(section);
-        self.sections.push(SectionType::Input(section));
-        self.areas.push(Rect::default());
+        if let Some(section) = section {
+            self.sections.push(SectionType::Input(section));
+            self.areas.push(Rect::default());
+        }
         self
     }
 

--- a/src/ui/modals/menu/select_section.rs
+++ b/src/ui/modals/menu/select_section.rs
@@ -1,0 +1,149 @@
+use anyhow::Result;
+use ratatui::{
+    buffer::Buffer,
+    layout::{Position, Rect},
+    style::Style,
+    text::Text,
+    widgets::Widget,
+};
+
+use super::Section;
+use crate::{ctx::Ctx, shared::ext::rect::RectExt};
+
+#[derive(derive_more::Debug, Default)]
+pub struct SelectSection {
+    pub items: Vec<SelectItem>,
+    pub area: Rect,
+    pub selected_idx: Option<usize>,
+    pub current_item_style: Style,
+    #[debug(skip)]
+    pub on_confirm: Option<Box<dyn FnOnce(&Ctx, String) -> Result<()> + Send + Sync + 'static>>,
+}
+
+#[derive(derive_more::Debug)]
+pub struct SelectItem {
+    pub label: String,
+    pub value: String,
+}
+
+impl SelectSection {
+    pub fn new(current_item_style: Style) -> Self {
+        Self {
+            items: Vec::new(),
+            area: Rect::default(),
+            selected_idx: None,
+            current_item_style,
+            on_confirm: None,
+        }
+    }
+
+    pub fn item(mut self, label: impl Into<String>, value: impl Into<String>) -> Self {
+        self.items.push(SelectItem { label: label.into(), value: value.into() });
+        self
+    }
+
+    pub fn action(
+        &mut self,
+        on_confirm: impl FnOnce(&Ctx, String) -> Result<()> + Send + Sync + 'static,
+    ) -> &mut Self {
+        self.on_confirm = Some(Box::new(on_confirm));
+        self
+    }
+
+    pub fn add_item(&mut self, label: impl Into<String>, value: impl Into<String>) -> &mut Self {
+        self.items.push(SelectItem { label: label.into(), value: value.into() });
+        self
+    }
+
+    pub fn item_at_position(&mut self, position: Position) -> Option<&mut SelectItem> {
+        if !self.area.contains(position) {
+            return None;
+        }
+
+        let idx = position.y.saturating_sub(self.area.y) as usize;
+        self.items.get_mut(idx)
+    }
+
+    pub fn select_item_at_position(&mut self, position: Position) {
+        if !self.area.contains(position) {
+            return;
+        }
+
+        let idx = position.y.saturating_sub(self.area.y) as usize;
+        if idx < self.items.len() {
+            self.selected_idx = Some(idx);
+        } else {
+            self.selected_idx = None;
+        }
+    }
+}
+
+impl Section for SelectSection {
+    fn down(&mut self) -> bool {
+        self.selected_idx = match self.selected_idx {
+            Some(idx) if idx + 1 == self.items.len() => None,
+            Some(idx) => Some(idx + 1),
+            None => Some(0),
+        };
+
+        self.selected_idx.is_some()
+    }
+
+    fn up(&mut self) -> bool {
+        self.selected_idx = match self.selected_idx {
+            Some(0) => None,
+            Some(idx) => Some(idx.saturating_sub(1)),
+            None => Some(self.items.len().saturating_sub(1)),
+        };
+
+        self.selected_idx.is_some()
+    }
+
+    fn unselect(&mut self) {
+        self.selected_idx = None;
+    }
+
+    fn confirm(&mut self, ctx: &Ctx) -> Result<bool> {
+        if let Some(selected_idx) = self.selected_idx
+            && let Some(cb) = self.on_confirm.take()
+        {
+            (cb)(ctx, std::mem::take(&mut self.items[selected_idx].value))?;
+        }
+        Ok(false)
+    }
+
+    fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    fn render(&mut self, area: Rect, buf: &mut Buffer) {
+        Widget::render(self, area, buf);
+    }
+
+    fn left_click(&mut self, position: Position) {
+        self.select_item_at_position(position);
+    }
+
+    fn double_click(&mut self, _pos: Position, ctx: &Ctx) -> Result<bool> {
+        self.confirm(ctx)?;
+        Ok(false)
+    }
+}
+
+impl Widget for &mut SelectSection {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        self.area = area;
+
+        for (idx, item) in self.items.iter().enumerate() {
+            let mut text = Text::raw(&item.label);
+
+            if self.selected_idx.is_some_and(|i| i == idx) {
+                text = text.style(self.current_item_style);
+            }
+
+            let mut item_area = area.shrink_from_top(idx as u16);
+            item_area.height = 1;
+            text.render(item_area, buf);
+        }
+    }
+}

--- a/src/ui/panes/albums.rs
+++ b/src/ui/panes/albums.rs
@@ -19,7 +19,6 @@ use crate::{
         key_event::KeyEvent,
         mouse_event::MouseEvent,
         mpd_client_ext::{Autoplay, Enqueue, MpdClientExt},
-        mpd_query::PreviewGroup,
     },
     ui::{
         UiEvent,
@@ -170,7 +169,7 @@ impl Pane for AlbumsPane {
         ctx: &Ctx,
     ) -> Result<()> {
         match (id, data) {
-            (PREVIEW, MpdQueryResult::DirOrSong { mut data, origin_path }) => {
+            (PREVIEW, MpdQueryResult::DirOrSong { data, origin_path }) => {
                 if let Some(origin_path) = origin_path
                     && origin_path != self.stack().path()
                 {
@@ -178,34 +177,7 @@ impl Pane for AlbumsPane {
                     return Ok(());
                 }
 
-                match self.stack().current().selected() {
-                    Some(DirOrSong::Dir { .. }) => {
-                        let res = PreviewGroup::from(
-                            None,
-                            None,
-                            data.into_iter().map(|v| v.to_list_item_simple(ctx)).collect(),
-                        );
-
-                        self.stack_mut().set_preview(Some(vec![res]));
-                    }
-                    Some(DirOrSong::Song(_)) => {
-                        let key_style = ctx.config.theme.preview_label_style;
-                        let group_style = ctx.config.theme.preview_metadata_group_style;
-                        let preview = data.pop().and_then(|song| match song {
-                            DirOrSong::Dir { .. } => None,
-                            DirOrSong::Song(song) => Some(song.to_preview(
-                                key_style,
-                                group_style,
-                                ctx.stickers.get(&song.file),
-                            )),
-                        });
-
-                        self.stack_mut().set_preview(preview);
-                    }
-                    None => {
-                        self.stack_mut().set_preview(None);
-                    }
-                }
+                self.stack_mut().set_preview(Some(data));
 
                 ctx.render()?;
             }

--- a/src/ui/panes/directories.rs
+++ b/src/ui/panes/directories.rs
@@ -227,7 +227,7 @@ impl Pane for DirectoriesPane {
                     .filter(|file| !ctx.stickers.contains_key(file))
                     .collect_vec();
 
-                if !songs.is_empty() && ctx.should_fetch_stickers {
+                if !songs.is_empty() && ctx.stickers_supported {
                     ctx.query().id(FETCH_SONG_STICKERS).query(move |client| {
                         Ok(MpdQueryResult::SongStickers(client.fetch_song_stickers(songs)?))
                     });

--- a/src/ui/panes/directories.rs
+++ b/src/ui/panes/directories.rs
@@ -19,7 +19,6 @@ use crate::{
         mpd_client_ext::{Autoplay, Enqueue, MpdClientExt},
     },
     ui::{
-        FETCH_SONG_STICKERS,
         UiEvent,
         browser::BrowserPane,
         dir_or_song::DirOrSong,
@@ -216,21 +215,6 @@ impl Pane for DirectoriesPane {
                 {
                     log::trace!(origin_path:?, current_path:? = self.stack().path(); "Dropping preview because it does not belong to this path");
                     return Ok(());
-                }
-
-                let songs = data
-                    .iter()
-                    .filter_map(|ds| match ds {
-                        DirOrSong::Dir { .. } => None,
-                        DirOrSong::Song(song) => Some(song.file.clone()),
-                    })
-                    .filter(|file| !ctx.stickers.contains_key(file))
-                    .collect_vec();
-
-                if !songs.is_empty() && ctx.stickers_supported {
-                    ctx.query().id(FETCH_SONG_STICKERS).query(move |client| {
-                        Ok(MpdQueryResult::SongStickers(client.fetch_song_stickers(songs)?))
-                    });
                 }
 
                 self.stack_mut().set_preview(Some(data));

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -442,7 +442,9 @@ pub(crate) mod browser {
 
             let mut result = vec![info_group, tags_group];
 
-            if let Some(stickers) = stickers {
+            if let Some(stickers) = stickers
+                && !stickers.is_empty()
+            {
                 let mut stickers_group =
                     PreviewGroup::new(Some(" --- [Stickers]"), Some(group_style));
 

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -25,7 +25,6 @@ use crate::{
     },
     status_warn,
     ui::{
-        FETCH_SONG_STICKERS,
         UiEvent,
         browser::{BrowserPane, MoveDirection},
         dir_or_song::DirOrSong,
@@ -219,23 +218,6 @@ impl Pane for PlaylistsPane {
                 {
                     log::trace!(origin_path:?, current_path:? = self.stack().path(); "Dropping preview because it does not belong to this path");
                     return Ok(());
-                }
-
-                let songs = data
-                    .iter()
-                    .filter_map(|ds| match ds {
-                        DirOrSong::Dir { .. } => None,
-                        DirOrSong::Song(song) => Some(song.file.clone()),
-                    })
-                    .filter(|file| !ctx.stickers.contains_key(file))
-                    .collect_vec();
-
-                log::debug!("Fetching stickers for {} songs", songs.len());
-                if !songs.is_empty() && ctx.stickers_supported {
-                    log::debug!("Fetching 2 stickers for {} songs", songs.len());
-                    ctx.query().id(FETCH_SONG_STICKERS).query(move |client| {
-                        Ok(MpdQueryResult::SongStickers(client.fetch_song_stickers(songs)?))
-                    });
                 }
 
                 self.stack_mut().set_preview(Some(data));

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -231,7 +231,7 @@ impl Pane for PlaylistsPane {
                     .collect_vec();
 
                 log::debug!("Fetching stickers for {} songs", songs.len());
-                if !songs.is_empty() && ctx.should_fetch_stickers {
+                if !songs.is_empty() && ctx.stickers_supported {
                     log::debug!("Fetching 2 stickers for {} songs", songs.len());
                     ctx.query().id(FETCH_SONG_STICKERS).query(move |client| {
                         Ok(MpdQueryResult::SongStickers(client.fetch_song_stickers(songs)?))

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -22,7 +22,6 @@ use crate::{
         macros::{modal, status_info},
         mouse_event::MouseEvent,
         mpd_client_ext::{Autoplay, Enqueue, MpdClientExt, MpdDelete},
-        mpd_query::PreviewGroup,
     },
     status_warn,
     ui::{
@@ -214,7 +213,7 @@ impl Pane for PlaylistsPane {
                 );
                 ctx.render()?;
             }
-            (PREVIEW, MpdQueryResult::DirOrSong { mut data, origin_path }) => {
+            (PREVIEW, MpdQueryResult::DirOrSong { data, origin_path }) => {
                 if let Some(origin_path) = origin_path
                     && origin_path != self.stack().path()
                 {
@@ -239,35 +238,7 @@ impl Pane for PlaylistsPane {
                     });
                 }
 
-                match self.stack().current().selected() {
-                    Some(DirOrSong::Dir { .. }) => {
-                        let res = PreviewGroup::from(
-                            None,
-                            None,
-                            data.into_iter().map(|v| v.to_list_item_simple(ctx)).collect(),
-                        );
-
-                        self.stack_mut().set_preview(Some(vec![res]));
-                    }
-                    Some(DirOrSong::Song(_)) => {
-                        let key_style = ctx.config.theme.preview_label_style;
-                        let group_style = ctx.config.theme.preview_metadata_group_style;
-                        let preview = data.pop().and_then(|song| match song {
-                            DirOrSong::Dir { .. } => None,
-                            DirOrSong::Song(song) => Some(song.to_preview(
-                                key_style,
-                                group_style,
-                                ctx.stickers.get(&song.file),
-                            )),
-                        });
-
-                        self.stack_mut().set_preview(preview);
-                    }
-                    None => {
-                        self.stack_mut().set_preview(None);
-                    }
-                }
-
+                self.stack_mut().set_preview(Some(data));
                 ctx.render()?;
             }
             (OPEN_OR_PLAY, MpdQueryResult::SongsList { data, origin_path }) => {

--- a/src/ui/panes/playlists/tests.rs
+++ b/src/ui/panes/playlists/tests.rs
@@ -513,7 +513,6 @@ fn song(name: &str) -> Song {
         file: name.to_string(),
         duration: Some(Duration::from_secs(1)),
         metadata: HashMap::new(),
-        stickers: None,
         last_modified: *NOW,
         added: None,
     }

--- a/src/ui/panes/property.rs
+++ b/src/ui/panes/property.rs
@@ -35,10 +35,12 @@ impl<'content> PropertyPane<'content> {
 impl Pane for PropertyPane<'_> {
     fn render(&mut self, frame: &mut Frame, area: Rect, ctx: &Ctx) -> Result<()> {
         let song = ctx.find_current_song_in_queue().map(|(_, song)| song);
+        let song_stickers = song.and_then(|s| ctx.stickers.get(&s.file));
 
         let line = Line::from(self.content.iter().fold(Vec::new(), |mut acc, val| {
             match val.as_span(
                 song,
+                song_stickers,
                 ctx,
                 &ctx.config.theme.format_tag_separator,
                 ctx.config.theme.multiple_tag_resolution_strategy,

--- a/src/ui/panes/property.rs
+++ b/src/ui/panes/property.rs
@@ -35,12 +35,10 @@ impl<'content> PropertyPane<'content> {
 impl Pane for PropertyPane<'_> {
     fn render(&mut self, frame: &mut Frame, area: Rect, ctx: &Ctx) -> Result<()> {
         let song = ctx.find_current_song_in_queue().map(|(_, song)| song);
-        let song_stickers = song.and_then(|s| ctx.stickers.get(&s.file));
 
         let line = Line::from(self.content.iter().fold(Vec::new(), |mut acc, val| {
             match val.as_span(
                 song,
-                song_stickers,
                 ctx,
                 &ctx.config.theme.format_tag_separator,
                 ctx.config.theme.multiple_tag_resolution_strategy,

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -1170,7 +1170,12 @@ impl Pane for QueuePane {
                 CommonAction::ContextMenu => {
                     self.open_context_menu(ctx)?;
                 }
-                CommonAction::Rate { kind: RatingKind::Value(value), current: false } => {
+                CommonAction::Rate {
+                    kind: RatingKind::Value(value),
+                    current: false,
+                    min_rating: _,
+                    max_rating: _,
+                } => {
                     let items = self.enqueue_items(false, ctx).0;
                     ctx.command(move |client| {
                         client.set_sticker_multiple("rating", value.to_string(), items)?;
@@ -1180,11 +1185,23 @@ impl Pane for QueuePane {
                 CommonAction::Rate {
                     kind: RatingKind::Modal { values, custom },
                     current: false,
+                    min_rating,
+                    max_rating,
                 } => {
                     let items = self.enqueue_items(false, ctx).0;
-                    modal!(ctx, create_rating_modal(items, values.as_slice(), custom, ctx));
+                    modal!(
+                        ctx,
+                        create_rating_modal(
+                            items,
+                            values.as_slice(),
+                            min_rating,
+                            max_rating,
+                            custom,
+                            ctx
+                        )
+                    );
                 }
-                CommonAction::Rate { kind: _, current: true } => {
+                CommonAction::Rate { kind: _, current: true, min_rating: _, max_rating: _ } => {
                     event.abandon();
                 }
             }

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -1170,21 +1170,21 @@ impl Pane for QueuePane {
                 CommonAction::ContextMenu => {
                     self.open_context_menu(ctx)?;
                 }
-                CommonAction::Rating { kind: RatingKind::Value(value), current: false } => {
+                CommonAction::Rate { kind: RatingKind::Value(value), current: false } => {
                     let items = self.enqueue_items(false, ctx).0;
                     ctx.command(move |client| {
                         client.set_sticker_multiple("rating", value.to_string(), items)?;
                         Ok(())
                     });
                 }
-                CommonAction::Rating {
+                CommonAction::Rate {
                     kind: RatingKind::Modal { values, custom },
                     current: false,
                 } => {
                     let items = self.enqueue_items(false, ctx).0;
                     modal!(ctx, create_rating_modal(items, values.as_slice(), custom, ctx));
                 }
-                CommonAction::Rating { kind: _, current: true } => {
+                CommonAction::Rate { kind: _, current: true } => {
                     event.abandon();
                 }
             }

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -21,7 +21,7 @@ use crate::{
         keys::{
             GlobalAction,
             QueueActions,
-            actions::{AddKind, AutoplayKind},
+            actions::{AddKind, AutoplayKind, RatingKind},
         },
         tabs::PaneType,
         theme::{
@@ -50,7 +50,7 @@ use crate::{
             confirm_modal::ConfirmModal,
             info_list_modal::InfoListModal,
             input_modal::InputModal,
-            menu::{create_add_modal, modal::MenuModal},
+            menu::{create_add_modal, create_rating_modal, modal::MenuModal},
             select_modal::SelectModal,
         },
     },
@@ -1173,7 +1173,17 @@ impl Pane for QueuePane {
                 CommonAction::ContextMenu => {
                     self.open_context_menu(ctx)?;
                 }
-                CommonAction::Rating { .. } => {}
+                CommonAction::Rating { kind: RatingKind::Value(value) } => {
+                    let items = self.enqueue_items(false, ctx).0;
+                    ctx.command(move |client| {
+                        client.set_sticker_multiple("rating", value.to_string(), items)?;
+                        Ok(())
+                    });
+                }
+                CommonAction::Rating { kind: RatingKind::Modal { values, custom } } => {
+                    let items = self.enqueue_items(false, ctx).0;
+                    modal!(ctx, create_rating_modal(items, values.as_slice(), custom, ctx));
+                }
             }
         } else if let Some(action) = event.as_global_action(ctx) {
             match action {

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -1170,16 +1170,22 @@ impl Pane for QueuePane {
                 CommonAction::ContextMenu => {
                     self.open_context_menu(ctx)?;
                 }
-                CommonAction::Rating { kind: RatingKind::Value(value) } => {
+                CommonAction::Rating { kind: RatingKind::Value(value), current: false } => {
                     let items = self.enqueue_items(false, ctx).0;
                     ctx.command(move |client| {
                         client.set_sticker_multiple("rating", value.to_string(), items)?;
                         Ok(())
                     });
                 }
-                CommonAction::Rating { kind: RatingKind::Modal { values, custom } } => {
+                CommonAction::Rating {
+                    kind: RatingKind::Modal { values, custom },
+                    current: false,
+                } => {
                     let items = self.enqueue_items(false, ctx).0;
                     modal!(ctx, create_rating_modal(items, values.as_slice(), custom, ctx));
+                }
+                CommonAction::Rating { kind: _, current: true } => {
+                    event.abandon();
                 }
             }
         } else if let Some(action) = event.as_global_action(ctx) {

--- a/src/ui/panes/search/inputs.rs
+++ b/src/ui/panes/search/inputs.rs
@@ -1,0 +1,520 @@
+use bon::bon;
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Position, Rect},
+    style::Style,
+    widgets::{Block, Borders, Widget},
+};
+use strum::{FromRepr, IntoStaticStr, VariantNames};
+
+use crate::{
+    config::Search,
+    mpd::mpd_client::FilterKind,
+    ui::widgets::{button::Button, input::Input},
+};
+
+pub const SEARCH_MODE_KEY: &str = "search_mode";
+pub const FOLD_CASE_KEY: &str = "fold_case";
+pub const STRIP_DIACRITICS_KEY: &str = "strip_diacritics";
+pub const RATING_MODE_KEY: &str = "rating";
+pub const RATING_VALUE_KEY: &str = "rating_value";
+pub const RESET_BUTTON_KEY: &str = "reset";
+
+#[derive(derive_more::Debug)]
+#[allow(clippy::struct_excessive_bools)]
+pub(super) struct InputGroups {
+    pub inputs: Vec<InputType>,
+
+    initial_fold_case: bool,
+    initial_strip_diacritics: bool,
+
+    focused_idx: usize,
+    pub insert_mode: bool,
+    pub area: Rect,
+
+    text_style: Style,
+    separator_style: Style,
+    current_item_style: Style,
+    highlight_item_style: Style,
+
+    fold_case: bool,
+    strip_diacritics: bool,
+    search_mode: SearchMode,
+    rating_mode: RatingMode,
+}
+
+#[bon]
+impl InputGroups {
+    #[builder]
+    pub fn new(
+        search_config: &Search,
+        initial_fold_case: bool,
+        initial_strip_diacritics: bool,
+        rating_supported: bool,
+        strip_diacritics_supported: bool,
+        text_style: Style,
+        separator_style: Style,
+        current_item_style: Style,
+        highlight_item_style: Style,
+    ) -> Self {
+        let mut inputs = Vec::new();
+        for tag in &search_config.tags {
+            inputs.push(InputType::Textbox(TextboxInput {
+                key: "",
+                filter_key: Some(tag.value.clone()),
+                label: format!(" {:<18}:", tag.label),
+                value: String::new(),
+                initial_value: None,
+            }));
+        }
+
+        if rating_supported {
+            inputs.push(InputType::Separator);
+            inputs.push(InputType::Spinner(SpinnerInput {
+                key: RATING_MODE_KEY,
+                label: format!(" {:<18}:", "Rating"),
+            }));
+            inputs.push(InputType::Numberbox(TextboxInput {
+                key: RATING_VALUE_KEY,
+                filter_key: None,
+                label: format!(" {:<18}:", "Value"),
+                value: "0".to_owned(),
+                initial_value: Some("0".to_owned()),
+            }));
+        }
+
+        inputs.push(InputType::Separator);
+
+        inputs.push(InputType::Spinner(SpinnerInput {
+            key: SEARCH_MODE_KEY,
+            label: format!(" {:<18}:", "Search mode"),
+        }));
+        inputs.push(InputType::Spinner(SpinnerInput {
+            key: FOLD_CASE_KEY,
+            label: format!(" {:<18}:", "Case sensitive"),
+        }));
+        if strip_diacritics_supported {
+            inputs.push(InputType::Spinner(SpinnerInput {
+                key: STRIP_DIACRITICS_KEY,
+                label: format!(" {:<18}:", "Ignore diacritics"),
+            }));
+        }
+
+        inputs.push(InputType::Separator);
+
+        inputs.push(InputType::Button(ButtonInput {
+            key: RESET_BUTTON_KEY,
+            label: " Reset".to_owned(),
+        }));
+
+        Self {
+            inputs,
+
+            focused_idx: 0,
+            area: Rect::default(),
+
+            initial_fold_case,
+            initial_strip_diacritics,
+            insert_mode: false,
+
+            text_style,
+            separator_style,
+            current_item_style,
+            highlight_item_style,
+
+            fold_case: initial_fold_case,
+            strip_diacritics: initial_strip_diacritics,
+            search_mode: search_config.mode.into(),
+            rating_mode: RatingMode::default(),
+        }
+    }
+
+    pub fn search_mode(&self) -> SearchMode {
+        self.search_mode
+    }
+
+    pub fn rating_mode(&self) -> RatingMode {
+        self.rating_mode
+    }
+
+    pub fn rating_value(&self) -> &str {
+        self.textbox_value(RATING_VALUE_KEY).unwrap_or_default()
+    }
+
+    pub fn fold_case(&self) -> bool {
+        self.fold_case
+    }
+
+    pub fn strip_diacritics(&self) -> bool {
+        self.strip_diacritics
+    }
+
+    pub fn first(&mut self) {
+        self.focused_idx = 0;
+    }
+
+    pub fn last(&mut self) {
+        self.focused_idx = self.inputs.len() - 1;
+    }
+
+    pub fn focused_mut(&mut self) -> &mut InputType {
+        &mut self.inputs[self.focused_idx]
+    }
+
+    pub fn focused(&self) -> &InputType {
+        &self.inputs[self.focused_idx]
+    }
+
+    pub fn activate_focused(&mut self) -> bool {
+        match &mut self.inputs[self.focused_idx] {
+            InputType::Textbox(_) | InputType::Numberbox(_) => {
+                self.insert_mode = !self.insert_mode;
+                true
+            }
+            InputType::Spinner(input) => {
+                match input.key {
+                    FOLD_CASE_KEY => {
+                        self.fold_case = !self.fold_case;
+                        if !self.fold_case {
+                            self.strip_diacritics = false;
+                        }
+                    }
+                    STRIP_DIACRITICS_KEY => {
+                        self.strip_diacritics = !self.strip_diacritics;
+                        if self.strip_diacritics {
+                            self.fold_case = true;
+                        }
+                    }
+                    SEARCH_MODE_KEY => {
+                        self.search_mode.cycle();
+                    }
+                    RATING_MODE_KEY => {
+                        self.rating_mode.cycle();
+                    }
+                    _ => {}
+                }
+
+                true
+            }
+            InputType::Button(ButtonInput { key: RESET_BUTTON_KEY, .. }) => {
+                self.reset_all();
+                true
+            }
+            InputType::Button(_) => false,
+            InputType::Separator => false,
+        }
+    }
+
+    fn reset_item(&mut self, idx: usize) {
+        if let Some(input) = self.inputs.get_mut(idx) {
+            match input {
+                InputType::Textbox(input) | InputType::Numberbox(input) => {
+                    if let Some(init) = &input.initial_value {
+                        input.value = init.clone();
+                    } else {
+                        input.value.clear();
+                    }
+                }
+                InputType::Spinner(spinner) => match spinner.key {
+                    FOLD_CASE_KEY => {
+                        self.fold_case = self.initial_fold_case;
+                    }
+                    STRIP_DIACRITICS_KEY => {
+                        self.strip_diacritics = self.initial_strip_diacritics;
+                    }
+                    SEARCH_MODE_KEY => {
+                        self.search_mode = SearchMode::default();
+                    }
+                    RATING_MODE_KEY => {
+                        self.rating_mode = RatingMode::default();
+                    }
+                    _ => {}
+                },
+                InputType::Button(_) | InputType::Separator => {}
+            }
+        }
+    }
+
+    pub fn reset_all(&mut self) {
+        for idx in 0..self.inputs.len() {
+            self.reset_item(idx);
+        }
+    }
+
+    pub fn reset_focused(&mut self) {
+        self.reset_item(self.focused_idx);
+    }
+
+    pub fn enter_insert_mode(&mut self) {
+        if matches!(self.focused(), InputType::Textbox(_) | InputType::Numberbox(_)) {
+            self.insert_mode = true;
+        }
+    }
+
+    pub fn next_non_wrapping(&mut self) {
+        self.focused_idx = self.focused_idx.min(self.inputs.len() - 1);
+
+        if matches!(self.focused(), InputType::Separator) {
+            self.next_non_wrapping();
+        }
+    }
+
+    pub fn next(&mut self) {
+        self.focused_idx = (self.focused_idx + 1) % self.inputs.len();
+
+        if matches!(self.focused(), InputType::Separator) {
+            self.next();
+        }
+    }
+
+    pub fn prev_non_wrapping(&mut self) {
+        if self.focused_idx > 0 {
+            self.focused_idx -= 1;
+        }
+
+        if matches!(self.focused(), InputType::Separator) {
+            self.prev_non_wrapping();
+        }
+    }
+
+    pub fn prev(&mut self) {
+        if self.focused_idx == 0 {
+            self.focused_idx = self.inputs.len() - 1;
+        } else {
+            self.focused_idx -= 1;
+        }
+
+        if matches!(self.focused(), InputType::Separator) {
+            self.prev();
+        }
+    }
+
+    pub fn focus_input_at(&mut self, position: Position) {
+        if !self.area.contains(position) {
+            return;
+        }
+        let y = (position.y - self.area.y) as usize;
+
+        if let Some(input) = self.inputs.get(y)
+            && !matches!(input, InputType::Separator)
+        {
+            self.focused_idx = y;
+        }
+    }
+
+    fn textbox_value(&self, key: &str) -> Option<&str> {
+        for input in &self.inputs {
+            if let InputType::Textbox(input) | InputType::Numberbox(input) = input
+                && input.key == key
+            {
+                return Some(input.value.trim());
+            }
+        }
+        None
+    }
+}
+
+#[derive(Debug)]
+pub(super) enum InputType {
+    Textbox(TextboxInput),
+    Numberbox(TextboxInput),
+    Spinner(SpinnerInput),
+    Button(ButtonInput),
+    Separator,
+}
+
+#[derive(Debug)]
+pub(super) struct TextboxInput {
+    pub value: String,
+    pub label: String,
+    pub key: &'static str,
+    pub filter_key: Option<String>,
+    pub initial_value: Option<String>,
+}
+
+#[derive(Debug)]
+pub(super) struct SpinnerInput {
+    pub key: &'static str,
+    pub label: String,
+}
+
+#[derive(Debug, Default, PartialEq, VariantNames, Clone, Copy, FromRepr, IntoStaticStr)]
+pub(super) enum SearchMode {
+    #[strum(serialize = "Contains")]
+    #[default]
+    Contains,
+    #[strum(serialize = "Exact")]
+    Exact,
+    #[strum(serialize = "Starts with")]
+    StartsWith,
+    #[strum(serialize = "Regex")]
+    Regex,
+}
+
+#[derive(Debug, Default, Clone, Copy, IntoStaticStr, VariantNames, FromRepr)]
+pub(super) enum RatingMode {
+    #[default]
+    #[strum(serialize = "Any")]
+    Any,
+    #[strum(serialize = "Equals")]
+    Equals,
+    #[strum(serialize = "Greater Than")]
+    GreaterThan,
+    #[strum(serialize = "Less Than")]
+    LessThan,
+}
+
+impl From<SearchMode> for FilterKind {
+    fn from(value: SearchMode) -> Self {
+        match value {
+            SearchMode::Exact => FilterKind::Exact,
+            SearchMode::StartsWith => FilterKind::StartsWith,
+            SearchMode::Contains => FilterKind::Contains,
+            SearchMode::Regex => FilterKind::Regex,
+        }
+    }
+}
+
+impl From<FilterKind> for SearchMode {
+    fn from(value: FilterKind) -> Self {
+        match value {
+            FilterKind::Exact => SearchMode::Exact,
+            FilterKind::StartsWith => SearchMode::StartsWith,
+            FilterKind::Contains => SearchMode::Contains,
+            FilterKind::Regex => SearchMode::Regex,
+        }
+    }
+}
+
+impl SearchMode {
+    fn cycle(&mut self) {
+        let i = *self as usize;
+        if let Some(new) = SearchMode::from_repr((i + 1) % SearchMode::VARIANTS.len()) {
+            *self = new;
+        }
+    }
+}
+
+impl RatingMode {
+    fn cycle(&mut self) {
+        let i = *self as usize;
+        if let Some(new) = RatingMode::from_repr((i + 1) % RatingMode::VARIANTS.len()) {
+            *self = new;
+        }
+    }
+}
+
+#[derive(derive_more::Debug)]
+pub(super) struct ButtonInput {
+    pub key: &'static str,
+    pub label: String,
+}
+
+impl Widget for &mut InputGroups {
+    fn render(self, mut area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        self.area = area;
+        area.height = 1;
+        for (idx, input) in self.inputs.iter().enumerate() {
+            let is_focused = idx == self.focused_idx;
+
+            match input {
+                InputType::Textbox(input) => {
+                    let mut widget = Input::default()
+                        .set_borderless(true)
+                        .set_label(&input.label)
+                        .set_placeholder("<None>")
+                        .set_focused(is_focused && self.insert_mode)
+                        .set_label_style(self.text_style)
+                        .set_input_style(self.text_style)
+                        .set_text(&input.value);
+
+                    widget = if self.insert_mode && is_focused {
+                        widget.set_label_style(self.highlight_item_style)
+                    } else if is_focused {
+                        widget
+                            .set_label_style(self.current_item_style)
+                            .set_input_style(self.current_item_style)
+                    } else if !input.value.is_empty() {
+                        widget.set_input_style(self.highlight_item_style)
+                    } else {
+                        widget
+                    };
+
+                    widget.render(area, buf);
+                }
+                InputType::Numberbox(input) => {
+                    let mut widget = Input::default()
+                        .set_borderless(true)
+                        .set_label(&input.label)
+                        .set_placeholder("<None>")
+                        .set_focused(is_focused && self.insert_mode)
+                        .set_label_style(self.text_style)
+                        .set_input_style(self.text_style)
+                        .set_text(&input.value);
+
+                    widget = if self.insert_mode && is_focused {
+                        widget.set_label_style(self.highlight_item_style)
+                    } else if is_focused {
+                        widget
+                            .set_label_style(self.current_item_style)
+                            .set_input_style(self.current_item_style)
+                    } else {
+                        widget
+                    };
+
+                    widget.render(area, buf);
+                }
+                InputType::Spinner(input) => {
+                    let mut inp = Input::default()
+                        .set_borderless(true)
+                        .set_label_style(self.text_style)
+                        .set_input_style(self.text_style)
+                        .set_label(&input.label)
+                        .set_text(match input.key {
+                            FOLD_CASE_KEY => {
+                                if self.fold_case {
+                                    "No"
+                                } else {
+                                    "Yes"
+                                }
+                            }
+                            STRIP_DIACRITICS_KEY => {
+                                if self.strip_diacritics {
+                                    "Yes"
+                                } else {
+                                    "No"
+                                }
+                            }
+                            SEARCH_MODE_KEY => self.search_mode.into(),
+                            RATING_MODE_KEY => self.rating_mode.into(),
+                            _ => "",
+                        });
+
+                    if is_focused {
+                        inp = inp
+                            .set_label_style(self.current_item_style)
+                            .set_input_style(self.current_item_style);
+                    }
+                    inp.render(area, buf);
+                }
+                InputType::Button(input) => {
+                    Button::default()
+                        .label(&input.label)
+                        .label_alignment(Alignment::Left)
+                        .style(if is_focused { self.current_item_style } else { self.text_style })
+                        .render(area, buf);
+                }
+                InputType::Separator => {
+                    Block::default()
+                        .borders(Borders::TOP)
+                        .border_style(self.separator_style)
+                        .render(area, buf);
+                }
+            }
+            area.y += 1;
+        }
+    }
+}

--- a/src/ui/panes/search/inputs.rs
+++ b/src/ui/panes/search/inputs.rs
@@ -9,7 +9,7 @@ use strum::{FromRepr, IntoStaticStr, VariantNames};
 
 use crate::{
     config::Search,
-    mpd::mpd_client::FilterKind,
+    mpd::mpd_client::{FilterKind, StickerFilter},
     ui::widgets::{button::Button, input::Input},
 };
 
@@ -133,12 +133,18 @@ impl InputGroups {
         self.search_mode
     }
 
-    pub fn rating_mode(&self) -> RatingMode {
-        self.rating_mode
-    }
-
     pub fn rating_value(&self) -> &str {
         self.textbox_value(RATING_VALUE_KEY).unwrap_or_default()
+    }
+
+    pub fn sticker_filter(&self) -> Result<Option<StickerFilter>, std::num::ParseIntError> {
+        let value = self.rating_value().trim().parse()?;
+        Ok(match self.rating_mode {
+            RatingMode::Equals => Some(StickerFilter::EqualsInt(value)),
+            RatingMode::GreaterThan => Some(StickerFilter::GreaterThanInt(value)),
+            RatingMode::LessThan => Some(StickerFilter::LessThanInt(value)),
+            RatingMode::Any => None,
+        })
     }
 
     pub fn fold_case(&self) -> bool {
@@ -358,9 +364,9 @@ pub(super) enum RatingMode {
     Any,
     #[strum(serialize = "Equals")]
     Equals,
-    #[strum(serialize = "Greater Than")]
+    #[strum(serialize = "Greater than")]
     GreaterThan,
-    #[strum(serialize = "Less Than")]
+    #[strum(serialize = "Less than")]
     LessThan,
 }
 

--- a/src/ui/panes/search/inputs.rs
+++ b/src/ui/panes/search/inputs.rs
@@ -422,8 +422,13 @@ impl Widget for &mut InputGroups {
         Self: Sized,
     {
         self.area = area;
+        let mut remaining_height = area.height as usize;
         area.height = 1;
         for (idx, input) in self.inputs.iter().enumerate() {
+            if remaining_height == 0 {
+                break;
+            }
+
             let is_focused = idx == self.focused_idx;
 
             match input {
@@ -521,6 +526,7 @@ impl Widget for &mut InputGroups {
                 }
             }
             area.y += 1;
+            remaining_height = remaining_height.saturating_sub(1);
         }
     }
 }

--- a/src/ui/panes/search/mod.rs
+++ b/src/ui/panes/search/mod.rs
@@ -1,11 +1,11 @@
-use std::rc::Rc;
+use std::collections::HashSet;
 
 use anyhow::Result;
 use crossterm::event::KeyCode;
 use enum_map::EnumMap;
 use itertools::Itertools;
 use ratatui::{
-    layout::{Alignment, Constraint, Layout, Rect},
+    layout::{Constraint, Layout, Rect},
     style::{Styled, Stylize},
     text::Span,
     widgets::{Block, Borders, List, ListItem, Padding},
@@ -15,8 +15,6 @@ use super::{CommonAction, Pane};
 use crate::{
     MpdQueryResult,
     config::{
-        Config,
-        Search,
         keys::{
             GlobalAction,
             actions::{AddKind, Position, RatingKind},
@@ -27,12 +25,12 @@ use crate::{
     ctx::Ctx,
     mpd::{
         commands::Song,
-        mpd_client::{Filter, FilterKind, MpdClient},
+        mpd_client::{Filter, MpdClient, StickerFilter},
         version::Version,
     },
     shared::{
         key_event::KeyEvent,
-        macros::{modal, status_info, status_warn},
+        macros::{modal, status_error, status_info, status_warn},
         mouse_event::{MouseEvent, MouseEventKind, calculate_scrollbar_position},
         mpd_client_ext::{Autoplay, Enqueue, MpdClientExt},
     },
@@ -45,18 +43,19 @@ use crate::{
             menu::{create_add_modal, create_rating_modal, modal::MenuModal},
             select_modal::SelectModal,
         },
-        widgets::{browser::BrowserArea, button::Button, input::Input},
+        panes::search::inputs::{InputGroups, InputType, RatingMode, TextboxInput},
+        widgets::browser::BrowserArea,
     },
 };
 
+mod inputs;
+
 #[derive(Debug)]
 pub struct SearchPane {
-    inputs: InputGroups<1>,
+    inputs: InputGroups,
     phase: Phase,
     songs_dir: Dir<Song>,
-    input_areas: Rc<[Rect]>,
     column_areas: EnumMap<BrowserArea, Rect>,
-    initial_ignore_diacritics: bool,
 }
 
 const SEARCH: &str = "search";
@@ -64,39 +63,24 @@ const SEARCH: &str = "search";
 impl SearchPane {
     pub fn new(ctx: &Ctx) -> Self {
         let config = &ctx.config;
-        let mut filter_inputs = vec![
-            FilterInput {
-                label: " Search mode       :".to_string(),
-                variant: FilterInputVariant::FilterKind { value: config.search.mode },
-            },
-            FilterInput {
-                label: " Case sensitive    :".to_string(),
-                variant: FilterInputVariant::CaseSensitive,
-            },
-        ];
 
-        let mut ignore_diacritics = false;
-        if ctx.mpd_version >= Version::new(0, 25, 0) {
-            filter_inputs.push(FilterInput {
-                label: " Ignore diacritics :".to_string(),
-                variant: FilterInputVariant::IgnoreDiacritics,
-            });
-            ignore_diacritics = ctx.config.search.ignore_diacritics;
-        }
+        let inputs = InputGroups::builder()
+            .search_config(&config.search)
+            .initial_fold_case(!config.search.case_sensitive)
+            .initial_strip_diacritics(config.search.ignore_diacritics)
+            .text_style(config.as_text_style())
+            .separator_style(config.theme.borders_style)
+            .current_item_style(config.theme.current_item_style)
+            .highlight_item_style(config.theme.highlighted_item_style)
+            .rating_supported(ctx.stickers_supported)
+            .strip_diacritics_supported(ctx.mpd_version >= Version::new(0, 25, 0))
+            .build();
 
         Self {
             phase: Phase::Search,
             songs_dir: Dir::default(),
-            inputs: InputGroups::new(
-                &config.search,
-                filter_inputs,
-                [ButtonInput { label: " Reset", variant: ButtonInputVariant::Reset }],
-                !ctx.config.search.case_sensitive,
-                ignore_diacritics,
-            ),
-            input_areas: Rc::default(),
+            inputs,
             column_areas: EnumMap::default(),
-            initial_ignore_diacritics: ignore_diacritics,
         }
     }
 
@@ -185,138 +169,13 @@ impl SearchPane {
         }
     }
 
-    fn render_input_column(
-        &mut self,
-        frame: &mut ratatui::prelude::Frame,
-        area: ratatui::prelude::Rect,
-        config: &Config,
-    ) {
-        let input_areas = Layout::vertical(
-            (0..self.inputs.textbox_inputs.len()
-                + self.inputs.filter_inputs.len()
-                + self.inputs.button_inputs.len()
-                + 2) // +2 for borders/separators
-                .map(|_| Constraint::Length(1)),
-        )
-        .split(area);
-
-        self.input_areas = Rc::clone(&input_areas);
-
-        let mut idx = 0;
-        for input in &self.inputs.textbox_inputs {
-            match input {
-                Textbox { value, label, filter_key } => {
-                    let is_focused = matches!(self.inputs.focused(),
-                        FocusedInputGroup::Textboxes(Textbox { filter_key: filter_key2, .. }) if filter_key == filter_key2);
-
-                    let mut widget = Input::default()
-                        .set_borderless(true)
-                        .set_label(label)
-                        .set_placeholder("<None>")
-                        .set_focused(is_focused && matches!(self.phase, Phase::SearchTextboxInput))
-                        .set_label_style(config.as_text_style())
-                        .set_input_style(config.as_text_style())
-                        .set_text(value);
-
-                    widget = if matches!(self.phase, Phase::SearchTextboxInput) && is_focused {
-                        widget.set_label_style(config.theme.highlighted_item_style)
-                    } else if is_focused {
-                        widget
-                            .set_label_style(config.theme.current_item_style)
-                            .set_input_style(config.theme.current_item_style)
-                    } else if !value.is_empty() {
-                        widget.set_input_style(config.theme.highlighted_item_style)
-                    } else {
-                        widget
-                    };
-
-                    frame.render_widget(widget, input_areas[idx]);
-                }
-            }
-            idx += 1;
-        }
-
-        frame.render_widget(
-            Block::default().borders(Borders::TOP).border_style(config.theme.borders_style),
-            input_areas[idx],
-        );
-        idx += 1;
-
-        for input in &self.inputs.filter_inputs {
-            let mut inp = match input.variant {
-                FilterInputVariant::FilterKind { value } => Input::default()
-                    .set_borderless(true)
-                    .set_label_style(config.as_text_style())
-                    .set_input_style(config.as_text_style())
-                    .set_label(&input.label)
-                    .set_text(Into::into(&value)),
-                FilterInputVariant::CaseSensitive => Input::default()
-                    .set_borderless(true)
-                    .set_label_style(config.as_text_style())
-                    .set_input_style(config.as_text_style())
-                    .set_label(&input.label)
-                    .set_text(if self.inputs.ignore_case { "No" } else { "Yes" }),
-                FilterInputVariant::IgnoreDiacritics => Input::default()
-                    .set_borderless(true)
-                    .set_label_style(config.as_text_style())
-                    .set_input_style(config.as_text_style())
-                    .set_label(&input.label)
-                    .set_text(if self.inputs.ignore_diacritics { "Yes" } else { "No" }),
-            };
-
-            let is_focused = matches!(self.inputs.focused(),
-                FocusedInputGroup::Filters(FilterInput { variant: variant2, .. }) if &input.variant == variant2);
-
-            if is_focused {
-                inp = inp
-                    .set_label_style(config.theme.current_item_style)
-                    .set_input_style(config.theme.current_item_style);
-            }
-            frame.render_widget(inp, input_areas[idx]);
-            idx += 1;
-        }
-
-        frame.render_widget(
-            Block::default().borders(Borders::TOP).border_style(config.theme.borders_style),
-            input_areas[idx],
-        );
-        idx += 1;
-
-        for input in &self.inputs.button_inputs {
-            let mut button = match input.variant {
-                ButtonInputVariant::Reset => {
-                    Button::default().label(input.label).label_alignment(Alignment::Left)
-                }
-            };
-
-            let is_focused = matches!(self.inputs.focused(),
-                FocusedInputGroup::Buttons(ButtonInput { variant, .. }) if &input.variant == variant);
-
-            if is_focused {
-                button = button.style(config.theme.current_item_style);
-            } else {
-                button = button.style(config.as_text_style());
-            }
-            frame.render_widget(button, input_areas[idx]);
-        }
-    }
-
-    fn filter_type(&self) -> FilterKind {
-        self.inputs
-            .filter_inputs
-            .iter()
-            .find_map(|f| match f.variant {
-                FilterInputVariant::FilterKind { value } => Some(value),
-                _ => None,
-            })
-            .unwrap_or(FilterKind::Contains)
-    }
-
     fn search(&mut self, ctx: &Ctx) {
-        let filter_kind = self.filter_type();
-        let filter = self.inputs.textbox_inputs.iter().filter_map(|input| match &input {
-            Textbox { value, filter_key, .. } if !value.is_empty() => {
-                Some((filter_key.to_owned(), value.to_owned(), filter_kind))
+        let filter_kind = self.inputs.search_mode();
+        let filter = self.inputs.inputs.iter().filter_map(|input| match &input {
+            InputType::Textbox(TextboxInput { value, filter_key: Some(key), .. })
+                if !value.is_empty() && !key.is_empty() =>
+            {
+                Some((key.to_owned(), value.to_owned(), filter_kind))
             }
             _ => None,
         });
@@ -328,111 +187,48 @@ impl SearchPane {
             return;
         }
 
-        let ignore_case = self.inputs.ignore_case;
-        let ignore_diacritics = self.inputs.ignore_diacritics;
+        let need_stickers_fetch = ctx.stickers_supported;
+        let rating_kind = self.inputs.rating_mode();
+        let Ok(rating_value) = self.inputs.rating_value().parse::<i32>() else {
+            status_error!("Rating must be a valid integer {:?}", self.inputs.rating_value());
+            return;
+        };
+
+        let fold_case = self.inputs.fold_case();
+        let strip_diacritics = self.inputs.strip_diacritics();
         ctx.query().id(SEARCH).replace_id(SEARCH).target(PaneType::Search).query(move |client| {
             let filter = filter
                 .iter_mut()
                 .map(|&mut (ref mut key, ref value, ref mut kind)| {
-                    Filter::new(std::mem::take(key), value).with_type(*kind)
+                    Filter::new(std::mem::take(key), value).with_type((*kind).into())
                 })
                 .collect_vec();
 
-            let result = if ignore_case {
-                client.search(&filter, ignore_diacritics)
+            let data = if fold_case {
+                client.search(&filter, strip_diacritics)
             } else {
                 client.find(&filter)
             }?;
 
-            Ok(MpdQueryResult::SongsList { data: result, origin_path: None })
+            if need_stickers_fetch && !matches!(rating_kind, RatingMode::Any) {
+                let filter: Option<StickerFilter> = match rating_kind {
+                    RatingMode::Equals => Some(StickerFilter::EqualsInt(rating_value)),
+                    RatingMode::GreaterThan => Some(StickerFilter::GreaterThanInt(rating_value)),
+                    RatingMode::LessThan => Some(StickerFilter::LessThanInt(rating_value)),
+                    RatingMode::Any => None,
+                };
+
+                // empty URI returns all songs with the sticker
+                let ratings = client.find_stickers("", "rating", filter)?;
+                let ratings: HashSet<_> = ratings.into_iter().map(|r| r.file).collect();
+
+                let data = data.into_iter().filter(|song| ratings.contains(&song.file)).collect();
+
+                Ok(MpdQueryResult::SearchResult { data })
+            } else {
+                Ok(MpdQueryResult::SearchResult { data })
+            }
         });
-    }
-
-    fn reset(&mut self, search_config: &Search) {
-        for val in &mut self.inputs.textbox_inputs {
-            let Textbox { value, .. } = val;
-            value.clear();
-        }
-        for val in &mut self.inputs.filter_inputs {
-            match val.variant {
-                FilterInputVariant::FilterKind { ref mut value } => {
-                    *value = search_config.mode;
-                }
-                FilterInputVariant::CaseSensitive => {}
-                FilterInputVariant::IgnoreDiacritics => {}
-            }
-        }
-        self.inputs.ignore_case = search_config.case_sensitive;
-        self.inputs.ignore_diacritics = self.initial_ignore_diacritics;
-    }
-
-    fn activate_input(&mut self, ctx: &Ctx) {
-        match self.inputs.focused_mut() {
-            FocusedInputGroup::Textboxes(_) => self.phase = Phase::SearchTextboxInput,
-            FocusedInputGroup::Buttons(_) => {
-                // Reset is the only button in this group at the moment
-                self.reset(&ctx.config.search);
-                self.songs_dir = Dir::default();
-            }
-            FocusedInputGroup::Filters(FilterInput {
-                variant: FilterInputVariant::FilterKind { value },
-                ..
-            }) => {
-                value.cycle();
-                self.search(ctx);
-            }
-            FocusedInputGroup::Filters(FilterInput {
-                variant: FilterInputVariant::CaseSensitive,
-                ..
-            }) => {
-                self.inputs.ignore_case = !self.inputs.ignore_case;
-                // Ignore case and ignore diacritics cannot exist at the same time because they
-                // are different MPD commands (search vs find).
-                if !self.inputs.ignore_case {
-                    self.inputs.ignore_diacritics = false;
-                }
-                self.search(ctx);
-            }
-            FocusedInputGroup::Filters(FilterInput {
-                variant: FilterInputVariant::IgnoreDiacritics,
-                ..
-            }) => {
-                self.inputs.ignore_diacritics = !self.inputs.ignore_diacritics;
-                // Ignore case and ignore diacritics cannot exist at the same time because they
-                // are different MPD commands (search vs find).
-                if self.inputs.ignore_diacritics {
-                    self.inputs.ignore_case = true;
-                }
-                self.search(ctx);
-            }
-        }
-    }
-
-    fn get_clicked_input(&self, event: MouseEvent) -> Option<FocusedInput> {
-        for i in 0..self.inputs.textbox_inputs.len() {
-            if self.input_areas[i].contains(event.into()) {
-                return Some(FocusedInput::Textboxes(i));
-            }
-        }
-
-        // have to account for the separator between inputs/filter config inputs
-        let start = self.inputs.textbox_inputs.len() + 1;
-        for i in start..start + self.inputs.filter_inputs.len() {
-            if self.input_areas[i].contains(event.into()) {
-                return Some(FocusedInput::Filters(i - start));
-            }
-        }
-
-        // have to account for the separator between filter config
-        // inputs/buttons
-        let start = start + self.inputs.filter_inputs.len() + 1;
-        for i in start..start + self.inputs.button_inputs.len() {
-            if self.input_areas[i].contains(event.into()) {
-                return Some(FocusedInput::Buttons(i - start));
-            }
-        }
-
-        None
     }
 
     fn handle_search_phase_action(&mut self, event: &mut KeyEvent, ctx: &mut Ctx) -> Result<()> {
@@ -495,14 +291,13 @@ impl SearchPane {
                 CommonAction::Rename => {}
                 CommonAction::Close => {}
                 CommonAction::Confirm => {
-                    self.activate_input(ctx);
+                    if self.inputs.activate_focused() {
+                        self.search(ctx);
+                    }
                     ctx.render()?;
                 }
-                CommonAction::FocusInput
-                    if matches!(self.inputs.focused(), FocusedInputGroup::Textboxes(_)) =>
-                {
-                    self.phase = Phase::SearchTextboxInput;
-
+                CommonAction::FocusInput => {
+                    self.inputs.enter_insert_mode();
                     ctx.render()?;
                 }
                 // Modal while we are on search column does not support all options. It can
@@ -525,16 +320,7 @@ impl SearchPane {
                 // This action only makes sense when opts.all is true while we are on the
                 // search column.
                 CommonAction::AddOptions { kind: AddKind::Action(_) } => {}
-                CommonAction::FocusInput => {}
-                CommonAction::Delete => match self.inputs.focused_mut() {
-                    FocusedInputGroup::Textboxes(textbox) if !textbox.value.is_empty() => {
-                        textbox.value.clear();
-                        self.search(ctx);
-
-                        ctx.render()?;
-                    }
-                    _ => {}
-                },
+                CommonAction::Delete => self.inputs.reset_focused(),
                 CommonAction::PaneDown => {}
                 CommonAction::PaneUp => {}
                 CommonAction::PaneRight => {}
@@ -942,54 +728,6 @@ impl SearchPane {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_search_pane_scrollbar_calculation() {
-        let scrollbar_height: u16 = 10;
-        let total_items: usize = 50;
-
-        let clicked_y = scrollbar_height.saturating_sub(1);
-        let target_idx = if clicked_y >= scrollbar_height.saturating_sub(1) {
-            total_items.saturating_sub(1)
-        } else {
-            let position_ratio =
-                f64::from(clicked_y) / f64::from(scrollbar_height.saturating_sub(1));
-            ((position_ratio * (total_items.saturating_sub(1)) as f64) as usize)
-                .min(total_items.saturating_sub(1))
-        };
-
-        assert_eq!(target_idx, total_items - 1);
-
-        let clicked_y = 0;
-        let position_ratio = f64::from(clicked_y) / f64::from(scrollbar_height.saturating_sub(1));
-        let target_idx = ((position_ratio * (total_items.saturating_sub(1)) as f64) as usize)
-            .min(total_items.saturating_sub(1));
-
-        assert_eq!(target_idx, 0);
-
-        let clicked_y = 5;
-        let position_ratio = f64::from(clicked_y) / f64::from(scrollbar_height.saturating_sub(1));
-        let target_idx = ((position_ratio * (total_items.saturating_sub(1)) as f64) as usize)
-            .min(total_items.saturating_sub(1));
-
-        // should be roughly in the middle (around 25-27)
-        assert!((20..=30).contains(&target_idx));
-    }
-
-    #[test]
-    fn test_search_pane_phase_check() {
-        assert!(matches!(
-            Phase::BrowseResults { filter_input_on: false },
-            Phase::BrowseResults { .. }
-        ));
-        assert!(!matches!(Phase::Search, Phase::BrowseResults { .. }));
-        assert!(!matches!(Phase::SearchTextboxInput, Phase::BrowseResults { .. }));
-    }
-}
-
 impl Pane for SearchPane {
     fn render(
         &mut self,
@@ -1029,9 +767,9 @@ impl Pane for SearchPane {
         };
 
         match self.phase {
-            Phase::Search | Phase::SearchTextboxInput => {
+            Phase::Search => {
                 self.column_areas[BrowserArea::Current] = current_area;
-                self.render_input_column(frame, current_area, &ctx.config);
+                frame.render_widget(&mut self.inputs, current_area);
 
                 // Render only the part of the preview that is actually supposed to be shown
                 let offset = self.songs_dir.state.offset();
@@ -1043,7 +781,7 @@ impl Pane for SearchPane {
             }
             Phase::BrowseResults { filter_input_on: _ } => {
                 self.render_song_column(frame, current_area, ctx);
-                self.render_input_column(frame, previous_area, &ctx.config);
+                frame.render_widget(&mut self.inputs, previous_area);
                 if let Some(song) = self.songs_dir.selected() {
                     let preview = song.to_preview(
                         ctx.config.theme.preview_label_style,
@@ -1100,15 +838,15 @@ impl Pane for SearchPane {
         ctx: &Ctx,
     ) -> Result<()> {
         match (id, data) {
-            (SEARCH, MpdQueryResult::SongsList { data, origin_path: _ }) => {
-                log::debug!("fetching song stickers for search results");
+            (SEARCH, MpdQueryResult::SearchResult { data }) => {
+                log::debug!(len = data.len(); "fetching song stickers for search results");
                 let songs = data
                     .iter()
                     .map(|song| song.file.clone())
                     .filter(|file| !ctx.stickers.contains_key(file))
                     .collect_vec();
 
-                if !songs.is_empty() && ctx.should_fetch_stickers {
+                if !songs.is_empty() && ctx.stickers_supported {
                     log::debug!("fetching stickers for {} songs", songs.len());
                     ctx.query().id(FETCH_SONG_STICKERS).query(move |client| {
                         Ok(MpdQueryResult::SongStickers(client.fetch_song_stickers(songs)?))
@@ -1123,7 +861,7 @@ impl Pane for SearchPane {
         Ok(())
     }
 
-    fn handle_mouse_event(&mut self, mut event: MouseEvent, ctx: &Ctx) -> Result<()> {
+    fn handle_mouse_event(&mut self, event: MouseEvent, ctx: &Ctx) -> Result<()> {
         if self.handle_scrollbar_interaction(event, ctx)? {
             return Ok(());
         }
@@ -1133,22 +871,14 @@ impl Pane for SearchPane {
                 if self.column_areas[BrowserArea::Previous].contains(event.into()) =>
             {
                 self.phase = Phase::Search;
-                // Modify x coord to belong to middle column in order to satisfy
-                // the condition inside get_clicked_input. This
-                // is fine because phase is switched to Search.
-                // A bit hacky, but wcyd.
-                event.x = self.input_areas[1].x;
-                if let Some(input) = self.get_clicked_input(event) {
-                    self.inputs.focused_idx = input;
-                }
-
+                self.inputs.focus_input_at(event.into());
                 ctx.render()?;
             }
             MouseEventKind::LeftClick
                 if self.column_areas[BrowserArea::Preview].contains(event.into()) =>
             {
                 match self.phase {
-                    Phase::SearchTextboxInput | Phase::Search => {
+                    Phase::Search => {
                         if !self.songs_dir.items.is_empty() {
                             self.phase = Phase::BrowseResults { filter_input_on: false };
 
@@ -1188,16 +918,14 @@ impl Pane for SearchPane {
                 if self.column_areas[BrowserArea::Current].contains(event.into()) =>
             {
                 match self.phase {
-                    Phase::SearchTextboxInput | Phase::Search => {
-                        if matches!(self.phase, Phase::SearchTextboxInput) {
+                    Phase::Search => {
+                        if self.inputs.insert_mode {
                             self.phase = Phase::Search;
+                            self.inputs.insert_mode = false;
                             self.search(ctx);
                         }
 
-                        if let Some(input) = self.get_clicked_input(event) {
-                            self.inputs.focused_idx = input;
-                        }
-
+                        self.inputs.focus_input_at(event.into());
                         ctx.render()?;
                     }
                     Phase::BrowseResults { .. } => {
@@ -1215,11 +943,13 @@ impl Pane for SearchPane {
                 }
             }
             MouseEventKind::DoubleClick => match self.phase {
-                Phase::SearchTextboxInput | Phase::Search => {
-                    if self.get_clicked_input(event).is_some() {
-                        self.activate_input(ctx);
-                        ctx.render()?;
+                Phase::Search => {
+                    if self.column_areas[BrowserArea::Current].contains(event.into())
+                        && self.inputs.activate_focused()
+                    {
+                        self.search(ctx);
                     }
+                    ctx.render()?;
                 }
                 Phase::BrowseResults { .. } => {
                     let (_, items) = self.enqueue(false);
@@ -1235,7 +965,7 @@ impl Pane for SearchPane {
                 if self.column_areas[BrowserArea::Current].contains(event.into()) =>
             {
                 match self.phase {
-                    Phase::SearchTextboxInput | Phase::Search => {}
+                    Phase::Search => {}
                     Phase::BrowseResults { .. } => {
                         let clicked_row = event
                             .y
@@ -1258,8 +988,9 @@ impl Pane for SearchPane {
                 }
             }
             MouseEventKind::ScrollDown => match self.phase {
-                Phase::SearchTextboxInput | Phase::Search => {
-                    if matches!(self.phase, Phase::SearchTextboxInput) {
+                Phase::Search => {
+                    if self.inputs.insert_mode {
+                        self.inputs.insert_mode = false;
                         self.phase = Phase::Search;
                         self.search(ctx);
                     }
@@ -1272,8 +1003,9 @@ impl Pane for SearchPane {
                 }
             },
             MouseEventKind::ScrollUp => match self.phase {
-                Phase::SearchTextboxInput | Phase::Search => {
-                    if matches!(self.phase, Phase::SearchTextboxInput) {
+                Phase::Search => {
+                    if self.inputs.insert_mode {
+                        self.inputs.insert_mode = false;
                         self.phase = Phase::Search;
                         self.search(ctx);
                     }
@@ -1309,15 +1041,17 @@ impl Pane for SearchPane {
 
     fn handle_action(&mut self, event: &mut KeyEvent, ctx: &mut Ctx) -> Result<()> {
         match &mut self.phase {
-            Phase::SearchTextboxInput => match event.as_common_action(ctx) {
+            Phase::Search if self.inputs.insert_mode => match event.as_common_action(ctx) {
                 Some(CommonAction::Close) => {
                     self.phase = Phase::Search;
+                    self.inputs.insert_mode = false;
                     self.search(ctx);
 
                     ctx.render()?;
                 }
                 Some(CommonAction::Confirm) => {
                     self.phase = Phase::Search;
+                    self.inputs.insert_mode = false;
                     self.search(ctx);
 
                     ctx.render()?;
@@ -1326,20 +1060,25 @@ impl Pane for SearchPane {
                     event.stop_propagation();
                     match event.code() {
                         KeyCode::Char(c) => match self.inputs.focused_mut() {
-                            FocusedInputGroup::Textboxes(Textbox { value, .. }) => {
+                            InputType::Textbox(TextboxInput { value, .. }) => {
                                 value.push(c);
-
                                 ctx.render()?;
                             }
-                            FocusedInputGroup::Filters(_) | FocusedInputGroup::Buttons(_) => {}
+                            InputType::Numberbox(TextboxInput { value, .. }) => {
+                                if c.is_numeric() {
+                                    value.push(c);
+                                    ctx.render()?;
+                                }
+                            }
+                            _ => {}
                         },
                         KeyCode::Backspace => match self.inputs.focused_mut() {
-                            FocusedInputGroup::Textboxes(Textbox { value, .. }) => {
+                            InputType::Textbox(TextboxInput { value, .. })
+                            | InputType::Numberbox(TextboxInput { value, .. }) => {
                                 value.pop();
-
                                 ctx.render()?;
                             }
-                            FocusedInputGroup::Filters(_) | FocusedInputGroup::Buttons(_) => {}
+                            _ => {}
                         },
                         _ => {}
                     }
@@ -1359,206 +1098,44 @@ impl Pane for SearchPane {
     }
 }
 
-enum FocusedInputGroup<T, F, B> {
-    Textboxes(T),
-    Filters(F),
-    Buttons(B),
-}
-
-#[derive(Debug)]
-enum FocusedInput {
-    Textboxes(usize),
-    Filters(usize),
-    Buttons(usize),
-}
-
-#[derive(Debug)]
-struct InputGroups<const N3: usize> {
-    textbox_inputs: Vec<Textbox>,
-    filter_inputs: Vec<FilterInput>,
-    button_inputs: [ButtonInput; N3],
-    focused_idx: FocusedInput,
-    ignore_case: bool,
-    ignore_diacritics: bool,
-}
-
-impl<const N3: usize> InputGroups<N3> {
-    pub fn new(
-        search_config: &Search,
-        filter_inputs: Vec<FilterInput>,
-        button_inputs: [ButtonInput; N3],
-        initial_case_sensitive: bool,
-        initial_ignore_diacritics: bool,
-    ) -> Self {
-        Self {
-            textbox_inputs: search_config
-                .tags
-                .iter()
-                .map(|tag| Textbox {
-                    filter_key: tag.value.clone(),
-                    label: format!(" {:<18}:", tag.label),
-                    value: String::new(),
-                })
-                .collect_vec(),
-            filter_inputs,
-            button_inputs,
-            focused_idx: FocusedInput::Textboxes(0),
-            ignore_case: initial_case_sensitive,
-            ignore_diacritics: initial_ignore_diacritics,
-        }
-    }
-
-    pub fn first(&mut self) {
-        self.focused_idx = FocusedInput::Textboxes(0);
-    }
-
-    pub fn last(&mut self) {
-        self.focused_idx = FocusedInput::Buttons(self.button_inputs.len() - 1);
-    }
-
-    pub fn focused_mut(
-        &mut self,
-    ) -> FocusedInputGroup<&mut Textbox, &mut FilterInput, &mut ButtonInput> {
-        match self.focused_idx {
-            FocusedInput::Textboxes(idx) => {
-                FocusedInputGroup::Textboxes(&mut self.textbox_inputs[idx])
-            }
-            FocusedInput::Filters(idx) => FocusedInputGroup::Filters(&mut self.filter_inputs[idx]),
-            FocusedInput::Buttons(idx) => FocusedInputGroup::Buttons(&mut self.button_inputs[idx]),
-        }
-    }
-
-    pub fn focused(&self) -> FocusedInputGroup<&Textbox, &FilterInput, &ButtonInput> {
-        match self.focused_idx {
-            FocusedInput::Textboxes(idx) => FocusedInputGroup::Textboxes(&self.textbox_inputs[idx]),
-            FocusedInput::Filters(idx) => FocusedInputGroup::Filters(&self.filter_inputs[idx]),
-            FocusedInput::Buttons(idx) => FocusedInputGroup::Buttons(&self.button_inputs[idx]),
-        }
-    }
-
-    pub fn next_non_wrapping(&mut self) {
-        match self.focused_idx {
-            FocusedInput::Textboxes(idx) if idx == self.textbox_inputs.len() - 1 => {
-                self.focused_idx = FocusedInput::Filters(0);
-            }
-            FocusedInput::Textboxes(ref mut idx) => {
-                *idx += 1;
-            }
-            FocusedInput::Filters(idx) if idx == self.filter_inputs.len() - 1 => {
-                self.focused_idx = FocusedInput::Buttons(0);
-            }
-            FocusedInput::Filters(ref mut idx) => {
-                *idx += 1;
-            }
-            FocusedInput::Buttons(idx) if idx == self.button_inputs.len() - 1 => {}
-            FocusedInput::Buttons(ref mut idx) => {
-                *idx += 1;
-            }
-        }
-    }
-
-    pub fn next(&mut self) {
-        match self.focused_idx {
-            FocusedInput::Textboxes(idx) if idx == self.textbox_inputs.len() - 1 => {
-                self.focused_idx = FocusedInput::Filters(0);
-            }
-            FocusedInput::Textboxes(ref mut idx) => {
-                *idx += 1;
-            }
-            FocusedInput::Filters(idx) if idx == self.filter_inputs.len() - 1 => {
-                self.focused_idx = FocusedInput::Buttons(0);
-            }
-            FocusedInput::Filters(ref mut idx) => {
-                *idx += 1;
-            }
-            FocusedInput::Buttons(idx) if idx == self.button_inputs.len() - 1 => {
-                self.focused_idx = FocusedInput::Textboxes(0);
-            }
-            FocusedInput::Buttons(ref mut idx) => {
-                *idx += 1;
-            }
-        }
-    }
-
-    pub fn prev_non_wrapping(&mut self) {
-        match self.focused_idx {
-            FocusedInput::Textboxes(0) => {}
-            FocusedInput::Textboxes(ref mut idx) => {
-                *idx -= 1;
-            }
-            FocusedInput::Filters(0) => {
-                self.focused_idx = FocusedInput::Textboxes(self.textbox_inputs.len() - 1);
-            }
-            FocusedInput::Filters(ref mut idx) => {
-                *idx -= 1;
-            }
-            FocusedInput::Buttons(0) => {
-                self.focused_idx = FocusedInput::Filters(self.filter_inputs.len() - 1);
-            }
-            FocusedInput::Buttons(ref mut idx) => {
-                *idx -= 1;
-            }
-        }
-    }
-
-    pub fn prev(&mut self) {
-        match self.focused_idx {
-            FocusedInput::Textboxes(0) => {
-                self.focused_idx = FocusedInput::Buttons(self.button_inputs.len() - 1);
-            }
-            FocusedInput::Textboxes(ref mut idx) => {
-                *idx -= 1;
-            }
-            FocusedInput::Filters(0) => {
-                self.focused_idx = FocusedInput::Textboxes(self.textbox_inputs.len() - 1);
-            }
-            FocusedInput::Filters(ref mut idx) => {
-                *idx -= 1;
-            }
-            FocusedInput::Buttons(0) => {
-                self.focused_idx = FocusedInput::Filters(self.filter_inputs.len() - 1);
-            }
-            FocusedInput::Buttons(ref mut idx) => {
-                *idx -= 1;
-            }
-        }
-    }
-}
-
 #[derive(Debug)]
 enum Phase {
-    SearchTextboxInput,
     Search,
     BrowseResults { filter_input_on: bool },
 }
 
-#[derive(Debug)]
-struct Textbox {
-    value: String,
-    label: String,
-    filter_key: String,
-}
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_search_pane_scrollbar_calculation() {
+        let scrollbar_height: u16 = 10;
+        let total_items: usize = 50;
 
-#[derive(Debug)]
-struct FilterInput {
-    variant: FilterInputVariant,
-    label: String,
-}
+        let clicked_y = scrollbar_height.saturating_sub(1);
+        let target_idx = if clicked_y >= scrollbar_height.saturating_sub(1) {
+            total_items.saturating_sub(1)
+        } else {
+            let position_ratio =
+                f64::from(clicked_y) / f64::from(scrollbar_height.saturating_sub(1));
+            ((position_ratio * (total_items.saturating_sub(1)) as f64) as usize)
+                .min(total_items.saturating_sub(1))
+        };
 
-#[derive(Debug, PartialEq)]
-enum FilterInputVariant {
-    FilterKind { value: FilterKind },
-    CaseSensitive,
-    IgnoreDiacritics,
-}
+        assert_eq!(target_idx, total_items - 1);
 
-#[derive(Debug)]
-struct ButtonInput {
-    variant: ButtonInputVariant,
-    label: &'static str,
-}
+        let clicked_y = 0;
+        let position_ratio = f64::from(clicked_y) / f64::from(scrollbar_height.saturating_sub(1));
+        let target_idx = ((position_ratio * (total_items.saturating_sub(1)) as f64) as usize)
+            .min(total_items.saturating_sub(1));
 
-#[derive(Debug, PartialEq)]
-enum ButtonInputVariant {
-    Reset,
+        assert_eq!(target_idx, 0);
+
+        let clicked_y = 5;
+        let position_ratio = f64::from(clicked_y) / f64::from(scrollbar_height.saturating_sub(1));
+        let target_idx = ((position_ratio * (total_items.saturating_sub(1)) as f64) as usize)
+            .min(total_items.saturating_sub(1));
+
+        // should be roughly in the middle (around 25-27)
+        assert!((20..=30).contains(&target_idx));
+    }
 }

--- a/src/ui/panes/search/mod.rs
+++ b/src/ui/panes/search/mod.rs
@@ -342,10 +342,10 @@ impl SearchPane {
                 CommonAction::PaneLeft => {}
                 CommonAction::ShowInfo => {}
                 CommonAction::ContextMenu => {}
-                CommonAction::Rating { kind: _, current: true } => {
+                CommonAction::Rate { kind: _, current: true } => {
                     event.abandon();
                 }
-                CommonAction::Rating { .. } => {}
+                CommonAction::Rate { .. } => {}
             }
         }
 
@@ -561,21 +561,21 @@ impl SearchPane {
                 CommonAction::ContextMenu => {
                     self.open_result_phase_context_menu(ctx)?;
                 }
-                CommonAction::Rating { kind: RatingKind::Value(value), current: false } => {
+                CommonAction::Rate { kind: RatingKind::Value(value), current: false } => {
                     let items = self.enqueue(false).1;
                     ctx.command(move |client| {
                         client.set_sticker_multiple("rating", value.to_string(), items)?;
                         Ok(())
                     });
                 }
-                CommonAction::Rating {
+                CommonAction::Rate {
                     kind: RatingKind::Modal { values, custom },
                     current: false,
                 } => {
                     let items = self.enqueue(false).1;
                     modal!(ctx, create_rating_modal(items, values.as_slice(), custom, ctx));
                 }
-                CommonAction::Rating { kind: _, current: true } => {
+                CommonAction::Rate { kind: _, current: true } => {
                     event.abandon();
                 }
             }

--- a/src/ui/panes/search/mod.rs
+++ b/src/ui/panes/search/mod.rs
@@ -36,7 +36,6 @@ use crate::{
         mpd_client_ext::{Autoplay, Enqueue, MpdClientExt},
     },
     ui::{
-        FETCH_SONG_STICKERS,
         UiEvent,
         dirstack::Dir,
         modals::{
@@ -802,7 +801,7 @@ impl Pane for SearchPane {
                     let preview = song.to_preview(
                         ctx.config.theme.preview_label_style,
                         ctx.config.theme.preview_metadata_group_style,
-                        ctx.stickers.get(&song.file),
+                        ctx,
                     );
                     let mut result = Vec::new();
                     for group in preview {
@@ -855,20 +854,6 @@ impl Pane for SearchPane {
     ) -> Result<()> {
         match (id, data) {
             (SEARCH, MpdQueryResult::SearchResult { data }) => {
-                log::debug!(len = data.len(); "fetching song stickers for search results");
-                let songs = data
-                    .iter()
-                    .map(|song| song.file.clone())
-                    .filter(|file| !ctx.stickers.contains_key(file))
-                    .collect_vec();
-
-                if !songs.is_empty() && ctx.stickers_supported {
-                    log::debug!("fetching stickers for {} songs", songs.len());
-                    ctx.query().id(FETCH_SONG_STICKERS).query(move |client| {
-                        Ok(MpdQueryResult::SongStickers(client.fetch_song_stickers(songs)?))
-                    });
-                }
-
                 self.songs_dir = Dir::new(data);
                 ctx.render()?;
             }

--- a/src/ui/panes/search/mod.rs
+++ b/src/ui/panes/search/mod.rs
@@ -342,7 +342,7 @@ impl SearchPane {
                 CommonAction::PaneLeft => {}
                 CommonAction::ShowInfo => {}
                 CommonAction::ContextMenu => {}
-                CommonAction::Rate { kind: _, current: true } => {
+                CommonAction::Rate { kind: _, min_rating: _, max_rating: _, current: true } => {
                     event.abandon();
                 }
                 CommonAction::Rate { .. } => {}
@@ -561,7 +561,12 @@ impl SearchPane {
                 CommonAction::ContextMenu => {
                     self.open_result_phase_context_menu(ctx)?;
                 }
-                CommonAction::Rate { kind: RatingKind::Value(value), current: false } => {
+                CommonAction::Rate {
+                    kind: RatingKind::Value(value),
+                    current: false,
+                    min_rating: _,
+                    max_rating: _,
+                } => {
                     let items = self.enqueue(false).1;
                     ctx.command(move |client| {
                         client.set_sticker_multiple("rating", value.to_string(), items)?;
@@ -571,11 +576,23 @@ impl SearchPane {
                 CommonAction::Rate {
                     kind: RatingKind::Modal { values, custom },
                     current: false,
+                    min_rating,
+                    max_rating,
                 } => {
                     let items = self.enqueue(false).1;
-                    modal!(ctx, create_rating_modal(items, values.as_slice(), custom, ctx));
+                    modal!(
+                        ctx,
+                        create_rating_modal(
+                            items,
+                            values.as_slice(),
+                            min_rating,
+                            max_rating,
+                            custom,
+                            ctx
+                        )
+                    );
                 }
-                CommonAction::Rate { kind: _, current: true } => {
+                CommonAction::Rate { kind: _, current: true, min_rating: _, max_rating: _ } => {
                     event.abandon();
                 }
             }

--- a/src/ui/panes/search/mod.rs
+++ b/src/ui/panes/search/mod.rs
@@ -342,6 +342,9 @@ impl SearchPane {
                 CommonAction::PaneLeft => {}
                 CommonAction::ShowInfo => {}
                 CommonAction::ContextMenu => {}
+                CommonAction::Rating { kind: _, current: true } => {
+                    event.abandon();
+                }
                 CommonAction::Rating { .. } => {}
             }
         }
@@ -558,16 +561,22 @@ impl SearchPane {
                 CommonAction::ContextMenu => {
                     self.open_result_phase_context_menu(ctx)?;
                 }
-                CommonAction::Rating { kind: RatingKind::Value(value) } => {
+                CommonAction::Rating { kind: RatingKind::Value(value), current: false } => {
                     let items = self.enqueue(false).1;
                     ctx.command(move |client| {
                         client.set_sticker_multiple("rating", value.to_string(), items)?;
                         Ok(())
                     });
                 }
-                CommonAction::Rating { kind: RatingKind::Modal { values, custom } } => {
+                CommonAction::Rating {
+                    kind: RatingKind::Modal { values, custom },
+                    current: false,
+                } => {
                     let items = self.enqueue(false).1;
                     modal!(ctx, create_rating_modal(items, values.as_slice(), custom, ctx));
+                }
+                CommonAction::Rating { kind: _, current: true } => {
+                    event.abandon();
                 }
             }
         }

--- a/src/ui/panes/tag_browser.rs
+++ b/src/ui/panes/tag_browser.rs
@@ -28,6 +28,7 @@ use crate::{
         string_util::StringExt,
     },
     ui::{
+        FETCH_SONG_STICKERS,
         UiEvent,
         browser::BrowserPane,
         dir_or_song::DirOrSong,
@@ -46,15 +47,12 @@ pub struct TagBrowserPane {
     target_pane: PaneType,
     browser: Browser<DirOrSong>,
     initialized: bool,
-    cache: TagBrowserCache,
+    cache: HashMap<String, CachedRootTag>,
 }
 
 const INIT: &str = "init";
 const OPEN_OR_PLAY: &str = "open_or_play";
 const PREVIEW: &str = "preview";
-
-#[derive(Debug, Default)]
-struct TagBrowserCache(HashMap<String, CachedRootTag>);
 
 #[derive(Debug, Default)]
 struct CachedRootTag(Vec<CachedAlbum>);
@@ -82,7 +80,7 @@ impl TagBrowserPane {
             filter_input_mode: false,
             browser: Browser::new(),
             initialized: false,
-            cache: TagBrowserCache::default(),
+            cache: HashMap::default(),
         }
     }
 
@@ -137,7 +135,7 @@ impl TagBrowserPane {
                 }
             }
             [artist] => {
-                let Some(albums) = self.cache.0.get(artist) else {
+                let Some(albums) = self.cache.get(artist) else {
                     return Ok(());
                 };
                 let Some(CachedAlbum { songs, .. }) =
@@ -153,7 +151,7 @@ impl TagBrowserPane {
             }
             [] => {
                 let current = current.as_path().to_owned();
-                if let Some(albums) = self.cache.0.get(&current) {
+                if let Some(albums) = self.cache.get(&current) {
                     let albums = albums
                         .0
                         .iter()
@@ -192,7 +190,7 @@ impl TagBrowserPane {
         let display_mode = ctx.config.artists.album_display_mode;
         let sort_mode = ctx.config.artists.album_sort_by;
 
-        let cached_artist = self.cache.0.entry(artist).or_default();
+        let cached_artist = self.cache.entry(artist).or_default();
 
         let albums = data
             .into_iter()
@@ -270,7 +268,7 @@ impl Pane for TagBrowserPane {
             area,
             frame.buffer_mut(),
             &mut self.stack,
-            &ctx.config,
+            ctx,
         );
 
         Ok(())
@@ -296,7 +294,7 @@ impl Pane for TagBrowserPane {
             UiEvent::Database => {
                 let root_tag = self.root_tag.clone();
                 let target = self.target_pane.clone();
-                self.cache = TagBrowserCache::default();
+                self.cache = HashMap::default();
                 ctx.query().id(INIT).replace_id(INIT).target(target).query(move |client| {
                     let result = client.list_tag(root_tag, None).context("Cannot list artists")?;
                     Ok(MpdQueryResult::LsInfo { data: result.0, origin_path: None })
@@ -347,6 +345,12 @@ impl Pane for TagBrowserPane {
                     true
                 };
 
+                let files = data.iter().map(|s| s.file.clone()).collect_vec();
+                ctx.query().id(FETCH_SONG_STICKERS).query(|client| {
+                    let stickers = client.fetch_song_stickers(files)?;
+                    Ok(MpdQueryResult::SongStickers(stickers))
+                });
+
                 let cached_artist = self.process_songs(artist, data, ctx);
 
                 if cache_only {
@@ -360,8 +364,7 @@ impl Pane for TagBrowserPane {
                         .0
                         .iter()
                         .map(|album| {
-                            DirOrSong::name_only(album.name.clone())
-                                .to_list_item_simple(&ctx.config)
+                            DirOrSong::name_only(album.name.clone()).to_list_item_simple(ctx)
                         })
                         .collect(),
                 )];
@@ -383,6 +386,12 @@ impl Pane for TagBrowserPane {
                     log::trace!(artist:?, current_path:? = self.stack().path(); "Dropping result because it does not belong to this path");
                     true
                 };
+
+                let files = data.iter().map(|s| s.file.clone()).collect_vec();
+                ctx.query().id(FETCH_SONG_STICKERS).query(|client| {
+                    let stickers = client.fetch_song_stickers(files)?;
+                    Ok(MpdQueryResult::SongStickers(stickers))
+                });
 
                 if cache_only {
                     return Ok(());
@@ -435,11 +444,8 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
         &mut self.stack
     }
 
-    fn initial_playlist_name(&self) -> Option<String> {
-        self.stack().current().selected().and_then(|item| match item {
-            DirOrSong::Dir { name, .. } => Some(name.to_owned()),
-            DirOrSong::Song(_) => None,
-        })
+    fn browser_areas(&self) -> EnumMap<BrowserArea, Rect> {
+        self.browser.areas
     }
 
     fn set_filter_input_mode_active(&mut self, active: bool) {
@@ -448,6 +454,10 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
 
     fn is_filter_input_mode_active(&self) -> bool {
         self.filter_input_mode
+    }
+
+    fn next(&mut self, ctx: &Ctx) -> Result<()> {
+        self.open_or_play(false, ctx)
     }
 
     fn list_songs_in_item(
@@ -460,7 +470,6 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
         let album_name = match (self.stack().path(), &item) {
             ([artist], DirOrSong::Dir { name, .. }) => self
                 .cache
-                .0
                 .get(artist)
                 .and_then(|albums| {
                     albums.0.iter().find(|a| &a.name == name).map(|a| a.original_name.clone())
@@ -488,84 +497,6 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
         }
     }
 
-    fn enqueue<'a>(
-        &self,
-        items: impl Iterator<Item = &'a DirOrSong>,
-    ) -> (Vec<Enqueue>, Option<usize>) {
-        match self.stack.path() {
-            [_tag_value, _album] => {
-                let hovered =
-                    self.stack.current().selected().map(|item| item.dir_name_or_file_name());
-
-                items.enumerate().fold((Vec::new(), None), |mut acc, (idx, item)| {
-                    let filename = item.dir_name_or_file_name().into_owned();
-                    if hovered.as_ref().is_some_and(|hovered| hovered == &filename) {
-                        acc.1 = Some(idx);
-                    }
-                    acc.0.push(Enqueue::Find {
-                        filter: vec![(Tag::File, FilterKind::Exact, filename)],
-                    });
-
-                    acc
-                })
-            }
-            [tag_value] => {
-                let tag_value = tag_value.clone();
-                let Some(albums) = self.cache.0.get(&tag_value) else {
-                    return (Vec::new(), None);
-                };
-
-                let items = items
-                    .filter_map(|item| {
-                        let name = item.dir_name_or_file_name();
-                        albums.0.iter().find(|a| a.name == name)
-                    })
-                    .flat_map(|album| {
-                        album.songs.iter().map(|song| Enqueue::Find {
-                            filter: vec![(Tag::File, FilterKind::Exact, song.file.clone())],
-                        })
-                    })
-                    .collect_vec();
-
-                (items, None)
-            }
-            [] => {
-                let root_tag = self.root_tag.clone();
-                let separator = self.separator.clone();
-
-                (
-                    items
-                        .map(|item| item.dir_name_or_file_name().into_owned())
-                        .map(|name| {
-                            let mut filter = Self::root_tag_filter(
-                                root_tag.clone(),
-                                separator.as_deref(),
-                                &name,
-                            );
-                            Enqueue::Find {
-                                filter: vec![(
-                                    filter.tag,
-                                    filter.kind,
-                                    std::mem::take(&mut filter.value).into_owned(),
-                                )],
-                            }
-                        })
-                        .collect_vec(),
-                    None,
-                )
-            }
-            _ => (Vec::new(), None),
-        }
-    }
-
-    fn open(&mut self, ctx: &Ctx) -> Result<()> {
-        self.open_or_play(true, ctx)
-    }
-
-    fn next(&mut self, ctx: &Ctx) -> Result<()> {
-        self.open_or_play(false, ctx)
-    }
-
     fn prepare_preview(&mut self, ctx: &Ctx) -> Result<()> {
         let Some(current) = self.stack.current().selected().map(DirStackItem::as_path) else {
             return Ok(());
@@ -577,22 +508,21 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
             [artist, album] => {
                 let key_style = ctx.config.theme.preview_label_style;
                 let group_style = ctx.config.theme.preview_metadata_group_style;
-                let Some(albums) = self.cache.0.get(artist) else {
+                let Some(albums) = self.cache.get(artist) else {
                     return Ok(());
                 };
                 let Some(CachedAlbum { songs, .. }) = albums.0.iter().find(|a| &a.name == album)
                 else {
                     return Ok(());
                 };
-                let song = songs
-                    .iter()
-                    .find(|song| song.file == current)
-                    .map(|song| song.to_preview(key_style, group_style));
+                let song = songs.iter().find(|song| song.file == current).map(|song| {
+                    song.to_preview(key_style, group_style, ctx.stickers.get(&song.file))
+                });
                 self.stack_mut().set_preview(song);
                 ctx.render()?;
             }
             [artist] => {
-                let Some(albums) = self.cache.0.get(artist) else {
+                let Some(albums) = self.cache.get(artist) else {
                     return Ok(());
                 };
                 let Some(CachedAlbum { songs, .. }) =
@@ -603,13 +533,14 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
                 let songs = vec![PreviewGroup::from(
                     None,
                     None,
-                    songs.iter().map(|song| song.to_list_item_simple(&ctx.config)).collect_vec(),
+                    songs.iter().map(|song| song.to_list_item_simple(ctx)).collect_vec(),
                 )];
+
                 self.stack_mut().set_preview(Some(songs));
                 ctx.render()?;
             }
             [] => {
-                if let Some(albums) = self.cache.0.get(&current) {
+                if let Some(albums) = self.cache.get(&current) {
                     self.stack.set_preview(Some(vec![PreviewGroup::from(
                         None,
                         None,
@@ -617,8 +548,7 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
                             .0
                             .iter()
                             .map(|CachedAlbum { name, .. }| {
-                                DirOrSong::name_only(name.to_owned())
-                                    .to_list_item_simple(&ctx.config)
+                                DirOrSong::name_only(name.to_owned()).to_list_item_simple(ctx)
                             })
                             .collect(),
                     )]));
@@ -646,8 +576,84 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
         Ok(())
     }
 
-    fn browser_areas(&self) -> EnumMap<BrowserArea, Rect> {
-        self.browser.areas
+    fn enqueue<'a>(
+        &self,
+        items: impl Iterator<Item = &'a DirOrSong>,
+    ) -> (Vec<Enqueue>, Option<usize>) {
+        match self.stack.path() {
+            [_tag_value, _album] => {
+                let hovered = self.stack.current().selected().map(|item| item.dir_name_or_file());
+
+                items.enumerate().fold((Vec::new(), None), |mut acc, (idx, item)| {
+                    let filename = item.dir_name_or_file().into_owned();
+                    if hovered.as_ref().is_some_and(|hovered| hovered == &filename) {
+                        acc.1 = Some(idx);
+                    }
+                    acc.0.push(Enqueue::Find {
+                        filter: vec![(Tag::File, FilterKind::Exact, filename)],
+                    });
+
+                    acc
+                })
+            }
+            [tag_value] => {
+                let tag_value = tag_value.clone();
+                let Some(albums) = self.cache.get(&tag_value) else {
+                    return (Vec::new(), None);
+                };
+
+                let items = items
+                    .filter_map(|item| {
+                        let name = item.dir_name_or_file();
+                        albums.0.iter().find(|a| a.name == name)
+                    })
+                    .flat_map(|album| {
+                        album.songs.iter().map(|song| Enqueue::Find {
+                            filter: vec![(Tag::File, FilterKind::Exact, song.file.clone())],
+                        })
+                    })
+                    .collect_vec();
+
+                (items, None)
+            }
+            [] => {
+                let root_tag = self.root_tag.clone();
+                let separator = self.separator.clone();
+
+                (
+                    items
+                        .map(|item| item.dir_name_or_file().into_owned())
+                        .map(|name| {
+                            let mut filter = Self::root_tag_filter(
+                                root_tag.clone(),
+                                separator.as_deref(),
+                                &name,
+                            );
+                            Enqueue::Find {
+                                filter: vec![(
+                                    filter.tag,
+                                    filter.kind,
+                                    std::mem::take(&mut filter.value).into_owned(),
+                                )],
+                            }
+                        })
+                        .collect_vec(),
+                    None,
+                )
+            }
+            _ => (Vec::new(), None),
+        }
+    }
+
+    fn open(&mut self, ctx: &Ctx) -> Result<()> {
+        self.open_or_play(true, ctx)
+    }
+
+    fn initial_playlist_name(&self) -> Option<String> {
+        self.stack().current().selected().and_then(|item| match item {
+            DirOrSong::Dir { name, .. } => Some(name.to_owned()),
+            DirOrSong::Song(_) => None,
+        })
     }
 }
 
@@ -673,7 +679,6 @@ mod tests {
                 ("album".to_string(), Into::<String>::into(album).into()),
                 ("date".to_string(), Into::<String>::into(date).into()),
             ]),
-            stickers: None,
             last_modified: chrono::Utc::now(),
             added: None,
         }
@@ -693,7 +698,6 @@ mod tests {
                 ("date".to_string(), Into::<String>::into(date).into()),
                 ("originaldate".to_string(), Into::<String>::into(original_date).into()),
             ]),
-            stickers: None,
             last_modified: chrono::Utc::now(),
             added: None,
         }

--- a/src/ui/panes/tag_browser.rs
+++ b/src/ui/panes/tag_browser.rs
@@ -27,7 +27,6 @@ use crate::{
         string_util::StringExt,
     },
     ui::{
-        FETCH_SONG_STICKERS,
         UiEvent,
         browser::BrowserPane,
         dir_or_song::DirOrSong,
@@ -344,12 +343,6 @@ impl Pane for TagBrowserPane {
                     true
                 };
 
-                let files = data.iter().map(|s| s.file.clone()).collect_vec();
-                ctx.query().id(FETCH_SONG_STICKERS).query(|client| {
-                    let stickers = client.fetch_song_stickers(files)?;
-                    Ok(MpdQueryResult::SongStickers(stickers))
-                });
-
                 let cached_artist = self.process_songs(artist, data, ctx);
 
                 if cache_only {
@@ -380,12 +373,6 @@ impl Pane for TagBrowserPane {
                     log::trace!(artist:?, current_path:? = self.stack().path(); "Dropping result because it does not belong to this path");
                     true
                 };
-
-                let files = data.iter().map(|s| s.file.clone()).collect_vec();
-                ctx.query().id(FETCH_SONG_STICKERS).query(|client| {
-                    let stickers = client.fetch_song_stickers(files)?;
-                    Ok(MpdQueryResult::SongStickers(stickers))
-                });
 
                 if cache_only {
                     return Ok(());

--- a/src/ui/widgets/browser.rs
+++ b/src/ui/widgets/browser.rs
@@ -6,7 +6,7 @@ use ratatui::{
 use style::Styled;
 
 use crate::{
-    config::Config,
+    ctx::Ctx,
     ui::dirstack::{Dir, DirStack, DirStackItem},
 };
 
@@ -60,8 +60,9 @@ where
         area: ratatui::prelude::Rect,
         buf: &mut ratatui::prelude::Buffer,
         state: &mut DirStack<T>,
-        config: &Config,
+        ctx: &Ctx,
     ) {
+        let config = &ctx.config;
         let scrollbar_margin = match config.theme.scrollbar.as_ref() {
             Some(scrollbar) if config.theme.draw_borders => {
                 let scrollbar_track = &scrollbar.symbols[0];
@@ -71,8 +72,8 @@ where
         };
         let column_right_padding: u16 = config.theme.scrollbar.is_some().into();
 
-        let previous = state.previous().to_list_items(config);
-        let current = state.current().to_list_items(config);
+        let previous = state.previous().to_list_items(ctx);
+        let current = state.current().to_list_items(ctx);
         let preview = state.preview().cloned();
 
         let [previous_area, current_area, preview_area] = *Layout::horizontal([

--- a/src/ui/widgets/browser.rs
+++ b/src/ui/widgets/browser.rs
@@ -107,7 +107,10 @@ where
                 result
             } else if state.current().selected().is_some() {
                 state.preview().map_or(Vec::new(), |p| {
-                    p.iter().map(|item| item.to_list_item_simple(ctx)).collect_vec()
+                    p.iter()
+                        .take(self.areas[BrowserArea::Preview].height as usize)
+                        .map(|item| item.to_list_item_simple(ctx))
+                        .collect_vec()
                 })
             } else {
                 Vec::new()

--- a/src/ui/widgets/browser.rs
+++ b/src/ui/widgets/browser.rs
@@ -1,4 +1,5 @@
 use enum_map::{Enum, EnumMap};
+use itertools::Itertools;
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, List, ListItem, Padding},
@@ -74,7 +75,6 @@ where
 
         let previous = state.previous().to_list_items(ctx);
         let current = state.current().to_list_items(ctx);
-        let preview = state.preview().cloned();
 
         let [previous_area, current_area, preview_area] = *Layout::horizontal([
             Constraint::Percentage(config.theme.column_widths[0]),
@@ -85,21 +85,33 @@ where
             return;
         };
 
+        self.areas[BrowserArea::Preview] = preview_area;
         if config.theme.column_widths[2] > 0 {
-            self.areas[BrowserArea::Preview] = preview_area;
-
-            let mut result = Vec::new();
-            for group in preview.unwrap_or_default() {
-                if let Some(name) = group.name {
-                    let mut item = ListItem::new(name);
-                    if let Some(style) = group.header_style {
-                        item = item.style(style);
+            let result = if let Some(current) = state.current().selected()
+                && current.is_file()
+            {
+                let previews = current.to_file_preview(ctx);
+                let mut result = Vec::new();
+                for group in previews {
+                    if let Some(name) = group.name {
+                        let mut item = ListItem::new(name);
+                        if let Some(style) = group.header_style {
+                            item = item.style(style);
+                        }
+                        result.push(item);
                     }
-                    result.push(item);
+                    result.extend(group.items);
+                    result.push(ListItem::new(Span::raw("")));
                 }
-                result.extend(group.items);
-                result.push(ListItem::new(Span::raw("")));
-            }
+
+                result
+            } else if state.current().selected().is_some() {
+                state.preview().map_or(Vec::new(), |p| {
+                    p.iter().map(|item| item.to_list_item_simple(ctx)).collect_vec()
+                })
+            } else {
+                Vec::new()
+            };
 
             let preview = List::new(result).style(config.as_text_style());
             ratatui::widgets::Widget::render(preview, preview_area, buf);

--- a/src/ui/widgets/header.rs
+++ b/src/ui/widgets/header.rs
@@ -61,6 +61,7 @@ impl<'a> PropertyTemplates<'a> {
         Line::from(self.0.iter().fold(Vec::new(), |mut acc, val| {
             match val.as_span(
                 song,
+                song.and_then(|s| ctx.stickers.get(&s.file)),
                 ctx,
                 &config.theme.format_tag_separator,
                 config.theme.multiple_tag_resolution_strategy,

--- a/src/ui/widgets/header.rs
+++ b/src/ui/widgets/header.rs
@@ -61,7 +61,6 @@ impl<'a> PropertyTemplates<'a> {
         Line::from(self.0.iter().fold(Vec::new(), |mut acc, val| {
             match val.as_span(
                 song,
-                song.and_then(|s| ctx.stickers.get(&s.file)),
                 ctx,
                 &config.theme.format_tag_separator,
                 config.theme.multiple_tag_resolution_strategy,


### PR DESCRIPTION
## Description

- Adds a new keybind action: `Rate()`. Without any options set it will open a modal window which allows you to set rating on given song(s). The keybind can be further customized to set a rating directly or to customize what values are displayed in the modal - docs are missing on this still and the keybind will most likely still be expanded a little bit.
- Search pane now has rating filters (any/equal/greater than/less than) a given value. This is only visible when you have MPD configured to use stickers. You can search with any combination of filters and rating or just by rating.
- Stickers can now be displayed in the browser panes, meaning you can display song's rating in there. This was possible in the Queue pane till now.


A bunch of things happening here, some refactors to how previews are fetched and rendered. Stickers were moved to a separate map in ctx instead of in each song because their lifecycle is not inherently tied to the song. New modal section etc etc.

~~Very work in progress right now but~~ should set foundation for further stuff with stickers and further refinement of the dir stack which is kind of a mess right now. Also a fixes bunch of issues like previews sometimes not respecting browser song format and others.

### Related issues
partially addresses https://github.com/mierak/rmpc/issues/484

### Checklist

- [ ] All tests passed
- [ ] Code has been formatted with nightly
- [ ] Code has been checked with clippy (stable)
- [ ] Documentation has been updated (if needed)
- [ ] Changelog has been updated
