### PR TITLE
fix: unfocsusable panes unable to receive mouse evs in tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ configured with the new `album_art.order` option
 - Album art (sixel and iterm2) not rendering after detaching and reattaching from tmux session
 - `highlighted_item_style` having unstyled spaces between columns in the queue table
 - rmpc not correctly removing keyboard enhancement flags
+- Unfocusable panes being unable to receive mouse events when put inside a tab
 
 ## [0.10.0] - 2025-11-11
 


### PR DESCRIPTION
## Description

### Related issues
fixes https://github.com/mierak/rmpc/issues/770

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
