### PR TITLE
feat: center when double triggering JumpToCurrent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 word, ctrl+f/b to move forward/backwards etc.
 - `clear` options to keybinds, keep the default keybinds and only override the specified keybinds
 if false
+- Triggering `JumpToCurrent` twice will now center the currently playing song
 
 ### Changed
 

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -772,7 +772,13 @@ impl Pane for QueuePane {
                     if let Some((idx, _)) = ctx.status.songid.and_then(|id| {
                         self.queue.items.iter().enumerate().find(|(_, song)| song.id == id)
                     }) {
-                        self.queue.select_idx(idx, ctx.config.scrolloff);
+                        let scrolloff =
+                            if self.queue.selected_with_idx().is_some_and(|(i, _)| i == idx) {
+                                usize::MAX
+                            } else {
+                                ctx.config.scrolloff
+                            };
+                        self.queue.select_idx(idx, scrolloff);
                         ctx.render()?;
                     } else {
                         status_info!("No song is currently playing");


### PR DESCRIPTION
## Description

### Related issues
fixes https://github.com/mierak/rmpc/issues/769
docs pr: https://github.com/rmpc-org/rmpc-org.github.io/pull/7

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
