### PR TITLE
feat: lrc indexing toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ All notable changes to this project will be documented in this file.
 - `AfterCurrentAlbum` and `BeforeCurrentAlbum` to `AddOptions` keybind
 - `order` option to `album_art`, sets whether to check embedded image or cover image file first
 - Added hot reload for lyrics and corresponding `enable_lyrics_hot_reload` config option
+- `enable_lyrics_index` to disable `lyrics_dir` indexing on startup
 
 ### Changed
 
 - Moved docs to a new [repository](https://github.com/rmpc-org/rmpc-org.github.io) and [domain](https://rmpc.mierak.dev/)
 - Rmpc now checks for embedded image first and cover image in a file second by default, this can be
 configured with the new `album_art.order` option
+- The queue table should now be more performant for a very large number of items
 
 ### Fixed
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -56,6 +56,8 @@ pub struct Config {
     pub cache_dir: Option<PathBuf>,
     pub lyrics_dir: Option<String>,
     pub lyrics_offset: LrcOffset,
+    pub enable_lyrics_index: bool,
+    pub enable_lyrics_hot_reload: bool,
     pub volume_step: u8,
     pub max_fps: u32,
     pub scrolloff: usize,
@@ -63,7 +65,6 @@ pub struct Config {
     pub keybinds: KeyConfig,
     pub enable_mouse: bool,
     pub enable_config_hot_reload: bool,
-    pub enable_lyrics_hot_reload: bool,
     pub status_update_interval_ms: Option<u64>,
     pub select_current_song_on_change: bool,
     pub center_current_song_on_change: bool,
@@ -110,6 +111,10 @@ pub struct ConfigFile {
     lyrics_dir: Option<String>,
     #[serde(default = "defaults::i64::<0>")]
     lyrics_offset_ms: i64,
+    #[serde(default = "defaults::bool::<true>")]
+    enable_lyrics_index: bool,
+    #[serde(default = "defaults::bool::<false>")]
+    enable_lyrics_hot_reload: bool,
     #[serde(default)]
     pub theme: Option<String>,
     #[serde(default = "defaults::u8::<5>")]
@@ -142,8 +147,6 @@ pub struct ConfigFile {
     enable_mouse: bool,
     #[serde(default = "defaults::bool::<true>")]
     pub enable_config_hot_reload: bool,
-    #[serde(default = "defaults::bool::<false>")]
-    pub enable_lyrics_hot_reload: bool,
     #[serde(default)]
     keybinds: KeyConfigFile,
     // Deprecated
@@ -211,6 +214,8 @@ impl Default for ConfigFile {
             cache_dir: None,
             lyrics_dir: None,
             lyrics_offset_ms: 0,
+            enable_lyrics_index: true,
+            enable_lyrics_hot_reload: false,
             image_method: None,
             select_current_song_on_change: false,
             center_current_song_on_change: false,
@@ -226,7 +231,6 @@ impl Default for ConfigFile {
             tabs: TabsFile::default(),
             enable_mouse: true,
             enable_config_hot_reload: true,
-            enable_lyrics_hot_reload: false,
             wrap_navigation: false,
             password: None,
             artists: ArtistsFile::default(),
@@ -400,6 +404,8 @@ impl ConfigFile {
                 if v.ends_with('/') { v.into_owned() } else { format!("{v}/") }
             }),
             lyrics_offset: LrcOffset::from_millis(self.lyrics_offset_ms),
+            enable_lyrics_index: self.enable_lyrics_index,
+            enable_lyrics_hot_reload: self.enable_lyrics_hot_reload,
             tabs,
             active_panes,
             address,
@@ -414,7 +420,6 @@ impl ConfigFile {
             mpd_idle_read_timeout_ms: self.mpd_idle_read_timeout_ms.map(Duration::from_millis),
             enable_mouse: self.enable_mouse,
             enable_config_hot_reload: self.enable_config_hot_reload,
-            enable_lyrics_hot_reload: self.enable_lyrics_hot_reload,
             keybinds: self.keybinds.try_into()?,
             select_current_song_on_change: self.select_current_song_on_change,
             center_current_song_on_change: self.center_current_song_on_change,

--- a/src/core/event_loop.rs
+++ b/src/core/event_loop.rs
@@ -101,6 +101,7 @@ fn main_task<B: Backend + std::io::Write>(
 
     // Listen to changes to lyrics when enabled
     let mut lyrics_watcher = if ctx.config.enable_lyrics_hot_reload
+        && ctx.config.enable_lyrics_index
         && let Some(lyrics_dir) = &ctx.config.lyrics_dir
     {
         let lyrics_dir = PathBuf::from(lyrics_dir);
@@ -165,7 +166,9 @@ fn main_task<B: Backend + std::io::Write>(
                     min_frame_duration = Duration::from_secs_f64(1f64 / max_fps);
 
                     // Update lyrics watcher as needed
-                    if ctx.config.enable_lyrics_hot_reload != lyrics_watcher.is_some() {
+                    if ctx.config.enable_lyrics_hot_reload != lyrics_watcher.is_some()
+                        && ctx.config.enable_lyrics_index
+                    {
                         // IIFE may be better expressed with try blocks when it becomes stable
                         lyrics_watcher = (|| {
                             if !ctx.config.enable_lyrics_hot_reload {

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,7 +336,9 @@ fn main() -> Result<()> {
 
             config.validate()?;
 
-            if let Some(lyrics_dir) = &config.lyrics_dir {
+            if let Some(lyrics_dir) = &config.lyrics_dir
+                && config.enable_lyrics_index
+            {
                 worker_tx
                     .send(WorkRequest::IndexLyrics { lyrics_dir: lyrics_dir.clone() })
                     .context("Failed to request lyrics indexing")?;


### PR DESCRIPTION
## Description

Allows for disabling of lyrics indexing in case you use matching by exact file path and experience performance issues.

### Related issues
fixes https://github.com/mierak/rmpc/issues/742

docs PR: https://github.com/rmpc-org/rmpc-org.github.io/pull/4

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
