### PR TITLE
fix: add missing confiration when deleting playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ configured with the new `album_art.order` option
 You can still force other image backend via config.
 - yt-dlp integration will now try to issue a database update if the downloaded file cannot be found,
 should fix cases with `cache_dir` being set inside MPD's music directory
+- Added missing confirmation when deleting playlist/songs from playlist
 
 ## [0.10.0] - 2025-11-11
 


### PR DESCRIPTION
## Description

### Related issues
fixes https://github.com/mierak/rmpc/issues/789

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
