### PR TITLE
feat: like/dislike functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to this project will be documented in this file.
 - Stickers are now usable in `browser_song_format`
 - Rating support, rating can be set on a song. The rating can be displayed in the queue table and
 browser panes as well as searched for in the Search pane
+- Liked state support, songs can now be liked, disliked or set to neutral and searched for in the
+Search pane
 
 ### Changed
 

--- a/docs/src/content/docs/next/configuration/keybinds.mdx
+++ b/docs/src/content/docs/next/configuration/keybinds.mdx
@@ -170,8 +170,16 @@ attempts to stop you.
 
 `Rate(kind: <kind>, current: <bool>, min_rating: <number>, max_rating: <number>)`
 
-Possible values for the action `<kind>` are either a `Modal` or `Value`. Where modal takes a list
-of values to show for rating selector and whether to show a text input for custom rating.
+Possible values for the action `<kind>` are either a `Modal`, `Value`, `Like()`, `Neutral()`
+or `Dislike()`.
+These mean:
+
+- Modal - display a menu modal with possible options, takes a list of values to show for rating
+  selector, whether to show a text input for custom rating and whether to show like options
+- Value - set rating value directly
+- Like - set liked state directly
+- Neutral - set neutral state directly
+- Dislike - set disliked state directly
 
 The rating is applied to the currently playing song if any when `current` is set to true.
 
@@ -193,11 +201,19 @@ Rate(kind: Value(3), current: false),
 Rate(kind: Value(3)),
 ```
 
-- Open a modal which shows options to set rating (0-10) of the currently playing song as well as
-  input a custom value or clear the rating completely.
+- Set liked state of the song(s) under the cursor in either queue or the browser panes directly
 
 ```rust showLineNumbers=false
-Rate(kind: Modal(values: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], custom: true), current: false),
+Rate(kind: Like(), current: false),
+Rate(kind: Neutral(), current: false),
+Rate(kind: Dislike(), current: false),
+```
+
+- Open a modal which shows options to set rating (0-10) of the currently playing song as well as
+  input a custom value or clear the rating completely and options to like the song.
+
+```rust showLineNumbers=false
+Rate(kind: Modal(values: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], custom: true, like: true), current: false),
 // or equivalent
 Rate(kind: Modal(), current: false),
 ```
@@ -212,6 +228,12 @@ Rate(kind: Modal(values: [], custom: true), current: false),
 
 ```rust showLineNumbers=false
 Rate(kind: Modal(values: [], custom: true), current: false, max_rating: 100),
+```
+
+- Open a modal which shows only the like options
+
+```rust showLineNumbers=false
+Rate(kind: Modal(values: [], custom: false, like: true), current: false),
 ```
 
 #### AddOptions

--- a/docs/src/content/docs/next/configuration/stickers.mdx
+++ b/docs/src/content/docs/next/configuration/stickers.mdx
@@ -21,4 +21,5 @@ You can display these stickers using the `Sticker("<name>")` property.
 | Name      | Description                                                                                                                                                                                                  |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | rating    | Used to store ratings. Has to be a valid positive integer in the 0-10 range. Numbers outside this range are permitted too if configured to do so but might not work in other MPD clients/rmpc functionality. |
+| like      | Used to store like status. Possible values are `0`, `1` and `2` meaning "disliked", "neutral" and "liked" respectively                                                                                       |
 | playCount | How many times a song was played. Requires <a href={path("guides/on_song_change/#track-song-play-count")}>configuration</a>.                                                                                 |

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -39,6 +39,8 @@ use crate::{
 };
 
 pub const FETCH_SONG_STICKERS: &str = "fetch_song_stickers";
+pub const LIKE_STICKER: &str = "like";
+pub const RATING_STICKER: &str = "rating";
 
 #[derive(derive_more::Debug)]
 pub struct Ctx {


### PR DESCRIPTION
## Description

Builds on top of #633 and adds a like functionality. Liked songs are represented with the "like"
sticker where possible values are 0, 1 and 2 which mean "disliked", "neutral" and "liked" respectively.

This is to be consistent with basically the only thing even remotely representing standards for
sticker between MPD clients https://github.com/jcorporation/mpd-stickers and because it generally
makes sense.

### Related issues

fixes #484

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
