### PR TITLE
fix: highlight item style in queue table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ configured with the new `album_art.order` option
 - Fix directories pane not fetching data after using the `Confirm` action to enter a directory
 - Album art (sixel and iterm2) sometimes being aligned to an incorrect pane when in tmux splits
 - Album art (sixel and iterm2) not rendering after detaching and reattaching from tmux session
+- `highlighted_item_style` having unstyled spaces between columns in the queue table
 
 ## [0.10.0] - 2025-11-11
 

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -1297,7 +1297,7 @@ struct QueueRow {
 impl QueueRow {
     fn into_row<'a>(self, cells: impl Iterator<Item = Line<'a>>) -> Row<'a> {
         let mut row = if let Some(style) = self.cell_style {
-            Row::new(cells.map(|column| column.patch_style(style)))
+            Row::new(cells.map(|column| column.patch_style(style))).style(style)
         } else {
             Row::new(cells)
         };


### PR DESCRIPTION
## Description

### Related issues
fixes https://github.com/mierak/rmpc/issues/741

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
