### PR TITLE
fix: album art not visible after de/attach from tmux session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Ignore rare phantom inputs from querying terminal for protocol support on startup
 - Fix directories pane not fetching data after using the `Confirm` action to enter a directory
 - Album art (sixel and iterm2) sometimes being aligned to an incorrect pane when in tmux splits
+- Album art (sixel and iterm2) not rendering after detaching and reattaching from tmux session
 
 ## [0.10.0] - 2025-11-11
 

--- a/src/shared/tmux.rs
+++ b/src/shared/tmux.rs
@@ -48,7 +48,12 @@ impl TmuxHooks {
         let current_exe = std::env::current_exe()?;
         let current_exe = current_exe.to_string_lossy();
 
-        for hook in ["session-window-changed", "client-attached", "client-session-changed"] {
+        for hook in [
+            "session-window-changed",
+            "client-attached",
+            "client-detached",
+            "client-session-changed",
+        ] {
             let mut cmd = std::process::Command::new("tmux");
             let cmd = cmd.args([
                 "set-hook",


### PR DESCRIPTION
## Description

### Related issues

fixes https://github.com/mierak/rmpc/issues/733

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
