### PR TITLE
refactor: dirstack to tree structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ remote commands inside scripts triggered by rmpc
 - Browsers now properly use case insensitive sorting
 - Refactored and improved image backend detection
 - `JumpToCurrent` now jumps to last playing song in stopped state
+- Directories now keep their state when going back out of them
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ strum = { workspace = true }
 flate2 = { version = "1.1.2" }
 itertools = "0.14.0"
 ron = "0.10.1"
-derive_more = { version = "2.0.1", features = ["into_iterator", "into", "as_ref", "into_iterator", "display", "deref", "deref_mut", "debug"] }
+derive_more = { version = "2.0.1", features = ["into_iterator", "into", "as_ref", "into_iterator", "display", "deref", "debug"] }
 rustix = { version = "1.0.7", features = ["termios", "fs", "stdio", "process"] }
 bitflags = { version = "2.9.1", features = ["serde"] }
 log = { version = "0.4.27", features = ["kv"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ strum = { workspace = true }
 flate2 = { version = "1.1.2" }
 itertools = "0.14.0"
 ron = "0.10.1"
-derive_more = { version = "2.0.1", features = ["into_iterator", "into", "as_ref", "into_iterator", "display", "deref", "debug"] }
+derive_more = { version = "2.0.1", features = ["into_iterator", "into", "as_ref", "into_iterator", "display", "deref", "deref_mut", "debug"] }
 rustix = { version = "1.0.7", features = ["termios", "fs", "stdio", "process"] }
 bitflags = { version = "2.9.1", features = ["serde"] }
 log = { version = "0.4.27", features = ["kv"] }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -144,7 +144,7 @@ impl Ctx {
         if !stickers.is_empty() {
             let uris = stickers.into_iter().collect();
             log::debug!(uris:?; "Fetching stickers after frame");
-            self.query().id(FETCH_SONG_STICKERS).query(|client| {
+            self.query().id(FETCH_SONG_STICKERS).replace_id(FETCH_SONG_STICKERS).query(|client| {
                 let stickers = client.fetch_song_stickers(uris)?;
                 Ok(MpdQueryResult::SongStickers(stickers))
             });

--- a/src/shared/mpd_query.rs
+++ b/src/shared/mpd_query.rs
@@ -14,7 +14,7 @@ use crate::{
         mpd_client::MpdClient,
     },
     shared::{events::ClientRequest, macros::try_skip},
-    ui::dir_or_song::DirOrSong,
+    ui::{dir_or_song::DirOrSong, dirstack::Path},
 };
 
 pub const EXTERNAL_COMMAND: &str = "external_command";
@@ -80,11 +80,10 @@ impl PreviewGroup {
 #[derive(Debug)]
 #[allow(unused, clippy::large_enum_variant)]
 pub(crate) enum MpdQueryResult {
-    SongsList { data: Vec<Song>, origin_path: Option<Vec<String>> },
-    Song { data: Song, origin_path: Option<Vec<String>> },
+    SongsList { data: Vec<Song>, path: Option<Path> },
+    LsInfo { data: Vec<String>, path: Option<Path> },
+    DirOrSong { data: Vec<DirOrSong>, path: Option<Path> },
     SearchResult { data: Vec<Song> },
-    LsInfo { data: Vec<String>, origin_path: Option<Vec<String>> },
-    DirOrSong { data: Vec<DirOrSong>, origin_path: Option<Vec<String>> },
     AddToPlaylist { playlists: Vec<String>, song_file: String },
     AddToPlaylistMultiple { playlists: Vec<String>, song_files: Vec<String> },
     AlbumArt(Option<Vec<u8>>),

--- a/src/ui/dirstack/mod.rs
+++ b/src/ui/dirstack/mod.rs
@@ -7,9 +7,11 @@ use ratatui::{
 };
 
 mod dir;
+mod path;
 mod stack;
 mod state;
 pub use dir::Dir;
+pub use path::Path;
 pub use stack::DirStack;
 pub use state::DirState;
 

--- a/src/ui/dirstack/path.rs
+++ b/src/ui/dirstack/path.rs
@@ -1,0 +1,89 @@
+use derive_more::{Deref, DerefMut};
+
+#[derive(Debug, Default, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Deref, DerefMut)]
+// TODO make priv
+pub struct Path(pub Vec<String>);
+
+impl Path {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn push(&mut self, segment: impl Into<String>) {
+        self.0.push(segment.into());
+    }
+
+    pub fn pop(&mut self) -> Option<String> {
+        self.0.pop()
+    }
+
+    pub fn join(&self, segment: impl Into<String>) -> Path {
+        let mut res = self.0.clone();
+        res.push(segment.into());
+        Self(res)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Display for Path {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.join("/"))
+    }
+}
+
+impl From<String> for Path {
+    fn from(value: String) -> Self {
+        let mut res = Path::new();
+        res.push(value);
+        res
+    }
+}
+
+impl From<&String> for Path {
+    fn from(value: &String) -> Self {
+        let mut res = Path::new();
+        res.push(value);
+        res
+    }
+}
+
+impl From<&str> for Path {
+    fn from(value: &str) -> Self {
+        let mut res = Path::new();
+        res.push(value);
+        res
+    }
+}
+
+impl From<Vec<String>> for Path {
+    fn from(value: Vec<String>) -> Self {
+        let mut res = Path::new();
+        for val in value {
+            res.push(val);
+        }
+        res
+    }
+}
+
+impl From<&[&str]> for Path {
+    fn from(value: &[&str]) -> Self {
+        let mut res = Path::new();
+        for val in value {
+            res.push(val.to_owned());
+        }
+        res
+    }
+}
+
+impl<const N: usize> From<[&str; N]> for Path {
+    fn from(value: [&str; N]) -> Self {
+        let mut res = Path::new();
+        for val in value {
+            res.push(val.to_owned());
+        }
+        res
+    }
+}

--- a/src/ui/dirstack/path.rs
+++ b/src/ui/dirstack/path.rs
@@ -1,8 +1,5 @@
-use derive_more::{Deref, DerefMut};
-
-#[derive(Debug, Default, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, Deref, DerefMut)]
-// TODO make priv
-pub struct Path(pub Vec<String>);
+#[derive(Debug, Default, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Path(Vec<String>);
 
 impl Path {
     pub fn new() -> Self {
@@ -25,6 +22,10 @@ impl Path {
 
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+
+    pub fn as_slice(&self) -> &[String] {
+        self.0.as_slice()
     }
 }
 

--- a/src/ui/dirstack/stack.rs
+++ b/src/ui/dirstack/stack.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
+
 use super::{DirStackItem, dir::Dir, state::DirState};
-use crate::ui::dirstack::ScrollingState;
+use crate::ui::dirstack::{ScrollingState, path::Path};
 
 #[derive(Debug)]
 pub struct DirStack<T, S>
@@ -7,10 +9,8 @@ where
     T: std::fmt::Debug + DirStackItem + Clone + Send,
     S: ScrollingState + std::fmt::Debug + Default,
 {
-    current: Dir<T, S>,
-    others: Vec<Dir<T, S>>,
-    preview: Option<Vec<T>>,
-    path: Vec<String>,
+    path: Path,
+    pub dirs: HashMap<Path, Dir<T, S>>,
 }
 
 impl<T, S> Default for DirStack<T, S>
@@ -30,100 +30,101 @@ where
     S: ScrollingState + std::fmt::Debug + Default,
 {
     pub fn new(root: Vec<T>) -> Self {
-        let mut result =
-            Self { others: Vec::new(), path: Vec::new(), current: Dir::default(), preview: None };
-        result.push(Vec::new());
-        result.current = Dir::new(root);
+        let mut result = Self { dirs: HashMap::new(), path: Path::new() };
 
+        result.dirs.insert(result.path.clone(), Dir::new(root));
         result
     }
 
-    /// Returns the element at the top of the stack
+    pub fn len(&self) -> usize {
+        self.dirs.len()
+    }
+
     pub fn current(&self) -> &Dir<T, S> {
-        &self.current
+        self.dirs
+            .get(&self.path)
+            .expect("Path to exist in the directories. Should have been ensured in enter()")
     }
 
-    /// Returns the element at the top of the stack
     pub fn current_mut(&mut self) -> &mut Dir<T, S> {
-        &mut self.current
+        self.dirs
+            .get_mut(&self.path)
+            .expect("Path to exist in the directories. Should have been ensured in enter()")
     }
 
-    /// Returns the element at the second element from the top of the stack
-    pub fn previous(&self) -> &Dir<T, S> {
-        self.others
-            .last()
-            .expect("Previous items to always contain at least one item. This should have been handled in pop()")
+    pub fn previous(&self) -> Option<&Dir<T, S>> {
+        // If path is empty, meaning we are at root, there is no previous directory...
+        if self.path.is_empty() {
+            None
+        } else {
+            let mut path = self.path.clone();
+            path.pop();
+            self.dirs.get(&path)
+        }
     }
 
-    /// Returns the element at the second element from the top of the stack
-    pub fn previous_mut(&mut self) -> &mut Dir<T, S> {
-        self.others
-            .last_mut()
-            .expect("Previous items to always contain at least one item. This should have been handled in pop()")
+    pub fn previous_mut(&mut self) -> Option<&mut Dir<T, S>> {
+        // If path is empty, meaning we are at root, there is no previous directory...
+        if self.path.is_empty() {
+            None
+        } else {
+            let mut path = self.path.clone();
+            path.pop();
+            self.dirs.get_mut(&path)
+        }
     }
 
-    pub fn path(&self) -> &[String] {
+    pub fn next(&self) -> Option<&Dir<T, S>> {
+        self.next_path().and_then(|path| self.dirs.get(&path))
+    }
+
+    pub fn next_mut(&mut self) -> Option<&mut Dir<T, S>> {
+        self.next_path().and_then(|path| self.dirs.get_mut(&path))
+    }
+
+    pub fn path(&self) -> &Path {
         &self.path
     }
 
-    pub fn next_path(&self) -> Option<Vec<String>> {
-        if let Some(current) = self.current().selected().map(DirStackItem::as_path) {
-            let mut res = self.path().to_vec();
-            res.push(current.to_owned());
-            Some(res)
-        } else {
-            None
-        }
+    pub fn next_path(&self) -> Option<Path> {
+        self.current().selected().map(DirStackItem::as_path).map(|current| self.path.join(current))
     }
 
-    /// Returns the element at the second element from the top of the stack
-    pub fn preview(&self) -> Option<&Vec<T>> {
-        self.preview.as_ref()
+    // Returns items of the directory that is pointed to by the currently selected
+    // item if any
+    pub fn next_dir_items(&self) -> Option<&Vec<T>> {
+        self.next_path().and_then(|path| self.dirs.get(&path).map(|d| &d.items))
     }
 
-    pub fn clear_preview(&mut self) {
-        if let Some(ref mut p) = self.preview {
-            p.clear();
-        }
-    }
-
-    /// Returns the element at the second element from the top of the stack
-    pub fn set_preview(&mut self, preview: Option<Vec<T>>) -> &Self {
-        self.preview = preview;
-        self
-    }
-
-    pub fn replace(&mut self, head: Vec<T>) {
-        if self.pop().is_some() {
-            let len = head.len();
-            self.push(head);
-            self.current_mut().state.set_content_len(Some(len));
-        }
-    }
-
-    pub fn push(&mut self, head: Vec<T>) {
+    pub fn insert(&mut self, path: Path, items: Vec<T>) {
         let mut new_state = DirState::default();
-        if !head.is_empty() {
+        if !items.is_empty() {
             new_state.select(Some(0), 0);
         }
-        new_state.set_content_len(Some(head.len()));
+        new_state.set_content_len(Some(items.len()));
 
-        if let Some(current) = self.current().selected().map(DirStackItem::as_path) {
-            self.path.push(current.to_owned());
-        }
-
-        let old_current_dir =
-            std::mem::replace(&mut self.current, Dir::new_with_state(head, new_state));
-        self.others.push(old_current_dir);
+        self.dirs.insert(path, Dir::new_with_state(items, new_state));
     }
 
-    pub fn pop(&mut self) -> Option<Dir<T, S>> {
-        if self.others.len() > 1 {
-            let top = self.others.pop().expect("There should always be at least two elements");
-            self.path.pop();
-            Some(std::mem::replace(&mut self.current, top))
+    pub fn enter(&mut self) {
+        if let Some(next_path) = self.next_path() {
+            self.path = next_path;
+            // Ensure that the new path exists even if empty - it might get filled
+            // asynchronously
+            if !self.dirs.contains_key(&self.path) {
+                self.dirs.insert(self.path.clone(), Dir::default());
+            }
         } else {
-            None
+            log::error!(stack:? = self; "Cannot enter because next path is not available");
+        }
+    }
+
+    pub fn leave(&mut self) -> bool {
+        if self.path.is_empty() {
+            false
+        } else {
+            self.path.pop();
+            true
         }
     }
 }
@@ -167,7 +168,7 @@ mod tests {
     mod next_path {
         use ratatui::widgets::ListState;
 
-        use crate::ui::dirstack::DirStack;
+        use crate::ui::dirstack::{DirStack, Path};
 
         #[test]
         fn returns_none_when_nothing_is_selected() {
@@ -185,78 +186,51 @@ mod tests {
             let level1 = vec!["a".to_owned(), "b".to_owned(), "c".to_owned()];
             let mut subject: DirStack<String, ListState> = DirStack::new(level1.clone());
             subject.current_mut().state.select(Some(1), 0);
+            subject.enter();
             let level2 = vec!["d".to_owned(), "e".to_owned(), "f".to_owned()];
-            subject.push(level2);
+            subject.insert("b".into(), level2);
             subject.current_mut().state.select(Some(2), 0);
 
             let result = subject.next_path();
 
-            assert_eq!(result, Some(vec!["b".to_owned(), "f".to_owned()]));
+            assert_eq!(result, Some(Path::from(["b", "f"])));
         }
     }
 
-    mod push {
+    mod leave {
         use ratatui::widgets::ListState;
 
-        use crate::ui::dirstack::DirStack;
+        use crate::ui::dirstack::{DirStack, Path};
 
         #[test]
-        fn puts_current_to_top_of_others_and_new_input_to_current() {
-            let input = vec!["test".to_owned(), "test2".to_owned(), "test3".to_owned()];
-            let mut subject: DirStack<String, ListState> = DirStack::new(input.clone());
-            subject.current_mut().state.select(Some(1), 0);
-            let input2 = vec!["test4".to_owned(), "test3".to_owned(), "test4".to_owned()];
-            subject.previous_mut().state.select(Some(2), 0);
+        fn enter_and_leave_alters_path_correctly() {
+            let mut subject: DirStack<String, ListState> = DirStack::new(vec!["first".to_owned()]);
+            subject.insert("first".into(), vec!["second".to_owned()]);
+            subject.insert(["first", "second"].into(), vec!["third".to_owned()]);
+            subject.insert(["first", "second", "third"].into(), vec!["fourth".to_owned()]);
 
-            subject.push(input2.clone());
+            assert_eq!(subject.path(), &Path::new());
 
-            assert_eq!(subject.current().items, input2);
-            assert_eq!(subject.current().selected(), Some(input2[2].clone()).as_ref());
-            assert_eq!(subject.previous().items, input);
-            assert_eq!(subject.previous().selected(), Some(input[1].clone()).as_ref());
-        }
-    }
+            subject.current_mut().select_idx(0, 0);
+            subject.enter();
+            assert_eq!(subject.path(), &Path::from(["first"]));
 
-    mod pop {
-        use ratatui::widgets::ListState;
+            subject.current_mut().select_idx(0, 0);
+            subject.enter();
+            assert_eq!(subject.path(), &Path::from(["first", "second"]));
 
-        use crate::ui::dirstack::DirStack;
+            subject.current_mut().select_idx(0, 0);
+            subject.enter();
+            assert_eq!(subject.path(), &Path::from(["first", "second", "third"]));
 
-        #[test]
-        fn previous_element_is_moved_to_current() {
-            let mut subject: DirStack<String, ListState> = DirStack::new(Vec::new());
-            let el: Vec<String> =
-                vec!["a", "b", "c", "d"].into_iter().map(ToOwned::to_owned).collect();
-            let el2: Vec<String> =
-                vec!["e", "f", "g", "h"].into_iter().map(ToOwned::to_owned).collect();
-            subject.push(el.clone());
-            subject.push(el2.clone());
-
-            subject.pop();
-
-            assert_eq!(el, subject.current().items);
+            subject.leave();
+            assert_eq!(subject.path(), &Path::from(["first", "second"]));
         }
 
         #[test]
-        fn returns_the_popped_element() {
+        fn returns_false_on_root() {
             let mut val: DirStack<String, ListState> = DirStack::new(Vec::new());
-            let el: Vec<String> =
-                vec!["a", "b", "c", "d"].into_iter().map(ToOwned::to_owned).collect();
-            val.push(el.clone());
-
-            let result = val.pop();
-
-            assert_eq!(Some(el), result.map(|v| v.items));
-        }
-
-        #[test]
-        fn leaves_at_least_one_element_in_others() {
-            let mut val: DirStack<String, ListState> = DirStack::new(Vec::new());
-            val.push(Vec::new());
-            assert!(val.pop().is_some());
-            assert!(val.pop().is_none());
-
-            val.previous();
+            assert!(!val.leave());
         }
     }
 }

--- a/src/ui/dirstack/stack.rs
+++ b/src/ui/dirstack/stack.rs
@@ -11,6 +11,7 @@ where
 {
     path: Path,
     pub dirs: HashMap<Path, Dir<T, S>>,
+    empty: Dir<T, S>,
 }
 
 impl<T, S> Default for DirStack<T, S>
@@ -30,7 +31,8 @@ where
     S: ScrollingState + std::fmt::Debug + Default,
 {
     pub fn new(root: Vec<T>) -> Self {
-        let mut result = Self { dirs: HashMap::new(), path: Path::new() };
+        let mut result =
+            Self { dirs: HashMap::new(), path: Path::new(), empty: Dir::new(Vec::new()) };
 
         result.dirs.insert(result.path.clone(), Dir::new(root));
         result
@@ -41,15 +43,11 @@ where
     }
 
     pub fn current(&self) -> &Dir<T, S> {
-        self.dirs
-            .get(&self.path)
-            .expect("Path to exist in the directories. Should have been ensured in enter()")
+        self.dirs.get(&self.path).unwrap_or(&self.empty)
     }
 
     pub fn current_mut(&mut self) -> &mut Dir<T, S> {
-        self.dirs
-            .get_mut(&self.path)
-            .expect("Path to exist in the directories. Should have been ensured in enter()")
+        self.dirs.get_mut(&self.path).unwrap_or(&mut self.empty)
     }
 
     pub fn previous(&self) -> Option<&Dir<T, S>> {

--- a/src/ui/dirstack/stack.rs
+++ b/src/ui/dirstack/stack.rs
@@ -10,7 +10,7 @@ where
     S: ScrollingState + std::fmt::Debug + Default,
 {
     path: Path,
-    pub dirs: HashMap<Path, Dir<T, S>>,
+    dirs: HashMap<Path, Dir<T, S>>,
     empty: Dir<T, S>,
 }
 
@@ -40,6 +40,14 @@ where
 
     pub fn len(&self) -> usize {
         self.dirs.len()
+    }
+
+    pub fn get(&self, path: &Path) -> Option<&Dir<T, S>> {
+        self.dirs.get(path)
+    }
+
+    pub fn contained_paths(&self) -> impl Iterator<Item = &Path> {
+        self.dirs.keys()
     }
 
     pub fn current(&self) -> &Dir<T, S> {

--- a/src/ui/panes/albums.rs
+++ b/src/ui/panes/albums.rs
@@ -50,7 +50,7 @@ impl AlbumsPane {
     }
 
     fn open_or_play(&mut self, autoplay: bool, ctx: &Ctx) -> Result<()> {
-        match &self.stack.path()[..] {
+        match self.stack.path().as_slice() {
             [_album] => {
                 let (items, hovered_song_idx) = self.enqueue(self.stack().current().items.iter());
                 let queue_len = ctx.queue.len();
@@ -217,7 +217,7 @@ impl BrowserPane<DirOrSong> for AlbumsPane {
             return Ok(());
         };
 
-        match &self.stack.path()[..] {
+        match self.stack.path().as_slice() {
             [_album] => {}
             [] => {
                 let sort_order = ctx.config.browser_song_sort.clone();
@@ -249,7 +249,7 @@ impl BrowserPane<DirOrSong> for AlbumsPane {
         &self,
         items: impl Iterator<Item = &'a DirOrSong>,
     ) -> (Vec<Enqueue>, Option<usize>) {
-        match &self.stack.path()[..] {
+        match self.stack.path().as_slice() {
             [album] => {
                 let hovered = self.stack.current().selected().map(|item| item.dir_name_or_file());
                 items.enumerate().fold((Vec::new(), None), |mut acc, (idx, item)| {

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -217,7 +217,7 @@ impl Pane for PlaylistsPane {
                 let old_viewport_len = self.stack.current().state.viewport_len();
                 let old_content_len = self.stack.current().state.content_len();
                 let old_marked = self.stack.current().marked().clone();
-                match &self.stack.path()[..] {
+                match self.stack.path().as_slice() {
                     [playlist_name] => {
                         let Some((selected_idx, selected_playlist)) =
                             self.stack().previous().map(|prev| {
@@ -368,7 +368,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
     }
 
     fn fetch_data(&self, selected: &DirOrSong, ctx: &Ctx) -> Result<()> {
-        match &self.stack.path()[..] {
+        match self.stack.path().as_slice() {
             [] => {
                 let DirOrSong::Dir { name: playlist, .. } = selected else {
                     log::error!(selected:? = selected; "Expected playlist to be selected");
@@ -447,7 +447,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
     }
 
     fn delete<'a>(&self, items: impl Iterator<Item = (usize, &'a DirOrSong)>) -> Vec<MpdDelete> {
-        match &self.stack().path()[..] {
+        match self.stack().path().as_slice() {
             [playlist] => {
                 let playlist: Arc<str> = Arc::from(playlist.as_str());
                 items

--- a/src/ui/panes/playlists.rs
+++ b/src/ui/panes/playlists.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, sync::Arc};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use enum_map::EnumMap;
 use itertools::Itertools;
 use ratatui::{Frame, prelude::Rect, widgets::ListState};
@@ -12,7 +12,7 @@ use crate::{
     ctx::Ctx,
     mpd::{
         client::Client,
-        commands::{Song, lsinfo::LsInfoEntry},
+        commands::Song,
         mpd_client::{MpdClient, SingleOrRange},
     },
     shared::{
@@ -43,13 +43,11 @@ pub struct PlaylistsPane {
     filter_input_mode: bool,
     browser: Browser<DirOrSong>,
     initialized: bool,
-    selected_song: Option<(usize, String)>,
 }
 
 const INIT: &str = "init";
 const REINIT: &str = "reinit";
-const OPEN_OR_PLAY: &str = "open_or_play";
-const PREVIEW: &str = "preview";
+const FETCH_DATA: &str = "fetch_data";
 const PLAYLIST_INFO: &str = "preview";
 
 impl PlaylistsPane {
@@ -59,33 +57,18 @@ impl PlaylistsPane {
             filter_input_mode: false,
             browser: Browser::new(),
             initialized: false,
-            selected_song: None,
         }
     }
 
     fn open_or_play(&mut self, autoplay: bool, ctx: &Ctx) -> Result<()> {
         let Some(selected) = self.stack().current().selected() else {
             log::error!("Failed to move deeper inside dir. Current value is None");
-
-            ctx.render()?;
-            return Ok(());
-        };
-        let Some(next_path) = self.stack.next_path() else {
-            log::error!("Failed to move deeper inside dir. Next path is None");
             return Ok(());
         };
 
         match selected {
-            DirOrSong::Dir { name: playlist, .. } => {
-                let playlist = playlist.clone();
-                ctx.query().id(OPEN_OR_PLAY).target(PaneType::Playlists).query(move |client| {
-                    Ok(MpdQueryResult::SongsList {
-                        data: client.list_playlist_info(&playlist, None)?,
-                        origin_path: Some(next_path),
-                    })
-                });
-                self.stack_mut().push(Vec::new());
-                self.stack_mut().clear_preview();
+            DirOrSong::Dir { .. } => {
+                self.stack_mut().enter();
                 ctx.render()?;
             }
             DirOrSong::Song(_song) => {
@@ -137,7 +120,7 @@ impl Pane for PlaylistsPane {
                         .sorted_by(|a, b| compare.compare(&a.name, &b.name))
                         .map(|playlist| DirOrSong::playlist_name_only(playlist.name))
                         .collect();
-                    Ok(MpdQueryResult::DirOrSong { data: result, origin_path: None })
+                    Ok(MpdQueryResult::DirOrSong { data: result, path: None })
                 },
             );
 
@@ -167,7 +150,7 @@ impl Pane for PlaylistsPane {
                             })
                             .map(|playlist| DirOrSong::playlist_name_only(playlist.name))
                             .collect();
-                        Ok(MpdQueryResult::DirOrSong { data: result, origin_path: None })
+                        Ok(MpdQueryResult::DirOrSong { data: result, path: None })
                     },
                 );
             }
@@ -212,92 +195,101 @@ impl Pane for PlaylistsPane {
                 );
                 ctx.render()?;
             }
-            (PREVIEW, MpdQueryResult::DirOrSong { data, origin_path }) => {
-                if let Some(origin_path) = origin_path
-                    && origin_path != self.stack().path()
-                {
-                    log::trace!(origin_path:?, current_path:? = self.stack().path(); "Dropping preview because it does not belong to this path");
+            (FETCH_DATA, MpdQueryResult::DirOrSong { data, path }) => {
+                let Some(path) = path else {
+                    log::error!(path:?, current_path:? = self.stack().path(); "Cannot insert data because path is not provided");
                     return Ok(());
-                }
+                };
 
-                self.stack_mut().set_preview(Some(data));
+                self.stack_mut().insert(path, data);
+                self.fetch_data_internal(ctx)?;
                 ctx.render()?;
             }
-            (OPEN_OR_PLAY, MpdQueryResult::SongsList { data, origin_path }) => {
-                if let Some(origin_path) = origin_path
-                    && origin_path != self.stack().path()
-                {
-                    log::trace!(origin_path:?, current_path:? = self.stack().path(); "Dropping result because it does not belong to this path");
-                    return Ok(());
-                }
-                self.stack_mut().replace(data.into_iter().map(DirOrSong::Song).collect());
-                self.prepare_preview(ctx)?;
-                ctx.render()?;
-            }
-            (INIT, MpdQueryResult::DirOrSong { data, origin_path: _ }) => {
+            (INIT, MpdQueryResult::DirOrSong { data, path: _ }) => {
                 self.stack = DirStack::new(data);
-                self.prepare_preview(ctx)?;
+                if let Some(sel) = self.stack.current().selected() {
+                    self.fetch_data(sel, ctx)?;
+                }
+                ctx.render()?;
             }
             (REINIT, MpdQueryResult::DirOrSong { data, .. }) => {
                 let mut new_stack = DirStack::new(data);
                 let old_viewport_len = self.stack.current().state.viewport_len();
                 let old_content_len = self.stack.current().state.content_len();
                 let old_marked = self.stack.current().marked().clone();
-                match self.stack.path() {
+                match &self.stack.path()[..] {
                     [playlist_name] => {
-                        let (selected_idx, selected_playlist) = self
-                            .stack()
-                            .previous()
-                            .selected_with_idx()
-                            .map_or((0, playlist_name.as_str()), |(idx, playlist)| {
-                                (idx, playlist.as_path())
-                            });
+                        let Some((selected_idx, selected_playlist)) =
+                            self.stack().previous().map(|prev| {
+                                prev.selected_with_idx()
+                                    .map_or((0, playlist_name.as_str()), |(idx, playlist)| {
+                                        (idx, playlist.as_path())
+                                    })
+                            })
+                        else {
+                            log::error!(stack:? = self.stack(); "Reinitializing playlists. Current path sugsests that we are inside a playlist but previous is None");
+                            return Ok(());
+                        };
+
                         let idx_to_select = new_stack
                             .current()
                             .items
                             .iter()
                             .find_position(|item| item.as_path() == selected_playlist)
                             .map_or(selected_idx, |(idx, _)| idx);
-                        new_stack.current_mut().state.set_viewport_len(old_viewport_len);
 
+                        new_stack.current_mut().state.set_viewport_len(old_viewport_len); // is this needed?
                         new_stack
                             .current_mut()
                             .state
                             .select(Some(idx_to_select), ctx.config.scrolloff);
 
-                        if let Some((idx, DirOrSong::Song(song))) =
-                            self.stack().current().selected_with_idx()
-                        {
-                            self.selected_song = Some((idx, song.as_path().to_owned()));
-                        }
-                        let playlist = playlist_name.to_owned();
-                        self.stack = new_stack;
-                        self.stack_mut().current_mut().state.set_content_len(old_content_len);
-                        self.stack_mut().current_mut().state.set_viewport_len(old_viewport_len);
+                        log::debug!(stack:? = new_stack; "Reinitializing playlist stack");
+
+                        let selected_song = self.stack().current().selected_with_idx();
+
+                        // Get the actually selected playlist after the resolution. If none is
+                        // selected then it means that we have no more playlists to go into so we
+                        // end here
+                        let Some(new_playlist) = new_stack.current().selected() else {
+                            return Ok(());
+                        };
+
+                        let playlist = new_playlist.as_path().to_owned();
+                        new_stack.current_mut().state.set_content_len(old_content_len);
+                        new_stack.current_mut().state.set_viewport_len(old_viewport_len);
 
                         let songs = ctx.query_sync(move |client| {
                             Ok(client.list_playlist_info(&playlist, None)?)
                         })?;
 
-                        self.stack_mut().push(songs.into_iter().map(DirOrSong::Song).collect());
-                        self.prepare_preview(ctx)?;
-                        if let Some((idx, song)) = &self.selected_song {
-                            let idx_to_select = self
-                                .stack
+                        // Calculate next path based on the playlist that was selected, can be
+                        // either the same playlist by name or the same index. If no playllist is
+                        // selected, ie the stack is empty, we end here
+                        let Some(next_path) = new_stack.next_path() else {
+                            log::debug!(stack:? = new_stack; "No playlist selected after reinit, not entering");
+                            return Ok(());
+                        };
+                        new_stack
+                            .insert(next_path, songs.into_iter().map(DirOrSong::Song).collect());
+                        new_stack.enter();
+
+                        if let Some((idx, song)) = selected_song {
+                            let idx_to_select = new_stack
                                 .current()
                                 .items
                                 .iter()
-                                .find_position(|item| item.as_path() == song)
-                                .map_or(*idx, |(idx, _)| idx);
-                            self.stack.current_mut().state.set_viewport_len(old_viewport_len);
-                            self.stack
+                                .find_position(|item| item.as_path() == song.as_path())
+                                .map_or(idx, |(idx, _)| idx);
+                            new_stack.current_mut().state.set_viewport_len(old_viewport_len);
+                            new_stack
                                 .current_mut()
                                 .state
                                 .select(Some(idx_to_select), ctx.config.scrolloff);
                         }
-                        *self.stack_mut().current_mut().marked_mut() = old_marked;
-                        self.stack_mut().clear_preview();
-                        self.prepare_preview(ctx)?;
+                        *new_stack.current_mut().marked_mut() = old_marked;
+
+                        self.stack = new_stack;
                         ctx.render()?;
                     }
                     [] => {
@@ -323,7 +315,9 @@ impl Pane for PlaylistsPane {
                             .select(Some(idx_to_select), ctx.config.scrolloff);
 
                         self.stack = new_stack;
-                        self.prepare_preview(ctx)?;
+                        if let Some(sel) = self.stack.current().selected() {
+                            self.fetch_data(sel, ctx)?;
+                        }
                     }
                     _ => {
                         log::error!(stack:? = self.stack; "Invalid playlist stack state");
@@ -373,40 +367,31 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
         }
     }
 
-    fn prepare_preview(&mut self, ctx: &Ctx) -> Result<()> {
-        let s = self.stack().current().selected().cloned();
-        self.stack_mut().clear_preview();
-        let origin_path = Some(self.stack().path().to_vec());
-        ctx.query().id(PREVIEW).replace_id("playlists_preview").target(PaneType::Playlists).query(
-            move |client| {
-                let data = s.as_ref().map_or(Ok(Vec::new()), move |current| -> Result<_> {
-                    let response = match current {
-                        DirOrSong::Dir { name: d, .. } => client
-                            .list_playlist_info(d, None)?
+    fn fetch_data(&self, selected: &DirOrSong, ctx: &Ctx) -> Result<()> {
+        match &self.stack.path()[..] {
+            [] => {
+                let DirOrSong::Dir { name: playlist, .. } = selected else {
+                    log::error!(selected:? = selected; "Expected playlist to be selected");
+                    return Ok(());
+                };
+                let path = self.stack.next_path();
+                let playlist = playlist.to_owned();
+                ctx.query()
+                    .id(FETCH_DATA)
+                    .replace_id("playlists_data")
+                    .target(PaneType::Playlists)
+                    .query(move |client| {
+                        let data = client
+                            .list_playlist_info(&playlist, None)?
                             .into_iter()
                             .map(DirOrSong::Song)
-                            .collect_vec(),
-                        DirOrSong::Song(song) => {
-                            match client
-                                .lsinfo(Some(&song.file))
-                                .context(anyhow!("File '{}' was listed but not found", song.file))?
-                                .0
-                                .pop()
-                            {
-                                Some(LsInfoEntry::File(song)) => {
-                                    vec![DirOrSong::Song(song)]
-                                }
-                                _ => Vec::new(),
-                            }
-                        }
-                    };
+                            .collect_vec();
+                        Ok(MpdQueryResult::DirOrSong { data, path })
+                    });
+            }
+            _ => {}
+        }
 
-                    Ok(response)
-                })?;
-
-                Ok(MpdQueryResult::DirOrSong { data, origin_path })
-            },
-        );
         Ok(())
     }
 
@@ -446,7 +431,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
                     .id(PLAYLIST_INFO)
                     .query(move |client| {
                         let playlist = client.list_playlist_info(&playlist, None)?;
-                        Ok(MpdQueryResult::SongsList { data: playlist, origin_path: None })
+                        Ok(MpdQueryResult::SongsList { data: playlist, path: None })
                     });
             }
             DirOrSong::Song(_) => {}
@@ -462,7 +447,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
     }
 
     fn delete<'a>(&self, items: impl Iterator<Item = (usize, &'a DirOrSong)>) -> Vec<MpdDelete> {
-        match self.stack().path() {
+        match &self.stack().path()[..] {
             [playlist] => {
                 let playlist: Arc<str> = Arc::from(playlist.as_str());
                 items
@@ -525,7 +510,9 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
     }
 
     fn move_selected(&mut self, direction: MoveDirection, ctx: &Ctx) -> Result<()> {
-        let Some(DirOrSong::Dir { name: playlist, .. }) = self.stack.previous().selected() else {
+        let Some(DirOrSong::Dir { name: playlist, .. }) =
+            self.stack.previous().and_then(|p| p.selected())
+        else {
             return Ok(());
         };
 

--- a/src/ui/panes/tag_browser.rs
+++ b/src/ui/panes/tag_browser.rs
@@ -433,7 +433,7 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
                         let name = item.dir_name_or_file();
                         let path = path.join(name);
 
-                        self.stack.dirs.get(&path).map(|dir| {
+                        self.stack.get(&path).map(|dir| {
                             dir.items.iter().filter_map(|song| match song {
                                 DirOrSong::Dir { .. } => None,
                                 DirOrSong::Song(song) => Some(Enqueue::Find {
@@ -538,7 +538,6 @@ mod tests {
 
     fn pane_albums(pane: &TagBrowserPane) -> Vec<String> {
         pane.stack
-            .dirs
             .get(&"artist".into())
             .expect("expected artist dir to exist")
             .items
@@ -563,7 +562,7 @@ mod tests {
 
         pane.process_songs(artist.clone(), songs, &ctx);
 
-        assert_eq!(pane.stack.dirs.keys().sorted().collect_vec(), vec![
+        assert_eq!(pane.stack.contained_paths().sorted().collect_vec(), vec![
             &Path::from([]),
             &Path::from("artist"),
             &Path::from(["artist", "album_a"]),
@@ -588,7 +587,7 @@ mod tests {
 
         pane.process_songs(artist.clone(), songs, &ctx);
 
-        assert_eq!(pane.stack.dirs.keys().sorted().collect_vec(), vec![
+        assert_eq!(pane.stack.contained_paths().sorted().collect_vec(), vec![
             &Path::from([]),
             &Path::from("artist"),
             &Path::from(["artist", "(2020) album_a"]),
@@ -614,7 +613,7 @@ mod tests {
 
         pane.process_songs(artist.clone(), songs, &ctx);
 
-        assert_eq!(pane.stack.dirs.keys().sorted().collect_vec(), vec![
+        assert_eq!(pane.stack.contained_paths().sorted().collect_vec(), vec![
             &Path::from([]),
             &Path::from("artist"),
             &Path::from(["artist", "(2019) album_b"]),
@@ -640,7 +639,7 @@ mod tests {
 
         pane.process_songs(artist.clone(), songs, &ctx);
 
-        assert_eq!(pane.stack.dirs.keys().sorted().collect_vec(), vec![
+        assert_eq!(pane.stack.contained_paths().sorted().collect_vec(), vec![
             &Path::from([]),
             &Path::from("artist"),
             &Path::from(["artist", "album_a"]),
@@ -666,7 +665,7 @@ mod tests {
 
         pane.process_songs(artist.clone(), songs, &ctx);
 
-        assert_eq!(pane.stack.dirs.keys().sorted().collect_vec(), vec![
+        assert_eq!(pane.stack.contained_paths().sorted().collect_vec(), vec![
             &Path::from([]),
             &Path::from("artist"),
             &Path::from(["artist", "(1969) album_a"]), // Uses originaldate, not date
@@ -690,7 +689,7 @@ mod tests {
 
         pane.process_songs(artist.clone(), songs, &ctx);
 
-        assert_eq!(pane.stack.dirs.keys().sorted().collect_vec(), vec![
+        assert_eq!(pane.stack.contained_paths().sorted().collect_vec(), vec![
             &Path::from([]),
             &Path::from("artist"),
             &Path::from(["artist", "(1969) album_a"]), // Uses originaldate (first in list)
@@ -713,7 +712,7 @@ mod tests {
 
         pane.process_songs(artist.clone(), songs, &ctx);
 
-        assert_eq!(pane.stack.dirs.keys().sorted().collect_vec(), vec![
+        assert_eq!(pane.stack.contained_paths().sorted().collect_vec(), vec![
             &Path::from([]),
             &Path::from("artist"),
             &Path::from(["artist", "(<no date>) album_a"]) // Falls back to default

--- a/src/ui/panes/tag_browser.rs
+++ b/src/ui/panes/tag_browser.rs
@@ -90,7 +90,7 @@ impl TagBrowserPane {
     }
 
     fn open_or_play(&mut self, autoplay: bool, ctx: &Ctx) -> Result<()> {
-        match &self.stack.path()[..] {
+        match self.stack.path().as_slice() {
             [_artist, _album] => {
                 let (items, hovered_song_idx) = self.enqueue(self.stack().current().items.iter());
                 if !items.is_empty() {
@@ -270,8 +270,7 @@ impl Pane for TagBrowserPane {
     ) -> Result<()> {
         match (id, data) {
             (FETCH_SONGS, MpdQueryResult::SongsList { data, path }) => {
-                let Some(root_path) = path.and_then(|mut v| v.first_mut().map(std::mem::take))
-                else {
+                let Some(root_path) = path.and_then(|v| v.as_slice().iter().next().cloned()) else {
                     return Ok(());
                 };
 
@@ -341,7 +340,7 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
         let separator = self.separator.clone();
         let path = self.stack().path().to_owned();
 
-        let album_songs = match &self.stack.path()[..] {
+        let album_songs = match self.stack.path().as_slice() {
             [_artist] => self
                 .stack
                 .next_dir_items()
@@ -375,7 +374,7 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
     }
 
     fn fetch_data(&self, selected: &DirOrSong, ctx: &Ctx) -> Result<()> {
-        match &self.stack.path()[..] {
+        match self.stack.path().as_slice() {
             [_artist, _album] => {
                 ctx.render()?;
             }
@@ -411,7 +410,7 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
         &self,
         items: impl Iterator<Item = &'a DirOrSong>,
     ) -> (Vec<Enqueue>, Option<usize>) {
-        match &self.stack.path()[..] {
+        match self.stack.path().as_slice() {
             [_tag_value, _album] => {
                 let hovered = self.stack.current().selected().map(|item| item.dir_name_or_file());
 

--- a/src/ui/panes/tag_browser.rs
+++ b/src/ui/panes/tag_browser.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, collections::HashMap, sync::Arc};
+use std::{cmp::Ordering, sync::Arc};
 
 use anyhow::{Context, Result};
 use enum_map::EnumMap;
@@ -16,7 +16,7 @@ use crate::{
     ctx::Ctx,
     mpd::{
         client::Client,
-        commands::{Song, metadata_tag::MetadataTagExt},
+        commands::Song,
         mpd_client::{Filter, FilterKind, MpdClient, Tag},
     },
     shared::{
@@ -30,7 +30,7 @@ use crate::{
         UiEvent,
         browser::BrowserPane,
         dir_or_song::DirOrSong,
-        dirstack::{DirStack, DirStackItem},
+        dirstack::{DirStack, DirStackItem, Path},
         widgets::browser::{Browser, BrowserArea},
     },
 };
@@ -45,22 +45,10 @@ pub struct TagBrowserPane {
     target_pane: PaneType,
     browser: Browser<DirOrSong>,
     initialized: bool,
-    cache: HashMap<String, CachedRootTag>,
 }
 
 const INIT: &str = "init";
-const OPEN_OR_PLAY: &str = "open_or_play";
-const PREVIEW: &str = "preview";
-
-#[derive(Debug, Default)]
-struct CachedRootTag(Vec<CachedAlbum>);
-
-#[derive(Debug, Default)]
-struct CachedAlbum {
-    name: String,
-    original_name: String,
-    songs: Vec<Song>,
-}
+const FETCH_SONGS: &str = "fetch_songs";
 
 impl TagBrowserPane {
     pub fn new(
@@ -78,7 +66,6 @@ impl TagBrowserPane {
             filter_input_mode: false,
             browser: Browser::new(),
             initialized: false,
-            cache: HashMap::default(),
         }
     }
 
@@ -103,16 +90,7 @@ impl TagBrowserPane {
     }
 
     fn open_or_play(&mut self, autoplay: bool, ctx: &Ctx) -> Result<()> {
-        let Some(current) = self.stack.current().selected() else {
-            log::error!("Failed to move deeper inside dir. Current value is None");
-            return Ok(());
-        };
-        let Some(_next_path) = self.stack.next_path() else {
-            log::error!("Failed to move deeper inside dir. Next path is None");
-            return Ok(());
-        };
-
-        match self.stack.path() {
+        match &self.stack.path()[..] {
             [_artist, _album] => {
                 let (items, hovered_song_idx) = self.enqueue(self.stack().current().items.iter());
                 if !items.is_empty() {
@@ -132,49 +110,13 @@ impl TagBrowserPane {
                     });
                 }
             }
-            [artist] => {
-                let Some(albums) = self.cache.get(artist) else {
-                    return Ok(());
-                };
-                let Some(CachedAlbum { songs, .. }) =
-                    albums.0.iter().find(|album| album.name == current.as_path())
-                else {
-                    return Ok(());
-                };
-                let songs =
-                    songs.iter().map(|song| DirOrSong::Song(song.clone())).collect::<Vec<_>>();
-
-                self.stack_mut().push(songs);
+            [_artist] => {
+                self.stack_mut().enter();
                 ctx.render()?;
             }
             [] => {
-                let current = current.as_path().to_owned();
-                if let Some(albums) = self.cache.get(&current) {
-                    let albums = albums
-                        .0
-                        .iter()
-                        .map(|CachedAlbum { name, .. }| DirOrSong::name_only(name.to_owned()))
-                        .collect();
-                    self.stack_mut().push(albums);
-                } else {
-                    let root_tag = self.root_tag.clone();
-                    let separator = self.separator.clone();
-                    let target = self.target_pane.clone();
-                    ctx.query().id(OPEN_OR_PLAY).replace_id(OPEN_OR_PLAY).target(target).query(
-                        move |client| {
-                            let root_tag_filter =
-                                Self::root_tag_filter(root_tag, separator.as_deref(), &current);
-                            let all_songs: Vec<Song> = client.find(&[root_tag_filter])?;
-                            Ok(MpdQueryResult::SongsList {
-                                data: all_songs,
-                                origin_path: Some(vec![current]),
-                            })
-                        },
-                    );
-                    self.stack_mut().push(Vec::new());
-                    self.stack_mut().clear_preview();
-                    ctx.render()?;
-                }
+                self.stack_mut().enter();
+                ctx.render()?;
             }
             _ => {
                 log::error!("Unexpected nesting in Artists dir structure");
@@ -184,11 +126,9 @@ impl TagBrowserPane {
         Ok(())
     }
 
-    fn process_songs(&mut self, artist: String, data: Vec<Song>, ctx: &Ctx) -> &CachedRootTag {
+    fn process_songs(&mut self, artist: String, data: Vec<Song>, ctx: &Ctx) {
         let display_mode = ctx.config.artists.album_display_mode;
         let sort_mode = ctx.config.artists.album_sort_by;
-
-        let cached_artist = self.cache.entry(artist).or_default();
 
         let albums = data
             .into_iter()
@@ -207,34 +147,30 @@ impl TagBrowserPane {
                             .map(|v| v.last().to_string())
                     })
                     .unwrap_or_else(|| "<no date>".to_string());
-                let original_album = song.metadata.get("album").last().map(|v| v.to_owned());
 
-                (album, song_date, original_album)
+                (album, song_date)
             })
             .into_iter()
-            .sorted_by(|((album_a, date_a, _), _), ((album_b, date_b, _), _)| match sort_mode {
+            .sorted_by(|((album_a, date_a), _), ((album_b, date_b), _)| match sort_mode {
                 AlbumSortMode::Name => match album_a.cmp(album_b) {
                     Ordering::Equal => date_a.cmp(date_b),
                     ordering => ordering,
                 },
                 AlbumSortMode::Date => date_a.cmp(date_b),
             })
-            .map(|((album, date, original_name), mut songs)| {
+            .map(|((album, date), mut songs)| {
                 songs.sort_by(|a, b| {
                     a.with_custom_sort(&ctx.config.browser_song_sort)
                         .cmp(&b.with_custom_sort(&ctx.config.browser_song_sort))
                 });
 
-                CachedAlbum {
-                    name: match display_mode {
-                        AlbumDisplayMode::SplitByDate => {
-                            format!("({date}) {album}")
-                        }
-                        AlbumDisplayMode::NameOnly => album.to_string(),
-                    },
-                    original_name: original_name.unwrap_or_else(String::new),
-                    songs,
-                }
+                let name = match display_mode {
+                    AlbumDisplayMode::SplitByDate => {
+                        format!("({date}) {album}")
+                    }
+                    AlbumDisplayMode::NameOnly => album.to_string(),
+                };
+                (name, songs)
             })
             .fold(Vec::new(), |mut acc, album| {
                 match display_mode {
@@ -243,9 +179,9 @@ impl TagBrowserPane {
                     }
                     AlbumDisplayMode::NameOnly => {
                         if let Some(cached_album) =
-                            acc.iter_mut().find(|cached_album| cached_album.name == album.name)
+                            acc.iter_mut().find(|cached_album| cached_album.0 == album.0)
                         {
-                            cached_album.songs.extend(album.songs);
+                            cached_album.1.extend(album.1);
                         } else {
                             acc.push(album);
                         }
@@ -254,9 +190,16 @@ impl TagBrowserPane {
                 acc
             });
 
-        cached_artist.0 = albums;
+        let path: Path = artist.into();
+        self.stack.insert(
+            path.clone(),
+            albums.iter().map(|album| DirOrSong::name_only(album.0.clone())).collect(),
+        );
 
-        cached_artist
+        for album in albums {
+            let album_path = path.join(album.0);
+            self.stack.insert(album_path, album.1.into_iter().map(DirOrSong::Song).collect());
+        }
     }
 }
 
@@ -278,7 +221,7 @@ impl Pane for TagBrowserPane {
             let target = self.target_pane.clone();
             ctx.query().id(INIT).replace_id(INIT).target(target).query(move |client| {
                 let result = client.list_tag(root_tag, None).context("Cannot list artists")?;
-                Ok(MpdQueryResult::LsInfo { data: result.0, origin_path: None })
+                Ok(MpdQueryResult::LsInfo { data: result.0, path: None })
             });
 
             self.initialized = true;
@@ -292,10 +235,10 @@ impl Pane for TagBrowserPane {
             UiEvent::Database => {
                 let root_tag = self.root_tag.clone();
                 let target = self.target_pane.clone();
-                self.cache = HashMap::default();
+                self.stack = DirStack::default();
                 ctx.query().id(INIT).replace_id(INIT).target(target).query(move |client| {
                     let result = client.list_tag(root_tag, None).context("Cannot list artists")?;
-                    Ok(MpdQueryResult::LsInfo { data: result.0, origin_path: None })
+                    Ok(MpdQueryResult::LsInfo { data: result.0, path: None })
                 });
             }
             UiEvent::Reconnected => {
@@ -326,70 +269,17 @@ impl Pane for TagBrowserPane {
         ctx: &Ctx,
     ) -> Result<()> {
         match (id, data) {
-            (PREVIEW, MpdQueryResult::SongsList { data, origin_path }) => {
-                let Some(artist) = origin_path.and_then(|mut v| v.first_mut().map(std::mem::take))
+            (FETCH_SONGS, MpdQueryResult::SongsList { data, path }) => {
+                let Some(root_path) = path.and_then(|mut v| v.first_mut().map(std::mem::take))
                 else {
                     return Ok(());
                 };
 
-                let current_item_path = self.stack().current().selected().map(|c| c.as_path());
-                // We still want to cache the result to avoid refetch later, but
-                // do not rerender current state because rmpc is
-                // already on a different item
-                let cache_only = if current_item_path == Some(&artist) {
-                    false
-                } else {
-                    log::trace!(artist:?, current_item_path:?; "Dropping preview because it does not belong to this path");
-                    true
-                };
-
-                let cached_artist = self.process_songs(artist, data, ctx);
-
-                if cache_only {
-                    return Ok(());
-                }
-
-                let songs = cached_artist
-                    .0
-                    .iter()
-                    .map(|album| DirOrSong::name_only(album.name.clone()))
-                    .collect();
-                self.stack_mut().set_preview(Some(songs));
-
+                self.process_songs(root_path, data, ctx);
+                self.fetch_data_internal(ctx)?;
                 ctx.render()?;
             }
-            (OPEN_OR_PLAY, MpdQueryResult::SongsList { data, origin_path }) => {
-                let Some(artist) = origin_path.and_then(|mut v| v.first_mut().map(std::mem::take))
-                else {
-                    return Ok(());
-                };
-
-                // We still want to cache the result to avoid refetch later, but
-                // do not rerender current state because rmpc is
-                // already on a different item
-                let cache_only = if self.stack().path().first() == Some(&artist) {
-                    false
-                } else {
-                    log::trace!(artist:?, current_path:? = self.stack().path(); "Dropping result because it does not belong to this path");
-                    true
-                };
-
-                if cache_only {
-                    return Ok(());
-                }
-
-                let cached_artist = self.process_songs(artist, data, ctx);
-
-                let albums = cached_artist
-                    .0
-                    .iter()
-                    .map(|CachedAlbum { name, .. }| DirOrSong::name_only(name.to_owned()))
-                    .collect();
-                self.stack.replace(albums);
-                self.prepare_preview(ctx)?;
-                ctx.render()?;
-            }
-            (INIT, MpdQueryResult::LsInfo { data, origin_path: _ }) => {
+            (INIT, MpdQueryResult::LsInfo { data, path: _ }) => {
                 let sort_opts = ctx.config.browser_song_sort.as_ref();
 
                 let data = if let Some(sep) = &self.unescaped_separator {
@@ -407,7 +297,9 @@ impl Pane for TagBrowserPane {
                 };
 
                 self.stack = DirStack::new(data);
-                self.prepare_preview(ctx)?;
+                if let Some(sel) = self.stack.current().selected() {
+                    self.fetch_data(sel, ctx)?;
+                }
                 ctx.render()?;
             }
             _ => {}
@@ -448,24 +340,28 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
         let root_tag = self.root_tag.clone();
         let separator = self.separator.clone();
         let path = self.stack().path().to_owned();
-        let album_name = match (self.stack().path(), &item) {
-            ([artist], DirOrSong::Dir { name, .. }) => self
-                .cache
-                .get(artist)
-                .and_then(|albums| {
-                    albums.0.iter().find(|a| &a.name == name).map(|a| a.original_name.clone())
+
+        let album_songs = match &self.stack.path()[..] {
+            [_artist] => self
+                .stack
+                .next_dir_items()
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter_map(|item| match item {
+                            DirOrSong::Dir { .. } => None,
+                            DirOrSong::Song(song) => Some(song.clone()),
+                        })
+                        .collect()
                 })
                 .unwrap_or_default(),
-            _ => String::new(),
+            _ => Vec::new(),
         };
 
         move |client| {
             Ok(match item {
                 DirOrSong::Dir { name, .. } => match path.as_slice() {
-                    [artist] => client.find(&[
-                        Filter::new(Tag::Album, &album_name),
-                        Self::root_tag_filter(root_tag, separator.as_deref(), artist),
-                    ])?,
+                    [_artist] => album_songs,
                     [] => client.find(&[Self::root_tag_filter(
                         root_tag,
                         separator.as_deref(),
@@ -478,59 +374,33 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
         }
     }
 
-    fn prepare_preview(&mut self, ctx: &Ctx) -> Result<()> {
-        let Some(current) = self.stack.current().selected().map(DirStackItem::as_path) else {
-            return Ok(());
-        };
-        let current = current.to_owned();
-
-        self.stack_mut().clear_preview();
-        match self.stack.path() {
+    fn fetch_data(&self, selected: &DirOrSong, ctx: &Ctx) -> Result<()> {
+        match &self.stack.path()[..] {
             [_artist, _album] => {
-                // No need to do anything except request render, the song data is already
-                // present in the current item
                 ctx.render()?;
             }
-            [artist] => {
-                let Some(albums) = self.cache.get(artist) else {
-                    return Ok(());
-                };
-                let Some(CachedAlbum { songs, .. }) =
-                    albums.0.iter().find(|album| album.name == current)
-                else {
-                    return Ok(());
-                };
-
-                let songs = songs.iter().map(|s| DirOrSong::Song(s.clone())).collect();
-                self.stack_mut().set_preview(Some(songs));
+            [_artist] => {
                 ctx.render()?;
             }
             [] => {
-                if let Some(albums) = self.cache.get(&current) {
-                    let albums: Vec<_> = albums
-                        .0
-                        .iter()
-                        .map(|CachedAlbum { name, .. }| DirOrSong::name_only(name.to_owned()))
-                        .collect();
-                    self.stack.set_preview(Some(albums));
-                    ctx.render()?;
-                } else {
-                    let root_tag = self.root_tag.clone();
-                    let separator = self.separator.clone();
-                    let target = self.target_pane.clone();
-                    ctx.query().id(PREVIEW).replace_id(PREVIEW).target(target).query(
-                        move |client| {
-                            let separator = separator.map(|v| v.as_ref().to_owned());
-                            let separator = separator.as_deref();
-                            let all_songs: Vec<Song> = client
-                                .find(&[Self::root_tag_filter(root_tag, separator, &current)])?;
-                            Ok(MpdQueryResult::SongsList {
-                                data: all_songs,
-                                origin_path: Some(vec![current]),
-                            })
-                        },
-                    );
-                }
+                let current = selected.as_path();
+                let root_tag = self.root_tag.clone();
+                let separator = self.separator.clone();
+                let target = self.target_pane.clone();
+                let current = current.to_owned();
+
+                ctx.query().id(FETCH_SONGS).replace_id(FETCH_SONGS).target(target).query(
+                    move |client| {
+                        let separator = separator.map(|v| v.as_ref().to_owned());
+                        let separator = separator.as_deref();
+                        let all_songs: Vec<Song> =
+                            client.find(&[Self::root_tag_filter(root_tag, separator, &current)])?;
+                        Ok(MpdQueryResult::SongsList {
+                            data: all_songs,
+                            path: Some(current.into()),
+                        })
+                    },
+                );
             }
             _ => {}
         }
@@ -541,7 +411,7 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
         &self,
         items: impl Iterator<Item = &'a DirOrSong>,
     ) -> (Vec<Enqueue>, Option<usize>) {
-        match self.stack.path() {
+        match &self.stack.path()[..] {
             [_tag_value, _album] => {
                 let hovered = self.stack.current().selected().map(|item| item.dir_name_or_file());
 
@@ -558,24 +428,25 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
                 })
             }
             [tag_value] => {
-                let tag_value = tag_value.clone();
-                let Some(albums) = self.cache.get(&tag_value) else {
-                    return (Vec::new(), None);
-                };
-
-                let items = items
+                let path: Path = tag_value.as_str().into();
+                let albums = items
                     .filter_map(|item| {
                         let name = item.dir_name_or_file();
-                        albums.0.iter().find(|a| a.name == name)
-                    })
-                    .flat_map(|album| {
-                        album.songs.iter().map(|song| Enqueue::Find {
-                            filter: vec![(Tag::File, FilterKind::Exact, song.file.clone())],
+                        let path = path.join(name);
+
+                        self.stack.dirs.get(&path).map(|dir| {
+                            dir.items.iter().filter_map(|song| match song {
+                                DirOrSong::Dir { .. } => None,
+                                DirOrSong::Song(song) => Some(Enqueue::Find {
+                                    filter: vec![(Tag::File, FilterKind::Exact, song.file.clone())],
+                                }),
+                            })
                         })
                     })
+                    .flatten()
                     .collect_vec();
 
-                (items, None)
+                (albums, None)
             }
             [] => {
                 let root_tag = self.root_tag.clone();
@@ -620,6 +491,8 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use rstest::rstest;
 
     use super::*;
@@ -664,6 +537,17 @@ mod tests {
         }
     }
 
+    fn pane_albums(pane: &TagBrowserPane) -> Vec<String> {
+        pane.stack
+            .dirs
+            .get(&"artist".into())
+            .expect("expected artist dir to exist")
+            .items
+            .iter()
+            .map(|item| item.as_path().to_owned())
+            .collect_vec()
+    }
+
     #[rstest]
     fn albums_no_date_sort_name(mut ctx: Ctx, mut config: Config) {
         config.artists.album_display_mode = AlbumDisplayMode::NameOnly;
@@ -678,11 +562,15 @@ mod tests {
             song("album_b", "2022"),
         ];
 
-        let CachedRootTag(result) = pane.process_songs(artist, songs, &ctx);
+        pane.process_songs(artist.clone(), songs, &ctx);
 
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].name, "album_a");
-        assert_eq!(result[1].name, "album_b");
+        assert_eq!(pane.stack.dirs.keys().sorted().collect_vec(), vec![
+            &Path::from([]),
+            &Path::from("artist"),
+            &Path::from(["artist", "album_a"]),
+            &Path::from(["artist", "album_b"]),
+        ]);
+        assert_eq!(pane_albums(&pane), vec!["album_a", "album_b"]);
     }
 
     #[rstest]
@@ -699,12 +587,16 @@ mod tests {
             song("album_b", "2022"),
         ];
 
-        let CachedRootTag(result) = pane.process_songs(artist, songs, &ctx);
+        pane.process_songs(artist.clone(), songs, &ctx);
 
-        assert_eq!(result.len(), 3);
-        assert_eq!(result[0].name, "(2020) album_a");
-        assert_eq!(result[1].name, "(2021) album_a");
-        assert_eq!(result[2].name, "(2022) album_b");
+        assert_eq!(pane.stack.dirs.keys().sorted().collect_vec(), vec![
+            &Path::from([]),
+            &Path::from("artist"),
+            &Path::from(["artist", "(2020) album_a"]),
+            &Path::from(["artist", "(2021) album_a"]),
+            &Path::from(["artist", "(2022) album_b"]),
+        ]);
+        assert_eq!(pane_albums(&pane), vec!["(2020) album_a", "(2021) album_a", "(2022) album_b"]);
     }
 
     #[rstest]
@@ -721,12 +613,16 @@ mod tests {
             song("album_b", "2019"),
         ];
 
-        let CachedRootTag(result) = pane.process_songs(artist, songs, &ctx);
+        pane.process_songs(artist.clone(), songs, &ctx);
 
-        assert_eq!(result.len(), 3);
-        assert_eq!(result[0].name, "(2019) album_b");
-        assert_eq!(result[1].name, "(2020) album_a");
-        assert_eq!(result[2].name, "(2021) album_a");
+        assert_eq!(pane.stack.dirs.keys().sorted().collect_vec(), vec![
+            &Path::from([]),
+            &Path::from("artist"),
+            &Path::from(["artist", "(2019) album_b"]),
+            &Path::from(["artist", "(2020) album_a"]),
+            &Path::from(["artist", "(2021) album_a"]),
+        ]);
+        assert_eq!(pane_albums(&pane), vec!["(2019) album_b", "(2020) album_a", "(2021) album_a"]);
     }
 
     #[rstest]
@@ -743,12 +639,15 @@ mod tests {
             song("album_b", "2025"),
         ];
 
-        let CachedRootTag(result) = pane.process_songs(artist, songs, &ctx);
-        dbg!(&result);
+        pane.process_songs(artist.clone(), songs, &ctx);
 
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].name, "album_b");
-        assert_eq!(result[1].name, "album_a");
+        assert_eq!(pane.stack.dirs.keys().sorted().collect_vec(), vec![
+            &Path::from([]),
+            &Path::from("artist"),
+            &Path::from(["artist", "album_a"]),
+            &Path::from(["artist", "album_b"]),
+        ]);
+        assert_eq!(pane_albums(&pane), vec!["album_b", "album_a"]);
     }
 
     #[rstest]
@@ -766,11 +665,15 @@ mod tests {
                                                                 * from 1970 */
         ];
 
-        let CachedRootTag(result) = pane.process_songs(artist, songs, &ctx);
+        pane.process_songs(artist.clone(), songs, &ctx);
 
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].name, "(1969) album_a"); // Uses originaldate, not date
-        assert_eq!(result[1].name, "(1970) album_b"); // Uses originaldate, not date
+        assert_eq!(pane.stack.dirs.keys().sorted().collect_vec(), vec![
+            &Path::from([]),
+            &Path::from("artist"),
+            &Path::from(["artist", "(1969) album_a"]), // Uses originaldate, not date
+            &Path::from(["artist", "(1970) album_b"]), // Uses originaldate, not date
+        ]);
+        assert_eq!(pane_albums(&pane), vec!["(1969) album_a", "(1970) album_b"]);
     }
 
     #[rstest]
@@ -786,11 +689,15 @@ mod tests {
             song("album_b", "1990"),                           // Only has date, not originaldate
         ];
 
-        let CachedRootTag(result) = pane.process_songs(artist, songs, &ctx);
+        pane.process_songs(artist.clone(), songs, &ctx);
 
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].name, "(1969) album_a"); // Uses originaldate (first in list)
-        assert_eq!(result[1].name, "(1990) album_b"); // Falls back to date (second in list)
+        assert_eq!(pane.stack.dirs.keys().sorted().collect_vec(), vec![
+            &Path::from([]),
+            &Path::from("artist"),
+            &Path::from(["artist", "(1969) album_a"]), // Uses originaldate (first in list)
+            &Path::from(["artist", "(1990) album_b"]), // Falls back to date (second in list)
+        ]);
+        assert_eq!(pane_albums(&pane), vec!["(1969) album_a", "(1990) album_b"]);
     }
 
     #[rstest]
@@ -805,9 +712,13 @@ mod tests {
             song("album_a", "1987"), // Only has "date", not in our list
         ];
 
-        let CachedRootTag(result) = pane.process_songs(artist, songs, &ctx);
+        pane.process_songs(artist.clone(), songs, &ctx);
 
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].name, "(<no date>) album_a"); // Falls back to default
+        assert_eq!(pane.stack.dirs.keys().sorted().collect_vec(), vec![
+            &Path::from([]),
+            &Path::from("artist"),
+            &Path::from(["artist", "(<no date>) album_a"]) // Falls back to default
+        ]);
+        assert_eq!(pane_albums(&pane), vec!["(<no date>) album_a"]);
     }
 }


### PR DESCRIPTION
## Description

No changes to behavior (hopefully) except fewer refetches and more caching in rmpc. This further
simplifies the data flow in the various browsers and brings their implementation closer to each other.
Also makes rmpc keep the dir state when going back out.

### Related issues

Also fixes https://github.com/mierak/rmpc/issues/658

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
