### PR TITLE
refactor: simplify image backends

### DIFF
--- a/src/core/work.rs
+++ b/src/core/work.rs
@@ -77,5 +77,6 @@ fn handle_work_request(
         WorkRequest::IndexSingleLrc { path } => {
             Ok(WorkDone::SingleLrcIndexed { lrc_entry: LrcIndex::index_single(path)? })
         }
+        WorkRequest::ResizeImage(fn_once) => Ok(WorkDone::ImageResized { data: fn_once() }),
     }
 }

--- a/src/mpd/commands/idle.rs
+++ b/src/mpd/commands/idle.rs
@@ -1,6 +1,6 @@
 use crate::mpd::{FromMpd, LineHandled, errors::MpdError};
 
-#[derive(Debug, Clone, Copy, strum::Display)]
+#[derive(Debug, Clone, Copy, strum::Display, Eq, Hash, PartialEq)]
 #[strum(serialize_all = "snake_case")]
 pub enum IdleEvent {
     Player,   /* the player has been started, stopped or seeked or tags of

--- a/src/shared/events.rs
+++ b/src/shared/events.rs
@@ -20,7 +20,7 @@ use crate::{
         theme::UiConfig,
     },
     mpd::{QueuePosition, commands::IdleEvent},
-    ui::UiAppEvent,
+    ui::{UiAppEvent, image::facade::EncodeData},
 };
 
 #[derive(Debug)]
@@ -31,7 +31,6 @@ pub(crate) enum ClientRequest {
     Command(MpdCommand),
 }
 
-#[derive(Debug)]
 #[allow(unused)]
 pub(crate) enum WorkRequest {
     IndexLyrics {
@@ -49,6 +48,7 @@ pub(crate) enum WorkRequest {
         position: Option<QueuePosition>,
     },
     Command(Command),
+    ResizeImage(Box<dyn FnOnce() -> Result<EncodeData> + Send + Sync>),
 }
 
 #[derive(Debug)]
@@ -58,6 +58,7 @@ pub(crate) enum WorkDone {
     SingleLrcIndexed { lrc_entry: Option<LrcIndexEntry> },
     MpdCommandFinished { id: &'static str, target: Option<PaneType>, data: MpdQueryResult },
     SearchYtResults { items: Vec<SearchItem>, position: Option<QueuePosition> },
+    ImageResized { data: Result<EncodeData> },
     None,
 }
 

--- a/src/ui/image/block.rs
+++ b/src/ui/image/block.rs
@@ -1,184 +1,117 @@
-use std::{
-    io::Write,
-    sync::{Arc, atomic::Ordering},
-};
+use std::io::Write;
 
 use ansi_colours::ansi256_from_rgb;
 use anyhow::Result;
-use crossbeam::channel::{Sender, unbounded};
 use crossterm::{
     cursor::{MoveTo, RestorePosition, SavePosition},
     queue,
-    style::{Color, Colors, Print, ResetColor, SetBackgroundColor, SetForegroundColor},
+    style::{Color, Print, ResetColor, SetBackgroundColor, SetForegroundColor},
 };
 use image::DynamicImage;
 use ratatui::layout::Rect;
 
-use super::{AlbumArtConfig, Backend, ImageBackendRequest};
+use super::Backend;
 use crate::{
-    shared::{
-        image::{AlignedArea, resize_image},
-        macros::try_cont,
-        terminal::TERMINAL,
+    config::{
+        Size,
+        album_art::{HorizontalAlign, VerticalAlign},
     },
-    try_skip,
-    ui::image::{EncodeRequest, clear_area, facade::IS_SHOWING, recv_data},
+    ctx::Ctx,
+    shared::image::{AlignedArea, resize_image},
+    ui::image::clear_area,
 };
 
 #[derive(Debug)]
-pub struct Block {
-    sender: Sender<ImageBackendRequest>,
-    colors: Colors,
-    handle: std::thread::JoinHandle<()>,
+pub struct Block;
+
+#[derive(derive_more::Debug)]
+pub struct Data {
+    #[debug(skip)]
+    image: DynamicImage,
+    aligned_area: AlignedArea,
 }
 
 impl Backend for Block {
-    fn hide(&mut self, size: Rect) -> anyhow::Result<()> {
-        let writer = TERMINAL.writer();
-        let mut writer = writer.lock();
-        clear_area(writer.by_ref(), self.colors, size)
+    type EncodedData = Data;
+
+    fn hide(
+        &mut self,
+        w: &mut impl Write,
+        size: Rect,
+        bg_color: Option<crossterm::style::Color>,
+    ) -> anyhow::Result<()> {
+        clear_area(w, bg_color, size)
     }
 
-    fn show(&mut self, data: Arc<Vec<u8>>, area: Rect) -> Result<()> {
-        Ok(self.sender.send(ImageBackendRequest::Encode(EncodeRequest { area, data }))?)
-    }
+    fn display(&mut self, w: &mut impl Write, data: Self::EncodedData, _ctx: &Ctx) -> Result<()> {
+        queue!(w, SavePosition)?;
+        let img = data.image;
+        let resized_area = data.aligned_area;
 
-    fn set_config(&self, config: AlbumArtConfig) -> Result<()> {
-        Ok(self.sender.send(ImageBackendRequest::SetConfig(config))?)
-    }
+        let img_buffer = img.to_rgba8();
+        let area = &resized_area.area;
+        let size_px = &resized_area.size_px;
 
-    fn cleanup(self: Box<Self>, _area: Rect) -> Result<()> {
-        self.sender.send(ImageBackendRequest::Stop)?;
-        self.handle.join().expect("block thread to end gracefully");
+        let cell_width = (f64::from(size_px.width) / f64::from(area.width)) as u32;
+        let cell_height = (f64::from(size_px.height) / (f64::from(area.height) * 2.0)) as u32;
+
+        let (img_width, img_height) = img_buffer.dimensions();
+
+        for term_y in 0..area.height {
+            queue!(w, MoveTo(area.x, area.y + term_y))?;
+
+            let top_pixel_row = u32::from(term_y) * 2 * cell_height;
+            let bottom_pixel_row = top_pixel_row + cell_height;
+            let is_last_term_row = term_y == area.height - 1;
+
+            for term_x in 0..area.width {
+                let pixel_x = u32::from(term_x) * cell_width;
+
+                let top_pixel =
+                    get_pixel_safe(&img_buffer, pixel_x, top_pixel_row, img_width, img_height);
+                let bottom_pixel =
+                    get_pixel_safe(&img_buffer, pixel_x, bottom_pixel_row, img_width, img_height);
+
+                let top_color = color_from_pixel(top_pixel);
+                let bottom_color = color_from_pixel(bottom_pixel);
+
+                if is_last_term_row {
+                    // Last row - only show top pixel, bottom is empty
+                    queue!(w, SetForegroundColor(top_color), Print(UPPER_HALF_BLOCK))?;
+                } else {
+                    // Normal rows - both pixels, use lower half block with fg/bg
+                    queue!(
+                        w,
+                        SetForegroundColor(bottom_color),
+                        SetBackgroundColor(top_color),
+                        Print(LOWER_HALF_BLOCK)
+                    )?;
+                }
+            }
+
+            queue!(w, ResetColor)?;
+        }
+
+        w.flush()?;
+        queue!(w, RestorePosition)?;
+
         Ok(())
     }
-}
 
-impl Block {
-    pub(super) fn new(config: AlbumArtConfig) -> Self {
-        let (sender, receiver) = unbounded::<ImageBackendRequest>();
-        let colors = config.colors;
-
-        let handle = std::thread::Builder::new()
-            .name("block".to_string())
-            .spawn(move || {
-                let mut config = config;
-                let mut pending_req = None;
-                'outer: loop {
-                    let EncodeRequest { data, area } =
-                        match recv_data(&mut pending_req, &mut config, &receiver) {
-                            Ok(Some(msg)) => msg,
-                            Ok(None) => break,
-                            Err(err) => {
-                                log::error!("Error receiving ImageBackendRequest message: {err}");
-                                break;
-                            }
-                        };
-
-                    let (img, resized_area) = try_cont!(
-                        resize_image(&data, area, config.max_size, config.halign, config.valign),
-                        "Failed to resize block image"
-                    );
-
-                    // consume all pending messages, skipping older encode requests
-                    for msg in receiver.try_iter() {
-                        match msg {
-                            ImageBackendRequest::Stop => break 'outer,
-                            ImageBackendRequest::SetConfig(cfg) => config = cfg,
-                            ImageBackendRequest::Encode(req) => {
-                                pending_req = Some(req);
-                                log::debug!(
-                                    "Skipping image because another one is waiting in the queue"
-                                );
-                                continue 'outer;
-                            }
-                        }
-                    }
-
-                    let writer = TERMINAL.writer();
-                    let mut writer = writer.lock();
-                    let mut w = writer.by_ref();
-
-                    if !IS_SHOWING.load(Ordering::Relaxed) {
-                        log::trace!(
-                            "Not showing image because its not supposed to be displayed anymore"
-                        );
-                        continue;
-                    }
-
-                    try_cont!(
-                        clear_area(&mut w, config.colors, area),
-                        "Failed to clear image area"
-                    );
-
-                    try_skip!(display(&mut w, &img, resized_area), "Failed to display block");
-                }
-            })
-            .expect("block thread to be spawned");
-
-        Self { sender, colors, handle }
+    fn create_data(
+        image_data: &[u8],
+        area: Rect,
+        max_size: Size,
+        halign: HorizontalAlign,
+        valign: VerticalAlign,
+    ) -> Result<Self::EncodedData> {
+        let (img, resized_area) = resize_image(image_data, area, max_size, halign, valign)?;
+        Ok(Data { image: img, aligned_area: resized_area })
     }
 }
 
 const UPPER_HALF_BLOCK: &str = "\u{2580}";
 const LOWER_HALF_BLOCK: &str = "\u{2584}";
-
-fn display(
-    w: &mut impl Write,
-    img: &DynamicImage,
-    resized_area: AlignedArea,
-) -> std::io::Result<()> {
-    queue!(w, SavePosition)?;
-
-    let img_buffer = img.to_rgba8();
-    let area = &resized_area.area;
-    let size_px = &resized_area.size_px;
-
-    let cell_width = (f64::from(size_px.width) / f64::from(area.width)) as u32;
-    let cell_height = (f64::from(size_px.height) / (f64::from(area.height) * 2.0)) as u32;
-
-    let (img_width, img_height) = img_buffer.dimensions();
-
-    for term_y in 0..area.height {
-        queue!(w, MoveTo(area.x, area.y + term_y))?;
-
-        let top_pixel_row = u32::from(term_y) * 2 * cell_height;
-        let bottom_pixel_row = top_pixel_row + cell_height;
-        let is_last_term_row = term_y == area.height - 1;
-
-        for term_x in 0..area.width {
-            let pixel_x = u32::from(term_x) * cell_width;
-
-            let top_pixel =
-                get_pixel_safe(&img_buffer, pixel_x, top_pixel_row, img_width, img_height);
-            let bottom_pixel =
-                get_pixel_safe(&img_buffer, pixel_x, bottom_pixel_row, img_width, img_height);
-
-            let top_color = color_from_pixel(top_pixel);
-            let bottom_color = color_from_pixel(bottom_pixel);
-
-            if is_last_term_row {
-                // Last row - only show top pixel, bottom is empty
-                queue!(w, SetForegroundColor(top_color), Print(UPPER_HALF_BLOCK))?;
-            } else {
-                // Normal rows - both pixels, use lower half block with fg/bg
-                queue!(
-                    w,
-                    SetForegroundColor(bottom_color),
-                    SetBackgroundColor(top_color),
-                    Print(LOWER_HALF_BLOCK)
-                )?;
-            }
-        }
-
-        queue!(w, ResetColor)?;
-    }
-
-    w.flush()?;
-    queue!(w, RestorePosition)?;
-
-    Ok(())
-}
 
 #[inline]
 fn get_pixel_safe(

--- a/src/ui/image/facade.rs
+++ b/src/ui/image/facade.rs
@@ -1,9 +1,7 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
+use std::{io::Write, sync::Arc};
 
 use anyhow::Result;
+use crossbeam::channel::Sender;
 use ratatui::layout::Rect;
 
 use super::{
@@ -14,20 +12,25 @@ use super::{
     sixel::Sixel,
     ueberzug::{Layer, Ueberzug},
 };
-use crate::config::{Config, album_art::ImageMethod};
-
-pub static IS_SHOWING: AtomicBool = AtomicBool::new(false);
+use crate::{
+    config::album_art::ImageMethod,
+    ctx::Ctx,
+    shared::{events::WorkRequest, macros::status_error, terminal::TERMINAL},
+};
 
 #[derive(Debug)]
 pub struct AlbumArtFacade {
-    image_state: ImageState,
+    image_backend: ImageBackend,
     current_album_art: Option<Arc<Vec<u8>>>,
     default_album_art: Arc<Vec<u8>>,
     last_size: Rect,
+    work_tx: Sender<WorkRequest>,
+    is_showing: bool,
+    request_queue: Vec<Arc<Vec<u8>>>,
 }
 
 #[derive(Debug, Default)]
-enum ImageState {
+enum ImageBackend {
     Kitty(Kitty),
     Ueberzug(Ueberzug),
     Iterm2(Iterm2),
@@ -37,107 +40,218 @@ enum ImageState {
     None,
 }
 
+#[derive(Debug, Default)]
+pub enum EncodeData {
+    Kitty(<Kitty as Backend>::EncodedData),
+    Ueberzug(<Ueberzug as Backend>::EncodedData),
+    Iterm2(<Iterm2 as Backend>::EncodedData),
+    Sixel(<Sixel as Backend>::EncodedData),
+    Block(<Block as Backend>::EncodedData),
+    #[default]
+    Empty,
+}
+
 impl AlbumArtFacade {
-    pub fn new(config: &Config) -> Self {
-        let image_state = match config.album_art.method {
-            ImageMethod::Kitty => ImageState::Kitty(Kitty::new(config.into())),
-            ImageMethod::UeberzugWayland => ImageState::Ueberzug(Ueberzug::new(Layer::Wayland)),
-            ImageMethod::UeberzugX11 => ImageState::Ueberzug(Ueberzug::new(Layer::X11)),
-            ImageMethod::Iterm2 => ImageState::Iterm2(Iterm2::new(config.into())),
-            ImageMethod::Sixel => ImageState::Sixel(Sixel::new(config.into())),
-            ImageMethod::Block => ImageState::Block(Block::new(config.into())),
-            ImageMethod::None => ImageState::None,
+    pub fn new(ctx: &Ctx) -> Self {
+        let config = ctx.config.as_ref();
+        let image_backend = match config.album_art.method {
+            ImageMethod::Kitty => ImageBackend::Kitty(Kitty),
+            ImageMethod::UeberzugWayland => ImageBackend::Ueberzug(Ueberzug::new(Layer::Wayland)),
+            ImageMethod::UeberzugX11 => ImageBackend::Ueberzug(Ueberzug::new(Layer::X11)),
+            ImageMethod::Iterm2 => ImageBackend::Iterm2(Iterm2),
+            ImageMethod::Sixel => ImageBackend::Sixel(Sixel),
+            ImageMethod::Block => ImageBackend::Block(Block),
+            ImageMethod::None => ImageBackend::None,
         };
+
         Self {
-            image_state,
+            image_backend,
             current_album_art: None,
             last_size: Rect::default(),
             default_album_art: Arc::new(config.theme.default_album_art.to_vec()),
+            work_tx: ctx.work_sender.clone(),
+            is_showing: false,
+            request_queue: Vec::new(),
         }
     }
 
-    pub fn show_default(&mut self) -> Result<()> {
+    pub fn show_default(&mut self, ctx: &Ctx) -> Result<()> {
         self.current_album_art = Some(Arc::clone(&self.default_album_art));
-        self.show_current()
+        self.show_current(ctx)
     }
 
-    pub fn show_current(&mut self) -> Result<()> {
-        let Some(ref current_album_art) = self.current_album_art else {
+    pub fn show_current(&mut self, ctx: &Ctx) -> Result<()> {
+        let Some(current_album_art) = self.current_album_art.as_ref().map(Arc::clone) else {
             log::warn!("Tried to display current album art but none was present");
             return Ok(());
         };
 
-        IS_SHOWING.store(true, Ordering::Relaxed);
-
-        let data = Arc::clone(current_album_art);
-        log::debug!(bytes = data.len(), area:? = self.last_size; "Displaying current image again",);
-
-        match &mut self.image_state {
-            ImageState::Kitty(kitty) => kitty.show(data, self.last_size),
-            ImageState::Ueberzug(ueberzug) => ueberzug.show(data, self.last_size),
-            ImageState::Iterm2(iterm2) => iterm2.show(data, self.last_size),
-            ImageState::Sixel(s) => s.show(data, self.last_size),
-            ImageState::Block(s) => s.show(data, self.last_size),
-            ImageState::None => Ok(()),
-        }
+        self.show(current_album_art, ctx)?;
+        return Ok(());
     }
 
-    pub fn show(&mut self, data: Vec<u8>) -> Result<()> {
-        IS_SHOWING.store(true, Ordering::Relaxed);
+    pub fn show(&mut self, data: impl Into<Arc<Vec<u8>>>, ctx: &Ctx) -> Result<()> {
+        self.is_showing = true;
 
-        log::debug!(bytes = data.len(), area:? = self.last_size; "New image received",);
-        let data = Arc::new(data);
+        let max_size = ctx.config.album_art.max_size_px;
+        let halign = ctx.config.album_art.horizontal_align;
+        let valign = ctx.config.album_art.vertical_align;
+        let size = self.last_size;
+
+        let data = data.into();
         self.current_album_art = Some(Arc::clone(&data));
 
-        match &mut self.image_state {
-            ImageState::Kitty(kitty) => kitty.show(data, self.last_size),
-            ImageState::Ueberzug(ueberzug) => ueberzug.show(data, self.last_size),
-            ImageState::Iterm2(iterm2) => iterm2.show(data, self.last_size),
-            ImageState::Sixel(s) => s.show(data, self.last_size),
-            ImageState::Block(s) => s.show(data, self.last_size),
-            ImageState::None => Ok(()),
+        self.request_queue.push(Arc::clone(&data));
+        if self.request_queue.len() > 1 {
+            log::debug!("Image encode request already in flight, queueing the new one.");
+            return Ok(());
         }
+
+        match &mut self.image_backend {
+            ImageBackend::Kitty(_kitty) => {
+                self.work_tx.send(WorkRequest::ResizeImage(Box::new(move || {
+                    Ok(EncodeData::Kitty(Kitty::create_data(
+                        &data, size, max_size, halign, valign,
+                    )?))
+                })))?;
+            }
+            ImageBackend::Iterm2(_iterm2) => {
+                self.work_tx.send(WorkRequest::ResizeImage(Box::new(move || {
+                    Ok(EncodeData::Iterm2(Iterm2::create_data(
+                        &data, size, max_size, halign, valign,
+                    )?))
+                })))?;
+            }
+            ImageBackend::Sixel(_sixel) => {
+                log::debug!("Sending sixel image encode request");
+                self.work_tx.send(WorkRequest::ResizeImage(Box::new(move || {
+                    Ok(EncodeData::Sixel(Sixel::create_data(
+                        &data, size, max_size, halign, valign,
+                    )?))
+                })))?;
+            }
+            ImageBackend::Block(_block) => {
+                self.work_tx.send(WorkRequest::ResizeImage(Box::new(move || {
+                    Ok(EncodeData::Block(Block::create_data(
+                        &data, size, max_size, halign, valign,
+                    )?))
+                })))?;
+            }
+            ImageBackend::Ueberzug(_ueberzug) => {
+                self.work_tx.send(WorkRequest::ResizeImage(Box::new(move || {
+                    Ok(EncodeData::Ueberzug(Ueberzug::create_data(
+                        &data, size, max_size, halign, valign,
+                    )?))
+                })))?;
+            }
+            ImageBackend::None => {}
+        }
+
+        Ok(())
     }
 
-    pub fn hide(&mut self) -> Result<()> {
-        IS_SHOWING.store(false, Ordering::Relaxed);
-        match &mut self.image_state {
-            ImageState::Kitty(kitty) => kitty.hide(self.last_size)?,
-            ImageState::Ueberzug(ueberzug) => ueberzug.hide(self.last_size)?,
-            ImageState::Iterm2(iterm2) => iterm2.hide(self.last_size)?,
-            ImageState::Sixel(s) => s.hide(self.last_size)?,
-            ImageState::Block(s) => s.hide(self.last_size)?,
-            ImageState::None => {}
+    pub fn image_processing_failed(&mut self, err: &anyhow::Error, ctx: &Ctx) -> Result<()> {
+        status_error!("Failed to process album art image: {err:?}");
+
+        if let Some(req_data) = self.request_queue.pop()
+            && !self.request_queue.is_empty()
+        {
+            log::debug!("More image requests in queue, encoding the latest one instead");
+            self.request_queue.clear();
+            self.show(req_data, ctx)?;
+        }
+        Ok(())
+    }
+
+    pub fn display(&mut self, data: EncodeData, ctx: &Ctx) -> Result<()> {
+        if !self.is_showing {
+            log::trace!("Not showing image because its not supposed to be displayed anymore");
+            return Ok(());
+        }
+
+        if let Some(req_data) = self.request_queue.pop()
+            && !self.request_queue.is_empty()
+        {
+            log::debug!("More image requests in queue, encoding the latest one instead");
+            self.request_queue.clear();
+            self.show(req_data, ctx)?;
+            return Ok(());
+        }
+
+        log::debug!(data:?, area:? = self.last_size; "Received encoded data",);
+
+        let w = TERMINAL.writer();
+        let mut w = w.lock();
+        let w = w.by_ref();
+        let c = ctx.config.theme.background_color.map(Into::into);
+
+        let result = match (&mut self.image_backend, data) {
+            (ImageBackend::Kitty(kitty), EncodeData::Kitty(data)) => {
+                kitty.hide(w, self.last_size, c).and_then(|()| kitty.display(w, data, ctx))
+            }
+            (ImageBackend::Ueberzug(ueberzug), EncodeData::Ueberzug(data)) => {
+                ueberzug.hide(w, self.last_size, c).and_then(|()| ueberzug.display(w, data, ctx))
+            }
+            (ImageBackend::Iterm2(iterm2), EncodeData::Iterm2(data)) => {
+                iterm2.hide(w, self.last_size, c).and_then(|()| iterm2.display(w, data, ctx))
+            }
+            (ImageBackend::Sixel(sixel), EncodeData::Sixel(data)) => {
+                sixel.hide(w, self.last_size, c).and_then(|()| sixel.display(w, data, ctx))
+            }
+            (ImageBackend::Block(block), EncodeData::Block(data)) => {
+                block.hide(w, self.last_size, c).and_then(|()| block.display(w, data, ctx))
+            }
+            (ImageBackend::None, EncodeData::Empty) => {
+                log::warn!("Tried to display image but no backend is selected");
+                Ok(())
+            }
+            _ => {
+                status_error!(
+                    "Received encoded data for a different backend than the one in use. Please report this."
+                );
+                Ok(())
+            }
+        };
+
+        if let Err(err) = result {
+            status_error!("Failed to display image {err:#}");
+        }
+
+        Ok(())
+    }
+
+    pub fn hide(&mut self, ctx: &Ctx) -> Result<()> {
+        self.is_showing = false;
+        let w = TERMINAL.writer();
+        let mut w = w.lock();
+        let w = w.by_ref();
+        let c = ctx.config.theme.background_color.map(Into::into);
+
+        match &mut self.image_backend {
+            ImageBackend::Kitty(s) => s.hide(w, self.last_size, c)?,
+            ImageBackend::Ueberzug(s) => s.hide(w, self.last_size, c)?,
+            ImageBackend::Iterm2(s) => s.hide(w, self.last_size, c)?,
+            ImageBackend::Sixel(s) => s.hide(w, self.last_size, c)?,
+            ImageBackend::Block(s) => s.hide(w, self.last_size, c)?,
+            ImageBackend::None => {}
         }
         Ok(())
     }
 
     pub fn cleanup(&mut self) -> Result<()> {
-        let state = std::mem::take(&mut self.image_state);
-        IS_SHOWING.store(false, Ordering::Relaxed);
+        let state = std::mem::take(&mut self.image_backend);
+        self.is_showing = false;
         match state {
-            ImageState::Kitty(kitty) => Box::new(kitty).cleanup(self.last_size),
-            ImageState::Ueberzug(ueberzug) => Box::new(ueberzug).cleanup(self.last_size),
-            ImageState::Iterm2(iterm2) => Box::new(iterm2).cleanup(self.last_size),
-            ImageState::Sixel(s) => Box::new(s).cleanup(self.last_size),
-            ImageState::Block(s) => Box::new(s).cleanup(self.last_size),
-            ImageState::None => Ok(()),
+            ImageBackend::Kitty(kitty) => Box::new(kitty).cleanup(self.last_size),
+            ImageBackend::Ueberzug(ueberzug) => Box::new(ueberzug).cleanup(self.last_size),
+            ImageBackend::Iterm2(iterm2) => Box::new(iterm2).cleanup(self.last_size),
+            ImageBackend::Sixel(s) => Box::new(s).cleanup(self.last_size),
+            ImageBackend::Block(s) => Box::new(s).cleanup(self.last_size),
+            ImageBackend::None => Ok(()),
         }
     }
 
     pub fn set_size(&mut self, area: Rect) {
         self.last_size = area;
-    }
-
-    pub fn set_config(&mut self, config: &Config) -> Result<()> {
-        match &mut self.image_state {
-            ImageState::Kitty(kitty) => kitty.set_config(config.into())?,
-            ImageState::Ueberzug(ueberzug) => ueberzug.set_config(config.into())?,
-            ImageState::Iterm2(iterm2) => iterm2.set_config(config.into())?,
-            ImageState::Sixel(sixel) => sixel.set_config(config.into())?,
-            ImageState::Block(block) => block.set_config(config.into())?,
-            ImageState::None => {}
-        }
-        Ok(())
     }
 }

--- a/src/ui/image/sixel.rs
+++ b/src/ui/image/sixel.rs
@@ -1,235 +1,157 @@
-use std::{
-    collections::VecDeque,
-    io::Write,
-    ops::AddAssign,
-    sync::{Arc, atomic::Ordering},
-    time::Instant,
-};
+use std::{collections::VecDeque, io::Write, ops::AddAssign, time::Instant};
 
 use anyhow::{Result, bail};
 use color_quant::NeuQuant;
-use crossbeam::channel::{Sender, unbounded};
-use crossterm::style::Colors;
 use image::Rgba;
 use ratatui::layout::Rect;
 
-use super::{AlbumArtConfig, Backend, ImageBackendRequest, clear_area};
+use super::{Backend, clear_area};
 use crate::{
     config::{
         Size,
         album_art::{HorizontalAlign, VerticalAlign},
     },
-    shared::{
-        image::resize_image,
-        macros::{status_error, try_cont},
-        terminal::TERMINAL,
-        tmux::tmux_write_bytes,
-    },
+    ctx::Ctx,
+    shared::{image::resize_image, tmux::tmux_write_bytes},
     tmux,
-    try_skip,
-    ui::image::{EncodeRequest, facade::IS_SHOWING, recv_data},
 };
 
 #[derive(Debug)]
-pub struct Sixel {
-    sender: Sender<ImageBackendRequest>,
-    colors: Colors,
-    handle: std::thread::JoinHandle<()>,
+pub struct Sixel;
+
+#[derive(derive_more::Debug)]
+pub struct Data {
+    #[debug(skip)]
+    content: VecDeque<u8>,
+    area: Rect,
 }
 
 impl Backend for Sixel {
-    fn hide(&mut self, size: Rect) -> anyhow::Result<()> {
-        let writer = TERMINAL.writer();
-        let mut writer = writer.lock();
-        clear_area(writer.by_ref(), self.colors, size)
+    type EncodedData = Data;
+
+    fn hide(
+        &mut self,
+        w: &mut impl Write,
+        size: Rect,
+        bg_color: Option<crossterm::style::Color>,
+    ) -> anyhow::Result<()> {
+        clear_area(w, bg_color, size)
     }
 
-    fn show(&mut self, data: Arc<Vec<u8>>, area: Rect) -> Result<()> {
-        Ok(self.sender.send(ImageBackendRequest::Encode(EncodeRequest { area, data }))?)
-    }
+    fn display(
+        &mut self,
+        w: &mut impl Write,
+        mut data: Self::EncodedData,
+        _ctx: &Ctx,
+    ) -> Result<()> {
+        log::debug!(bytes = data.content.len(); "transmitting data");
 
-    fn set_config(&self, config: AlbumArtConfig) -> Result<()> {
-        Ok(self.sender.send(ImageBackendRequest::SetConfig(config))?)
-    }
+        // Adjust for tmux pane position if inside tmux
+        let (x, y) = if tmux::is_inside_tmux() {
+            match tmux::pane_position() {
+                Ok(pane_position) => {
+                    (data.area.x + 1 + pane_position.0, data.area.y + 1 + pane_position.1)
+                }
+                Err(err) => {
+                    log::error!(
+                        "Failed to get tmux pane position, falling back to unadjusted position, err: {err}"
+                    );
+                    (data.area.x + 1, data.area.y + 1)
+                }
+            }
+        } else {
+            (data.area.x + 1, data.area.y + 1)
+        };
 
-    fn cleanup(self: Box<Self>, _area: Rect) -> Result<()> {
-        self.sender.send(ImageBackendRequest::Stop)?;
-        self.handle.join().expect("sixel thread to end gracefully");
+        for b in format!("\x1b7\x1b[{y};{x}H").as_bytes().iter().rev() {
+            data.content.push_front(*b);
+        }
+
+        for b in "\x1b8".as_bytes() {
+            data.content.push_back(*b);
+        }
+
+        tmux_write_bytes!(w, data.content.make_contiguous());
+        w.flush()?;
+
         Ok(())
     }
-}
 
-impl Sixel {
-    pub(super) fn new(config: AlbumArtConfig) -> Self {
-        let (sender, receiver) = unbounded::<ImageBackendRequest>();
-        let colors = config.colors;
+    fn create_data(
+        image_data: &[u8],
+        area: Rect,
+        max_size: Size,
+        halign: HorizontalAlign,
+        valign: VerticalAlign,
+    ) -> Result<Self::EncodedData> {
+        let start = Instant::now();
 
-        let handle = std::thread::Builder::new()
-            .name("sixel".to_string())
-            .spawn(move || {
-                let mut config = config;
-                let mut pending_req = None;
-                'outer: loop {
-                    let EncodeRequest { data, area } =
-                        match recv_data(&mut pending_req, &mut config, &receiver) {
-                            Ok(Some(msg)) => msg,
-                            Ok(None) => break,
-                            Err(err) => {
-                                log::error!("Error receiving ImageBackendRequest message: {err}");
-                                break;
-                            }
-                        };
-
-                    let (buf, resized_area) = try_cont!(
-                        encode(&data, area, config.max_size, config.halign, config.valign),
-                        "Failed to encode"
-                    );
-
-                    // consume all pending messages, skipping older encode requests
-                    for msg in receiver.try_iter() {
-                        match msg {
-                            ImageBackendRequest::Stop => break 'outer,
-                            ImageBackendRequest::SetConfig(cfg) => config = cfg,
-                            ImageBackendRequest::Encode(req) => {
-                                pending_req = Some(req);
-                                log::debug!(
-                                    "Skipping image because another one is waiting in the queue"
-                                );
-                                continue 'outer;
-                            }
-                        }
-                    }
-
-                    let writer = TERMINAL.writer();
-                    let mut writer = writer.lock();
-                    let mut w = writer.by_ref();
-                    if !IS_SHOWING.load(Ordering::Relaxed) {
-                        log::trace!(
-                            "Not showing image because its not supposed to be displayed anymore"
-                        );
-                        continue;
-                    }
-
-                    try_cont!(
-                        clear_area(&mut w, config.colors, area),
-                        "Failed to clear sixel image area"
-                    );
-                    try_skip!(display(&mut w, buf, resized_area), "Failed to display sixel image");
-                }
-            })
-            .expect("sixel thread to be spawned");
-
-        Self { sender, colors, handle }
-    }
-}
-
-fn display(w: &mut impl Write, mut data: VecDeque<u8>, area: Rect) -> Result<()> {
-    log::debug!(bytes = data.len(); "transmitting data");
-
-    // Adjust for tmux pane position if inside tmux
-    let (x, y) = if tmux::is_inside_tmux() {
-        match tmux::pane_position() {
-            Ok(pane_position) => (area.x + 1 + pane_position.0, area.y + 1 + pane_position.1),
+        let (image, resized_area) = match resize_image(image_data, area, max_size, halign, valign) {
+            Ok(v) => v,
             Err(err) => {
-                log::error!(
-                    "Failed to get tmux pane position, falling back to unadjusted position, err: {err}"
-                );
-                (area.x + 1, area.y + 1)
+                bail!("Failed to resize image, err: {}", err);
             }
+        };
+
+        let width = image.width();
+        let height = image.height();
+        let tmux = tmux::is_inside_tmux();
+
+        let mut buf = Vec::new();
+
+        if tmux {
+            write!(buf, "\x1bPtmux;\x1b\x1bP0;1;7q\"1;1;{};{}", image.width(), image.height())?;
+        } else {
+            write!(buf, "\x1bP0;1;7q\"1;1;{};{}", image.width(), image.height())?;
         }
-    } else {
-        (area.x + 1, area.y + 1)
-    };
 
-    for b in format!("\x1b7\x1b[{y};{x}H").as_bytes().iter().rev() {
-        data.push_front(*b);
-    }
-
-    for b in "\x1b8".as_bytes() {
-        data.push_back(*b);
-    }
-
-    tmux_write_bytes!(w, data.make_contiguous());
-    w.flush()?;
-
-    Ok(())
-}
-
-fn encode(
-    data: &[u8],
-    area: Rect,
-    max_size: Size,
-    halign: HorizontalAlign,
-    valign: VerticalAlign,
-) -> Result<(VecDeque<u8>, Rect)> {
-    let start = Instant::now();
-
-    let (image, resized_area) = match resize_image(data, area, max_size, halign, valign) {
-        Ok(v) => v,
-        Err(err) => {
-            bail!("Failed to resize image, err: {}", err);
+        let image = image.to_rgba8();
+        let quantized = NeuQuant::new(10, 256, image.as_raw());
+        for (i, [r, g, b]) in quantized.color_map_rgb().u16_triples().enumerate() {
+            write!(buf, "#{i};2;{r};{g};{b}")?;
         }
-    };
 
-    let width = image.width();
-    let height = image.height();
-    let tmux = tmux::is_inside_tmux();
+        for y in 0..height {
+            let character: u8 = 63 + 2u8.pow(y % 6);
+            let mut repeat = 0;
+            let mut last_color = None;
 
-    let mut buf = Vec::new();
+            for x in 0..width {
+                let Rgba(current_pixel) = image.get_pixel(x, y);
+                let color = quantized.index_of(current_pixel);
 
-    if tmux {
-        write!(buf, "\x1bPtmux;\x1b\x1bP0;1;7q\"1;1;{};{}", image.width(), image.height())?;
-    } else {
-        write!(buf, "\x1bP0;1;7q\"1;1;{};{}", image.width(), image.height())?;
-    }
+                if last_color.is_some_and(|c| c == color) || last_color.is_none() {
+                    repeat.add_assign(1);
+                    last_color = Some(color);
+                    continue;
+                }
 
-    let image = image.to_rgba8();
-    let quantized = NeuQuant::new(10, 256, image.as_raw());
-    for (i, [r, g, b]) in quantized.color_map_rgb().u16_triples().enumerate() {
-        write!(buf, "#{i};2;{r};{g};{b}")?;
-    }
+                put_color(&mut buf, character, last_color.unwrap_or_default(), repeat)?;
 
-    for y in 0..height {
-        let character: u8 = 63 + 2u8.pow(y % 6);
-        let mut repeat = 0;
-        let mut last_color = None;
-
-        for x in 0..width {
-            let Rgba(current_pixel) = image.get_pixel(x, y);
-            let color = quantized.index_of(current_pixel);
-
-            if last_color.is_some_and(|c| c == color) || last_color.is_none() {
-                repeat.add_assign(1);
                 last_color = Some(color);
-                continue;
+                repeat = 1;
+            }
+
+            if tmux && buf.len() > 1_048_576 {
+                bail!(
+                    "Tmux supports a maximum of 1MB of data. Sixel image will not be displayed. Try decreasing max album art size."
+                )
             }
 
             put_color(&mut buf, character, last_color.unwrap_or_default(), repeat)?;
 
-            last_color = Some(color);
-            repeat = 1;
+            buf.push(if y % 6 == 5 { b'-' } else { b'$' });
         }
 
-        if tmux && buf.len() > 1_048_576 {
-            status_error!(
-                "Tmux supports a maximum of 1MB of data. Sixel image will not be displayed. Try decreasing max album art size.",
-            );
-            bail!("Exceeded tmux data limit")
+        if tmux {
+            write!(buf, "\x1b\\\x1b\\")?;
+        } else {
+            write!(buf, "\x1b\\")?;
         }
 
-        put_color(&mut buf, character, last_color.unwrap_or_default(), repeat)?;
-
-        buf.push(if y % 6 == 5 { b'-' } else { b'$' });
+        log::debug!(bytes = buf.len(), image_bytes = image.len(), elapsed:? = start.elapsed(); "encoded data");
+        Ok(Data { content: VecDeque::from(buf), area: resized_area.area })
     }
-
-    if tmux {
-        write!(buf, "\x1b\\\x1b\\")?;
-    } else {
-        write!(buf, "\x1b\\")?;
-    }
-
-    log::debug!(bytes = buf.len(), image_bytes = image.len(), elapsed:? = start.elapsed(); "encoded data");
-    Ok((buf.into(), resized_area.area))
 }
 
 fn put_color<W: Write>(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -52,7 +52,7 @@ use crate::{
         mpd_client_ext::{Enqueue, MpdClientExt},
         ytdlp::YtDlpHostKind,
     },
-    ui::modals::menu::create_rating_modal,
+    ui::{image::facade::EncodeData, modals::menu::create_rating_modal},
 };
 
 pub mod browser;
@@ -899,7 +899,7 @@ pub enum UiAppEvent {
     ChangeTab(TabName),
 }
 
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Debug)]
 #[allow(dead_code)]
 pub enum UiEvent {
     Player,
@@ -919,6 +919,8 @@ pub enum UiEvent {
     Hidden,
     ConfigChanged,
     PlaybackStateChanged,
+    ImageEncoded { data: EncodeData },
+    ImageEncodeFailed { err: anyhow::Error },
 }
 
 impl TryFrom<IdleEvent> for UiEvent {

--- a/src/ui/panes/cava.rs
+++ b/src/ui/panes/cava.rs
@@ -10,7 +10,7 @@ use crossbeam::channel::{Receiver, RecvError, Sender, TryRecvError};
 use crossterm::{
     cursor::{MoveTo, RestorePosition, SavePosition},
     queue,
-    style::{Colors, PrintStyledContent, Stylize},
+    style::{PrintStyledContent, Stylize},
     terminal::{BeginSynchronizedUpdate, EndSynchronizedUpdate},
 };
 use ratatui::{Frame, layout::Rect, style::Style, widgets::Block};
@@ -343,8 +343,7 @@ impl CavaPane {
         let writer = TERMINAL.writer();
         let mut w = writer.lock();
 
-        let colors = Colors { background: Some(ctx.config.theme.cava.bg_color), foreground: None };
-        clear_area(w.by_ref(), colors, self.area)?;
+        clear_area(w.by_ref(), ctx.config.theme.cava.bg_color.into(), self.area)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Description

This PR refactors the various image backends. Image backends now dont need to implement separate handling inside their own dedicated thread and are thus much simpler to implement. Instead the actual image processing (resizing, transform to protocol specific output) is done on the worker thread.

As a result rmpc now need one less thread to operate and the actual image rendering now happens on the same thread as the rest of the TUI.

No user-facing change in this one.

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
