### PR TITLE
Fix installation instructions for rmpc

### DIFF
--- a/docs/src/content/docs/next/installation.mdx
+++ b/docs/src/content/docs/next/installation.mdx
@@ -87,7 +87,7 @@ After it's done downloading, untar the archive, set execute permission and run r
 # compile the latest version from source
 cargo install rmpc --locked
 # or download precompiled binary with cargo binstall
-cargo binstall rmpc
+cargo install rmpc
 # or compile the latest work in progress version from git
 cargo install --git https://github.com/mierak/rmpc --locked
 ```


### PR DESCRIPTION
On the cargo install section, the command was wrong written

## Description
Word 'Install' was wrong

### Related issues

### Checklist

- [ Yes] All tests passed
- [ Yes] Code has been formatted with nightly
- [ Yes] Code has been checked with clippy (stable)
- [ Yes] Documentation has been updated (if needed)
- [ No] Changelog has been updated
