### PR TITLE
feat: sort queue by keybind/mouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ if false
 - Triggering `JumpToCurrent` twice will now center the currently playing song
 - Keybinds now support sequences of keys instead of a single key chord. Existing keybinds should work
 the same.
+- Added `SortByColumn(_)` to sort the queue by the given column. Clicking the table header also sorts
+the queue by the given column.
 
 ### Changed
 

--- a/src/config/keys/mod.rs
+++ b/src/config/keys/mod.rs
@@ -186,7 +186,11 @@ impl TryFrom<KeyConfigFile> for KeyConfig {
                 search: HashMap::new(),
                 #[cfg(debug_assertions)]
                 logs: value.logs.into_iter().map(|(k, v)| (k, v.into())).collect(),
-                queue: value.queue.into_iter().map(|(k, v)| (k, v.into())).collect(),
+                queue: value
+                    .queue
+                    .into_iter()
+                    .map(|(k, v)| -> anyhow::Result<_> { Ok((k, v.try_into()?)) })
+                    .collect::<anyhow::Result<_>>()?,
             })
         } else {
             let global: HashMap<KeySequence, GlobalAction> =
@@ -196,8 +200,11 @@ impl TryFrom<KeyConfigFile> for KeyConfig {
                 .into_iter()
                 .map(|(k, v)| -> anyhow::Result<_> { Ok((k, v.try_into()?)) })
                 .collect::<anyhow::Result<_>>()?;
-            let queue: HashMap<KeySequence, QueueActions> =
-                value.queue.into_iter().map(|(k, v)| (k, v.into())).collect();
+            let queue: HashMap<KeySequence, QueueActions> = value
+                .queue
+                .into_iter()
+                .map(|(k, v)| -> anyhow::Result<_> { Ok((k, v.try_into()?)) })
+                .collect::<anyhow::Result<_>>()?;
             #[cfg(debug_assertions)]
             let logs: HashMap<KeySequence, LogsActions> =
                 value.logs.into_iter().map(|(k, v)| (k, v.into())).collect();

--- a/src/mpd/mpd_client.rs
+++ b/src/mpd/mpd_client.rs
@@ -133,6 +133,8 @@ pub trait MpdCommand {
     fn send_list_mounts(&mut self) -> MpdResult<()>;
     fn send_add(&mut self, path: &str, position: Option<QueuePosition>) -> MpdResult<()>;
     fn send_clear(&mut self) -> MpdResult<()>;
+    fn send_swap_position(&mut self, song1: usize, song2: usize) -> MpdResult<()>;
+    fn send_swap_id(&mut self, id1: u32, id2: u32) -> MpdResult<()>;
     fn send_delete_id(&mut self, id: u32) -> MpdResult<()>;
     fn send_delete_from_queue(&mut self, songs: SingleOrRange) -> MpdResult<()>;
     fn send_playlist_info(&mut self) -> MpdResult<()>;
@@ -263,6 +265,10 @@ pub trait MpdClient: Sized {
     // Current queue
     fn add(&mut self, path: &str, position: Option<QueuePosition>) -> MpdResult<()>;
     fn clear(&mut self) -> MpdResult<()>;
+    // Swaps the songs at position SONG1 and SONG2 in the current playlist. Zero
+    // based index.
+    fn swap_position(&mut self, song1: usize, song2: usize) -> MpdResult<()>;
+    fn swap_id(&mut self, id1: u32, id2: u32) -> MpdResult<()>;
     fn delete_id(&mut self, id: u32) -> MpdResult<()>;
     fn delete_from_queue(&mut self, songs: SingleOrRange) -> MpdResult<()>;
     fn playlist_info(&mut self) -> MpdResult<Option<Vec<Song>>>;
@@ -527,6 +533,14 @@ impl MpdClient for Client<'_> {
 
     fn clear(&mut self) -> MpdResult<()> {
         self.send_clear().and_then(|()| self.read_ok())
+    }
+
+    fn swap_position(&mut self, song1: usize, song2: usize) -> MpdResult<()> {
+        self.send_swap_position(song1, song2).and_then(|()| self.read_ok())
+    }
+
+    fn swap_id(&mut self, id1: u32, id2: u32) -> MpdResult<()> {
+        self.send_swap_id(id1, id2).and_then(|()| self.read_ok())
     }
 
     fn delete_id(&mut self, id: u32) -> MpdResult<()> {
@@ -1093,6 +1107,14 @@ impl<T: SocketClient> MpdCommand for T {
 
     fn send_clear(&mut self) -> MpdResult<()> {
         self.execute("clear")
+    }
+
+    fn send_swap_position(&mut self, song1: usize, song2: usize) -> MpdResult<()> {
+        self.execute(&format!("swap {song1} {song2}"))
+    }
+
+    fn send_swap_id(&mut self, id1: u32, id2: u32) -> MpdResult<()> {
+        self.execute(&format!("swapid {id1} {id2}"))
     }
 
     fn send_delete_id(&mut self, id: u32) -> MpdResult<()> {

--- a/src/tests/fixtures/mpd_client.rs
+++ b/src/tests/fixtures/mpd_client.rs
@@ -309,6 +309,14 @@ impl MpdClient for TestMpdClient {
         Ok(())
     }
 
+    fn swap_position(&mut self, _song1: usize, _song2: usize) -> MpdResult<()> {
+        todo!("Not yet implemented")
+    }
+
+    fn swap_id(&mut self, _id1: u32, _id2: u32) -> MpdResult<()> {
+        todo!("Not yet implemented")
+    }
+
     fn delete_id(&mut self, _id: u32) -> MpdResult<()> {
         todo!("Not yet implemented")
     }


### PR DESCRIPTION
## Description

introduces new keybinds as well as mouse actions to sort the queue

### Related issues

fixes: https://github.com/mierak/rmpc/issues/636
docs pr: https://github.com/rmpc-org/rmpc-org.github.io/pull/12

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
