### PR TITLE
fix: failing to add songs after ytdlp download if cache_dir inside music_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ configured with the new `album_art.order` option
 - Tabs now respect changes in `components` when they change via remote ipc
 - Album art will now be completely disabled when zellij is detected and image method is set to `Auto`.
 You can still force other image backend via config.
+- yt-dlp integration will now try to issue a database update if the downloaded file cannot be found,
+should fix cases with `cache_dir` being set inside MPD's music directory
 
 ## [0.10.0] - 2025-11-11
 

--- a/src/config/cli_config.rs
+++ b/src/config/cli_config.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use super::{Config, ConfigFile, MpdAddress, address::MpdPassword, utils::tilde_expand};
+use crate::config::utils::tilde_expand_path;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CliConfigFile {
@@ -76,7 +77,7 @@ impl CliConfigFile {
             MpdAddress::resolve(address_cli, password_cli, self.address, self.password);
 
         CliConfig {
-            cache_dir: self.cache_dir,
+            cache_dir: self.cache_dir.map(|v| tilde_expand_path(&v)),
             lyrics_dir: self.lyrics_dir.map(|v| {
                 let v = tilde_expand(&v);
                 if v.ends_with('/') { v.into_owned() } else { format!("{v}/") }

--- a/src/core/command.rs
+++ b/src/core/command.rs
@@ -278,13 +278,9 @@ impl Command {
             })),
             Command::AddYt { url, position } => {
                 let file_paths = YtDlp::init_and_download(config, &url)?;
+                let cache_dir = config.cache_dir.clone();
                 Ok(Box::new(move |client| {
-                    client.send_start_cmd_list()?;
-                    for file in file_paths {
-                        client.send_add(&file, position)?;
-                    }
-                    client.send_execute_cmd_list()?;
-                    client.read_ok()?;
+                    client.add_downloaded_files_to_queue(file_paths, cache_dir, position)?;
                     Ok(())
                 }))
             }
@@ -296,13 +292,10 @@ impl Command {
                     YtDlp::search_single(kind, query.trim())?
                 };
                 let file_paths = YtDlp::init_and_download(config, &chosen_url)?;
+                let cache_dir = config.cache_dir.clone();
+
                 Ok(Box::new(move |client| {
-                    client.send_start_cmd_list()?;
-                    for file in &file_paths {
-                        client.send_add(file, position)?;
-                    }
-                    client.send_execute_cmd_list()?;
-                    client.read_ok()?;
+                    client.add_downloaded_files_to_queue(file_paths, cache_dir, position)?;
                     Ok(())
                 }))
             }

--- a/src/mpd/errors.rs
+++ b/src/mpd/errors.rs
@@ -141,6 +141,12 @@ pub struct MpdFailureResponse {
     pub message: String,
 }
 
+impl MpdFailureResponse {
+    pub fn is_no_exist(&self) -> bool {
+        self.code == ErrorCode::NoExist
+    }
+}
+
 impl Display for MpdFailureResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/src/shared/ytdlp.rs
+++ b/src/shared/ytdlp.rs
@@ -12,7 +12,7 @@ use walkdir::WalkDir;
 
 use super::dependencies;
 use crate::{
-    config::{cli_config::CliConfig, utils::tilde_expand},
+    config::cli_config::CliConfig,
     shared::macros::{status_error, status_info, status_warn},
 };
 
@@ -276,9 +276,7 @@ impl YtDlpHost {
     }
 
     pub fn get_cached(&self, cache_dir: &Path) -> Option<PathBuf> {
-        let raw_path = cache_dir.as_str();
-        let expanded_dir = tilde_expand(raw_path.ok()?);
-        WalkDir::new(self.cache_subdir(Path::new(&expanded_dir.as_ref())))
+        WalkDir::new(self.cache_subdir(cache_dir))
             .into_iter()
             .filter_map(Result::ok)
             .filter(|e| e.file_type().is_file())
@@ -287,9 +285,7 @@ impl YtDlpHost {
     }
 
     pub fn delete_cached(&self, cache_dir: &Path) -> Result<()> {
-        let raw_path = cache_dir.as_str();
-        let expanded_dir = tilde_expand(raw_path?);
-        let files = WalkDir::new(self.cache_subdir(Path::new(&expanded_dir.as_ref())))
+        let files = WalkDir::new(self.cache_subdir(cache_dir))
             .into_iter()
             .filter_map(Result::ok)
             .filter(|e| e.file_type().is_file())


### PR DESCRIPTION
## Description

Kind of an awkward fix. If a file is successfully downloaded but MPD responds with not found error we try to issue a database update ONLY IF `cache_dir` is set inside MPD's `music_dir` because MPD will refuse to add any files inside its `music_dir` which it does not know about yet.

### Related issues

fixes https://github.com/mierak/rmpc/issues/785

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
