### PR TITLE
feat: add search button config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ browser panes as well as searched for in the Search pane
 Search pane
 - Added `Replace` transform
 - Added section filter to docs search
+- `search_button` config option for search pane
 
 ### Changed
 

--- a/docs/src/content/docs/next/assets/example_config.ron
+++ b/docs/src/content/docs/next/assets/example_config.ron
@@ -109,6 +109,7 @@
     search: (
         case_sensitive: false,
         ignore_diacritics: false,
+        search_button: false,
         mode: Contains,
         tags: [
             (value: "any",         label: "Any Tag"),

--- a/docs/src/content/docs/next/configuration/search.mdx
+++ b/docs/src/content/docs/next/configuration/search.mdx
@@ -32,6 +32,13 @@ Cannot be enabled at the same time as [case_sensitive](#case_sensitive).
 This option requires MPD version 0.25.0 and newer to work
 :::
 
+## search_button
+
+<ConfigValue name="search_button" type="bool" />
+
+Display a dedicated search button in the search from when set to true. Otherwise the search is triggered
+on every change. Defaults to `false`.
+
 ## mode
 
 <ConfigValue name="mode" type={["Exact", "StartsWith", "Contains", "Regex"]} />

--- a/src/config/search.rs
+++ b/src/config/search.rs
@@ -1,12 +1,14 @@
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
+use super::defaults;
 use crate::mpd::mpd_client::FilterKind;
 
 #[derive(Debug, Default, Clone)]
 pub struct Search {
     pub case_sensitive: bool,
     pub ignore_diacritics: bool,
+    pub search_button: bool,
     pub mode: FilterKind,
     pub tags: Vec<SearchableTag>,
 }
@@ -16,6 +18,8 @@ pub struct SearchFile {
     case_sensitive: bool,
     #[serde(default)]
     ignore_diacritics: bool,
+    #[serde(default = "defaults::bool::<false>")]
+    search_button: bool,
     mode: FilterKindFile,
     tags: Vec<SearchableTagFile>,
 }
@@ -44,6 +48,7 @@ impl TryFrom<SearchFile> for Search {
         Ok(Self {
             case_sensitive: value.case_sensitive,
             ignore_diacritics: value.ignore_diacritics,
+            search_button: value.search_button,
             mode: value.mode.into(),
             tags: if value.tags.is_empty() {
                 vec![SearchableTag { label: "Any Tag".to_string(), value: "any".to_string() }]
@@ -63,6 +68,7 @@ impl Default for SearchFile {
         Self {
             case_sensitive: false,
             ignore_diacritics: false,
+            search_button: false,
             mode: FilterKindFile::Contains,
             tags: [
                 SearchableTagFile { value: "any".to_string(), label: "Any Tag".to_string() },


### PR DESCRIPTION
## Description

Adds `search_button` option. Displays a dedicated search button in the search pane instead of triggering the search on every change. Also display status notification with how many results when found.

### Related issues

fixes #670

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
