### PR TITLE
fix: pop keyboard enhancement flags correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ configured with the new `album_art.order` option
 - Album art (sixel and iterm2) sometimes being aligned to an incorrect pane when in tmux splits
 - Album art (sixel and iterm2) not rendering after detaching and reattaching from tmux session
 - `highlighted_item_style` having unstyled spaces between columns in the queue table
+- rmpc not correctly removing keyboard enhancement flags
 
 ## [0.10.0] - 2025-11-11
 

--- a/src/shared/terminal/mod.rs
+++ b/src/shared/terminal/mod.rs
@@ -6,6 +6,7 @@ use crossterm::{
         DisableMouseCapture,
         EnableMouseCapture,
         KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags,
         PushKeyboardEnhancementFlags,
     },
     execute,
@@ -185,13 +186,7 @@ impl Terminal {
             execute!(writer, DisableMouseCapture)?;
         }
         if TERMINAL.kitty_keyboard_protocol {
-            execute!(
-                writer,
-                PushKeyboardEnhancementFlags(
-                    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                        | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS,
-                )
-            )?;
+            execute!(writer, PopKeyboardEnhancementFlags)?;
         }
         disable_raw_mode()?;
         execute!(writer, LeaveAlternateScreen)?;


### PR DESCRIPTION
## Description

### Related issues

https://github.com/mierak/rmpc/issues/756

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
