### PR TITLE
feat: album art order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `AfterCurrentAlbum` and `BeforeCurrentAlbum` to `AddOptions` keybind
+- `order` option to `album_art`, sets whether to check embedded image or cover image file first
 
 ### Changed
 
 - Moved docs to a new [repository](https://github.com/rmpc-org/rmpc-org.github.io) and [domain](https://rmpc.mierak.dev/)
+- Rmpc now checks for embedded image first and cover image in a file second by default, this can be
+configured with the new `album_art.order` option
 
 ### Fixed
 

--- a/src/config/album_art.rs
+++ b/src/config/album_art.rs
@@ -2,12 +2,14 @@ use serde::{Deserialize, Serialize};
 use strum::Display;
 
 use super::Size;
-use crate::shared::terminal::ImageBackend;
+use crate::{mpd::mpd_client::AlbumArtOrder, shared::terminal::ImageBackend};
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct AlbumArtConfigFile {
     #[serde(default)]
     pub method: ImageMethodFile,
+    #[serde(default)]
+    pub order: AlbumArtOrderFile,
     #[serde(default)]
     pub max_size_px: Size,
     #[serde(default = "super::defaults::disabled_album_art_protos")]
@@ -21,6 +23,7 @@ pub struct AlbumArtConfigFile {
 #[derive(Debug, Default, Clone)]
 pub struct AlbumArtConfig {
     pub method: ImageMethod,
+    pub order: AlbumArtOrder,
     pub max_size_px: Size,
     pub disabled_protocols: Vec<String>,
     pub vertical_align: VerticalAlign,
@@ -40,6 +43,15 @@ pub enum HorizontalAlign {
     #[default]
     Center,
     Right,
+}
+
+#[derive(Default, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub enum AlbumArtOrderFile {
+    #[default]
+    EmbeddedFirst,
+    FileFirst,
+    EmbeddedOnly,
+    FileOnly,
 }
 
 #[derive(Default, Display, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
@@ -87,6 +99,12 @@ impl From<AlbumArtConfigFile> for AlbumArtConfig {
         let size = value.max_size_px;
         AlbumArtConfig {
             method: ImageMethod::default(),
+            order: match value.order {
+                AlbumArtOrderFile::EmbeddedFirst => AlbumArtOrder::EmbeddedFirst,
+                AlbumArtOrderFile::FileFirst => AlbumArtOrder::FileFirst,
+                AlbumArtOrderFile::EmbeddedOnly => AlbumArtOrder::EmbeddedOnly,
+                AlbumArtOrderFile::FileOnly => AlbumArtOrder::FileOnly,
+            },
             max_size_px: Size {
                 width: if size.width == 0 { u16::MAX } else { size.width },
                 height: if size.height == 0 { u16::MAX } else { size.height },

--- a/src/core/command.rs
+++ b/src/core/command.rs
@@ -13,7 +13,7 @@ use crate::{
         QueuePosition,
         client::Client,
         commands::{IdleEvent, State, mpd_config::MpdConfig, volume::Bound},
-        mpd_client::{Filter, MpdClient, MpdCommand, Tag, ValueChange},
+        mpd_client::{AlbumArtOrder, Filter, MpdClient, MpdCommand, Tag, ValueChange},
         proto_client::ProtoClient,
         version::Version,
     },
@@ -378,7 +378,7 @@ impl Command {
                     std::process::exit(3);
                 };
 
-                let album_art = client.find_album_art(&song.file)?;
+                let album_art = client.find_album_art(&song.file, AlbumArtOrder::EmbeddedFirst)?;
 
                 let Some(album_art) = album_art else {
                     std::process::exit(2);

--- a/src/tests/fixtures/mpd_client.rs
+++ b/src/tests/fixtures/mpd_client.rs
@@ -30,6 +30,7 @@ use crate::mpd::{
     },
     errors::MpdError,
     mpd_client::{
+        AlbumArtOrder,
         Filter,
         MpdClient,
         SaveMode,
@@ -581,7 +582,7 @@ impl MpdClient for TestMpdClient {
         todo!("Not yet implemented")
     }
 
-    fn find_album_art(&mut self, _path: &str) -> MpdResult<Option<Vec<u8>>> {
+    fn find_album_art(&mut self, _path: &str, _order: AlbumArtOrder) -> MpdResult<Option<Vec<u8>>> {
         self.calls.entry("find_album_art".to_string()).or_default().add_assign(1);
         Ok(Some(Vec::new()))
     }

--- a/src/ui/panes/album_art.rs
+++ b/src/ui/panes/album_art.rs
@@ -41,10 +41,11 @@ impl AlbumArtPane {
         }
 
         let song_uri = song_uri.to_owned();
+        let order = ctx.config.album_art.order;
         ctx.query().id(ALBUM_ART).replace_id(ALBUM_ART).target(PaneType::AlbumArt).query(move |client| {
             let start = std::time::Instant::now();
             log::debug!(file = song_uri.as_str(); "Searching for album art");
-            let result = client.find_album_art(&song_uri)?;
+            let result = client.find_album_art(&song_uri, order)?;
             log::debug!(elapsed:? = start.elapsed(), size = result.as_ref().map(|v|v.len()); "Found album art");
 
             Ok(MpdQueryResult::AlbumArt(result))


### PR DESCRIPTION
## Description

A simple use case: have cover.jpg image file in the album's directory but be able to override the album art for one or more files in the album.

This PR introduces a new `order` config option to `album_art` which defines where to look first. This also changes the default to look for embedded data first and file second.

### Related issues

Docs PR: https://github.com/rmpc-org/rmpc-org.github.io/pull/2

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
