### PR TITLE
fix: disable image backend for zellij by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ configured with the new `album_art.order` option
 - rmpc not correctly removing keyboard enhancement flags
 - Unfocusable panes being unable to receive mouse events when put inside a tab
 - Tabs now respect changes in `components` when they change via remote ipc
+- Album art will now be completely disabled when zellij is detected and image method is set to `Auto`.
+You can still force other image backend via config.
 
 ## [0.10.0] - 2025-11-11
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,6 +233,8 @@ fn main() -> Result<()> {
             println!("{:<20} {term}", "$TERM");
             println!("{:<20} {term_program}", "$TERM_PROGRAM");
             println!("{:<20} {}", "Emulator", TERMINAL.emulator());
+            println!("{:<20} {}", "Kitty Keyboard", TERMINAL.keyboard_protocol_kitty());
+            println!("{:<20} {}", "ZELLIJ", TERMINAL.zellij());
 
             println!("\nVisualizer:");
             println!("{}", CAVA.display());


### PR DESCRIPTION
## Description

Also added more stuff to debuginfo

### Related issues
fixes https://github.com/mierak/rmpc/issues/783

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
