### PR TITLE
fix: raw command to communicate with MPD directly

### DIFF
--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -114,6 +114,12 @@ pub enum Command {
     },
     /// Prints information about optional runtime dependencies
     DebugInfo,
+    /// Sends a raw command to MPD and prints the response
+    #[clap(hide = true)]
+    Raw {
+        /// Command to send to MPD
+        command: String,
+    },
     /// Prints the rmpc version
     Version,
     /// Prints the list of songs in the current queue

--- a/src/core/command.rs
+++ b/src/core/command.rs
@@ -36,6 +36,7 @@ impl Command {
             Command::Theme { .. } => bail!("Cannot use theme command here."),
             Command::Version => bail!("Cannot use version command here."),
             Command::DebugInfo => bail!("Cannot use debuginfo command here."),
+            Command::Raw { .. } => bail!("Cannot use raw command here."),
             Command::Remote { .. } => bail!("Cannot use remote command here."),
             Command::AddRandom { tag, count } => Ok(Box::new(move |client| {
                 match tag {


### PR DESCRIPTION
## Description

Ever so often I have to ask users about raw response to MPD protocol commands. Asking these users to connect to MPD via other tools like `netcat` makes this a bit more complicated than it needs to be.

Example: `rmpc raw "status"` to send the `status` command to MPD and print its raw response.

This command is hidden from help and undocumented on purpose, it is not intended to be used by users and may change in the future.

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with nightly
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (if needed)
- [x] Changelog has been updated
