### PR TITLE
feat: detect duplicates when adding to a playlist

### DIFF
--- a/docs/src/content/docs/next/assets/example_config.ron
+++ b/docs/src/content/docs/next/assets/example_config.ron
@@ -95,7 +95,7 @@
             "D":         Delete,
             "B":         ShowInfo,
             "<C-z>":     ContextMenu(),
-            "<C-s>":     Save(kind: Modal(all: false)),
+            "<C-s>":     Save(kind: Modal(all: false, duplicates_strategy: Ask)),
         },
         queue: {
             "D":       DeleteAll,

--- a/docs/src/content/docs/next/configuration/keybinds.mdx
+++ b/docs/src/content/docs/next/configuration/keybinds.mdx
@@ -258,12 +258,21 @@ These mean:
 - Playlist - save the items to a specified playlist directly, the playlist will be created if it does
   not exist
 
+Both kinds also take additional options:
+
+- `all` - Controls whether to add all items in the current directory or just the marked ones/the
+  one under the cursor. Can be either `true` or `false`. Defaults to `false`.
+- `duplicates_strategy` - what to do when the playlist you are adding songs to already contains some
+  or all of the songs you are adding. Possible values are: `All`, `None`, `NonDuplicate`, `Ask`. These
+  add all the songs anyway, no songs at all, only the non duplicate songs or display a modal asking
+  you what to do respectively. Defaults to `Ask`.
+
 ##### Examples
 
 - Adds items under cursor to a playlist named "myplaylist"
 
 ```rust showLineNumbers=false
-Save(kind: Playlist(name: "myplaylist"))
+Save(kind: Playlist(name: "myplaylist", duplicates_strategy: Ask))
 ```
 
 - Adds all items in the current directory to a playlist named "myplaylist"
@@ -279,7 +288,7 @@ Save()
 // or equivalent
 Save(kind: Modal())
 // or equivalent
-Save(kind: Modal(all: false))
+Save(kind: Modal(all: false, duplicates_strategy: Ask))
 ```
 
 - Display a modal with options to save all items to either a new or an existing playlist

--- a/src/shared/macros.rs
+++ b/src/shared/macros.rs
@@ -56,8 +56,12 @@ macro_rules! status_warn {
 
 macro_rules! modal {
     ( $i:ident, $e:expr ) => {{
-        $i.app_event_sender
-            .send(crate::AppEvent::UiEvent(crate::ui::UiAppEvent::Modal(Box::new($e))))?;
+        if let Err(err) = $i.app_event_sender
+            .send(crate::AppEvent::UiEvent(crate::ui::UiAppEvent::Modal(Box::new($e))))
+        {
+            log::error!("Failed to open a modal: {err}");
+            log::error!(target: "{status_bar}", "Failed to open a modal: {err}");
+        }
     }};
 }
 


### PR DESCRIPTION
## Description

Detect whether the target playlist already contains any of the songs being added. The `Save` keybind
can be configured to either add all, none, non duplicates only or ask the user what to do.

### Related issues

fixes #545

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
