### PR TITLE
fix: recalculate tabs when theme changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ configured with the new `album_art.order` option
 - `highlighted_item_style` having unstyled spaces between columns in the queue table
 - rmpc not correctly removing keyboard enhancement flags
 - Unfocusable panes being unable to receive mouse events when put inside a tab
+- Tabs now respect changes in `components` when they change via remote ipc
 
 ## [0.10.0] - 2025-11-11
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -85,6 +85,7 @@ pub struct Config {
     pub search: Search,
     pub artists: Artists,
     pub tabs: Tabs,
+    pub original_tabs_definition: TabsFile,
     pub active_panes: Vec<PaneType>,
     pub browser_song_sort: Arc<SortOptions>,
     pub show_playlists_in_browser: ShowPlaylistsMode,
@@ -398,6 +399,7 @@ impl ConfigFile {
 
         let theme = UiConfig::try_from(theme)?;
 
+        let original_tabs_definition = self.tabs.clone();
         let tabs: Tabs = self.tabs.convert(&theme.components)?;
         let active_panes = Config::calc_active_panes(&tabs.tabs, &theme.layout);
 
@@ -415,6 +417,7 @@ impl ConfigFile {
             enable_lyrics_index: self.enable_lyrics_index,
             enable_lyrics_hot_reload: self.enable_lyrics_hot_reload,
             tabs,
+            original_tabs_definition,
             active_panes,
             address,
             password,

--- a/src/config/tabs.rs
+++ b/src/config/tabs.rs
@@ -242,7 +242,7 @@ pub enum BorderTypeFile {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub(super) struct TabsFile(Vec<TabFile>);
+pub struct TabsFile(Vec<TabFile>);
 
 #[derive(Debug, Default, Clone)]
 pub struct Tabs {

--- a/src/core/event_loop.rs
+++ b/src/core/event_loop.rs
@@ -206,6 +206,19 @@ fn main_task<B: Backend + std::io::Write>(
                         status_error!(error:? = err; "Cannot change theme, invalid config: '{err}'");
                         continue;
                     }
+
+                    config.tabs = match config
+                        .original_tabs_definition
+                        .clone()
+                        .convert(&config.theme.components)
+                    {
+                        Ok(v) => v,
+                        Err(err) => {
+                            status_error!(error:? = err; "Cannot change theme, failed to convert tabs: '{err}'");
+                            continue;
+                        }
+                    };
+
                     config.active_panes =
                         Config::calc_active_panes(&config.tabs.tabs, &config.theme.layout);
                     ctx.config = Arc::new(config);


### PR DESCRIPTION
## Description

Rmpc did not recalculate tabs and used the old version of components when the theme is changed during runtime (and theme only, not config) and the `components` changed.

### Related issues

fixes https://github.com/mierak/rmpc/issues/755

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
