### PR TITLE
feat: QueueHeader pane and theming changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,19 @@ after starting a ytdlp download
 ### Changed
 
 - **Breaking** Keybinds now only override the defaults. Meaning your configured keybinds are combined
+- **Breaking** `show_song_table_header` has been removed. The queue header is now in a separate `QueueHeader`
+pane. You will need to update your config to include it in your tabs.
 with the default ones. Set `clear` to true to keep the old behavior.
+- **Breaking** `draw_borders` has been deprecated. The `Tabs` pane is no longer affected by this, use the
+- `Queue` pane no longer has empty space on the sides
+borders configuration on the pane itself instead. This now only affects borders in the browser panes
+and this will be romeved in the future as well.
 - Moved docs to a new [repository](https://github.com/rmpc-org/rmpc-org.github.io) and [domain](https://rmpc.mierak.dev/)
 - Rmpc now checks for embedded image first and cover image in a file second by default, this can be
 configured with the new `album_art.order` option
 - The queue table should now be more performant for a very large number of items
-- Default keybinds have been updated. This will not affect you if have properly setup config file.
+- Default keybinds have been updated. This will not affect you if have a properly setup config file.
+- Default theme has been updated. This will not affect you if have a properly setup config file.
 
 ### Fixed
 

--- a/assets/example_config.ron
+++ b/assets/example_config.ron
@@ -149,51 +149,133 @@
                 direction: Horizontal,
                 panes: [
                     (
-                        size: "40%",
+                        size: "35%",
                         pane: Split(
                             direction: Vertical,
                             panes: [
                                 (
-                                    size: "3",
-                                    pane: Pane(Lyrics)
+                                    size: "100%",
+                                    borders: "LEFT | RIGHT | TOP",
+                                    border_symbols: Rounded,
+                                    pane: Pane(AlbumArt)
                                 ),
                                 (
-                                    size: "100%",
-                                    pane: Pane(AlbumArt)
+                                    size: "6",
+                                    borders: "ALL",
+                                    border_symbols: Inherited(parent: Rounded, top_left: "├", top_right: "┤",),
+                                    border_title: [(kind: Text(" Lyrics "))],
+                                    border_title_alignment: Right,
+                                    pane: Pane(Lyrics)
                                 ),
                             ],
                         ),
                     ), 
                     (
-                        size: "60%",
-                        pane: Pane(Queue)
+                        size: "65%",
+                        pane: Split(
+                            direction: Vertical,
+                            panes: [
+                                (
+                                    size: "3",
+                                    borders: "ALL",
+                                    border_symbols: Inherited(parent: Rounded, bottom_left: "├", bottom_right: "┤",),
+                                    pane: Split(
+                                        direction: Horizontal,
+                                        panes: [
+                                            (
+                                                size: "1",
+                                                pane: Pane(Property(content: [], align: Left))
+                                            ),
+                                            (
+                                                size: "100%",
+                                                pane: Pane(QueueHeader())
+                                            ),
+                                        ]
+                                    )
+                                ),
+                                (
+                                    size: "100%",
+                                    borders: "LEFT | RIGHT | BOTTOM",
+                                    border_symbols: Rounded,
+                                    pane: Split(
+                                        direction: Horizontal,
+                                        panes: [
+                                            (
+                                                size: "1",
+                                                pane: Pane(Property(content: [], align: Left))
+                                            ),
+                                            (
+                                                size: "100%",
+                                                pane: Pane(Queue)
+                                            ),
+                                        ]
+                                    )
+                                ),
+                            ],
+                        )
                     ),
                 ],
             ),
         ),
         (
             name: "Directories",
-            pane: Pane(Directories),
+            borders: "ALL",
+            border_symbols: Rounded,
+            pane: Split(
+                size: "100%",
+                direction: Vertical,
+                panes: [(pane: Pane(Directories), size: "100%", borders: "ALL", border_symbols: Rounded)],
+            )
         ),
         (
             name: "Artists",
-            pane: Pane(Artists),
+            borders: "ALL",
+            border_symbols: Rounded,
+            pane: Split(
+                size: "100%",
+                direction: Vertical,
+                panes: [(pane: Pane(Artists), size: "100%", borders: "ALL", border_symbols: Rounded)],
+            )
         ),
         (
             name: "Album Artists",
-            pane: Pane(AlbumArtists),
+            borders: "ALL",
+            border_symbols: Rounded,
+            pane: Split(
+                size: "100%",
+                direction: Vertical,
+                panes: [(pane: Pane(AlbumArtists), size: "100%", borders: "ALL", border_symbols: Rounded)],
+            )
         ),
         (
             name: "Albums",
-            pane: Pane(Albums),
+            borders: "ALL",
+            border_symbols: Rounded,
+            pane: Split(
+                size: "100%",
+                direction: Vertical,
+                panes: [(pane: Pane(Albums), size: "100%", borders: "ALL", border_symbols: Rounded)],
+            )
         ),
         (
             name: "Playlists",
-            pane: Pane(Playlists),
+            borders: "ALL",
+            border_symbols: Rounded,
+            pane: Split(
+                size: "100%",
+                direction: Vertical,
+                panes: [(pane: Pane(Playlists), size: "100%", borders: "ALL", border_symbols: Rounded)],
+            )
         ),
         (
             name: "Search",
-            pane: Pane(Search),
+            borders: "ALL",
+            border_symbols: Rounded,
+            pane: Split(
+                size: "100%",
+                direction: Vertical,
+                panes: [(pane: Pane(Search), size: "100%", borders: "ALL", border_symbols: Rounded)],
+            )
         ),
     ],
 )

--- a/assets/example_theme.ron
+++ b/assets/example_theme.ron
@@ -3,8 +3,6 @@
 #![enable(unwrap_variant_newtypes)]
 (
     default_album_art_path: None,
-    show_song_table_header: true,
-    draw_borders: true,
     format_tag_separator: " | ",
     browser_column_widths: [20, 38, 42],
     background_color: None,
@@ -14,10 +12,6 @@
     modal_backdrop: false,
     preview_label_style: (fg: "yellow"),
     preview_metadata_group_style: (fg: "yellow", modifiers: "Bold"),
-    tab_bar: (
-        active_style: (fg: "black", bg: "blue", modifiers: "Bold"),
-        inactive_style: (),
-    ),
     highlighted_item_style: (fg: "blue", modifiers: "Bold"),
     current_item_style: (fg: "black", bg: "blue", modifiers: "Bold"),
     borders_style: (fg: "blue"),
@@ -40,10 +34,10 @@
         trace: (fg: "magenta", bg: "black"),
     ),
     progress_bar: (
-        symbols: ["[", "-", ">", " ", "]"],
+        symbols: ["[", "━", "➤", " ", "]"],
         track_style: (fg: "#1e2030"),
         elapsed_style: (fg: "blue"),
-        thumb_style: (fg: "blue", bg: "#1e2030"),
+        thumb_style: (fg: "blue"),
         use_track_when_empty: false,
     ),
     scrollbar: (
@@ -52,102 +46,12 @@
         ends_style: (),
         thumb_style: (fg: "blue"),
     ),
-    song_table_format: [
-        (
-            prop: (kind: Property(Artist),
-                default: (kind: Text("Unknown"))
-            ),
-            width: "20%",
-        ),
-        (
-            prop: (kind: Property(Title),
-                default: (kind: Text("Unknown"))
-            ),
-            width: "35%",
-        ),
-        (
-            prop: (kind: Property(Album), style: (fg: "white"),
-                default: (kind: Text("Unknown Album"), style: (fg: "white"))
-            ),
-            width: "30%",
-        ),
-        (
-            prop: (kind: Property(Duration),
-                default: (kind: Text("-"))
-            ),
-            width: "15%",
-            alignment: Right,
-        ),
-    ],
-    components: {},
-    layout: Split(
-        direction: Vertical,
-        panes: [
-            (
-                pane: Pane(Header),
-                size: "2",
-            ),
-            (
-                pane: Pane(Tabs),
-                size: "3",
-            ),
-            (
-                pane: Pane(TabContent),
-                size: "100%",
-            ),
-            (
-                pane: Pane(ProgressBar),
-                size: "1",
-            ),
-        ],
+    tab_bar: (
+        active_style: (fg: "black", bg: "blue", modifiers: "Bold"),
+        inactive_style: (),
     ),
-    header: (
-        rows: [
-            (
-                left: [
-                    (kind: Text("["), style: (fg: "yellow", modifiers: "Bold")),
-                    (kind: Property(Status(StateV2(playing_label: "Playing", paused_label: "Paused", stopped_label: "Stopped"))), style: (fg: "yellow", modifiers: "Bold")),
-                    (kind: Text("]"), style: (fg: "yellow", modifiers: "Bold"))
-                ],
-                center: [
-                    (kind: Property(Song(Title)), style: (modifiers: "Bold"),
-                        default: (kind: Text("No Song"), style: (modifiers: "Bold"))
-                    )
-                ],
-                right: [
-                    (kind: Property(Widget(ScanStatus)), style: (fg: "blue")),
-                    (kind: Property(Widget(Volume)), style: (fg: "blue"))
-                ]
-            ),
-            (
-                left: [
-                    (kind: Property(Status(Elapsed))),
-                    (kind: Text(" / ")),
-                    (kind: Property(Status(Duration))),
-                    (kind: Text(" (")),
-                    (kind: Property(Status(Bitrate))),
-                    (kind: Text(" kbps)"))
-                ],
-                center: [
-                    (kind: Property(Song(Artist)), style: (fg: "yellow", modifiers: "Bold"),
-                        default: (kind: Text("Unknown"), style: (fg: "yellow", modifiers: "Bold"))
-                    ),
-                    (kind: Text(" - ")),
-                    (kind: Property(Song(Album)),
-                        default: (kind: Text("Unknown Album"))
-                    )
-                ],
-                right: [
-                    (
-                        kind: Property(Widget(States(
-                            active_style: (fg: "white", modifiers: "Bold"),
-                            separator_style: (fg: "white")))
-                        ),
-                        style: (fg: "dark_gray")
-                    ),
-                ]
-            ),
-        ],
+    lyrics: (
+        timestamp: false
     ),
     browser_song_format: [
         (
@@ -165,7 +69,184 @@
             default: (kind: Property(Filename))
         ),
     ],
-    lyrics: (
-        timestamp: false
-    )
+    song_table_format: [
+        (
+            prop: (kind: Property(Artist),
+                default: (kind: Text("Unknown"))
+            ),
+            label_prop: (kind: Text("Artist")),
+            width: "20%",
+        ),
+        (
+            prop: (kind: Property(Title),
+                default: (kind: Text("Unknown"))
+            ),
+            label_prop: (kind: Text("Title")),
+            width: "35%",
+        ),
+        (
+            prop: (kind: Property(Album), style: (fg: "white"),
+                default: (kind: Text("Unknown Album"), style: (fg: "white"))
+            ),
+            label_prop: (kind: Text("Album")),
+            width: "30%",
+        ),
+        (
+            prop: (kind: Property(Duration),
+                default: (kind: Text("-"))
+            ),
+            label_prop: (kind: Text("Duration")),
+            width: "15%",
+            alignment: Right,
+        ),
+    ],
+    layout: Split(
+        direction: Vertical,
+        panes: [
+            (
+                size: "4",
+                pane: Split(
+                    direction: Horizontal,
+                    panes: [
+                        (
+                            size: "35",
+                            borders: "LEFT | TOP | BOTTOM",
+                            border_symbols: Inherited(parent: Rounded, bottom_left: "├"),
+                            pane: Component("header_left")
+                        ),
+                        (
+                            size: "100%",
+                            borders: "ALL",
+                            border_symbols: Inherited(parent: Rounded, top_left: "┬", top_right: "┬", bottom_left: "┴", bottom_right: "┴"),
+                            pane: Component("header_center")
+                        ),
+                        (
+                            size: "35",
+                            borders: "RIGHT | TOP | BOTTOM",
+                            border_symbols: Inherited(parent: Rounded, bottom_right: "┤"),
+                            pane: Component("header_right")
+                        ),
+                    ]
+                )
+            ),
+            (
+                pane: Pane(Tabs),
+                borders: "RIGHT | LEFT | BOTTOM",
+                border_symbols: Rounded,
+                size: "2",
+            ),
+            (
+                pane: Pane(TabContent),
+                size: "100%",
+            ),
+            (
+                pane: Pane(ProgressBar),
+                borders: "ALL",
+                border_symbols: Rounded,
+                border_title_alignment: Right,
+                border_title: [(kind: Text(" ")), (kind: Property(Status(QueueLength()))), (kind: Text(" songs / ")), (kind: Property(Status(QueueTimeTotal()))), (kind: Text(" total time "))],
+                size: "3",
+            ),
+        ],
+    ),
+    components: {
+        "state": Pane(Property(
+            content: [
+                (kind: Text("["), style: (fg: "yellow", modifiers: "Bold")),
+                (kind: Property(Status(StateV2( ))), style: (fg: "yellow", modifiers: "Bold")),
+                (kind: Text("]"), style: (fg: "yellow", modifiers: "Bold")),
+            ], align: Left,
+        )),
+        "title": Pane(Property(
+            content: [
+                (kind: Property(Song(Title)), style: (modifiers: "Bold"),
+                    default: (kind: Text("No Song"), style: (modifiers: "Bold"))),
+            ], align: Center, scroll_speed: 1
+        )),
+        "volume": Split(
+            direction: Horizontal,
+            panes: [
+                (size: "1", pane: Pane(Property(content: [(kind: Text(""))]))),
+                (size: "100%", pane: Pane(Volume(kind: Slider(symbols: (filled: "─", thumb: "●", track: "─"))))),
+                (size: "3", pane: Pane(Property(content: [(kind: Property(Status(Volume)), style: (fg: "blue"))], align: Right))),
+                (size: "2", pane: Pane(Property(content: [(kind: Text("%"), style: (fg: "blue"))]))),
+            ]
+        ),
+        "elapsed_and_bitrate": Pane(Property(
+            content: [
+                (kind: Property(Status(Elapsed))), 
+                (kind: Text(" / ")), 
+                (kind: Property(Status(Duration))), 
+                (kind: Group([
+                    (kind: Text(" (")), 
+                    (kind: Property(Status(Bitrate))), 
+                    (kind: Text(" kbps)")),
+                ])),
+            ],
+            align: Left,
+        )),
+        "artist_and_album": Pane(Property(
+            content: [
+                (kind: Property(Song(Artist)), style: (fg: "yellow", modifiers: "Bold"),
+                    default: (kind: Text("Unknown"), style: (fg: "yellow", modifiers: "Bold"))),
+                (kind: Text(" - ")),
+                (kind: Property(Song(Album)), default: (kind: Text("Unknown Album"))),
+            ], align: Center, scroll_speed: 1
+        )),
+        "states": Pane(Property(
+            content: [
+                (kind: Text("["), style: (fg: "blue", modifiers: "Bold")),
+                (kind: Property(Status(RepeatV2(
+                    on_label: "z",
+                    off_label: "z",
+                    on_style: (fg: "yellow", modifiers: "Bold"),
+                    off_style: (fg: "blue", modifiers: "Dim"),
+                )))),
+                (kind: Property(Status(RandomV2(
+                    on_label: "x",
+                    off_label: "x",
+                    on_style: (fg: "yellow", modifiers: "Bold"),
+                    off_style: (fg: "blue", modifiers: "Dim"),
+                )))),
+                (kind: Property(Status(ConsumeV2(
+                    on_label: "c",
+                    off_label: "c",
+                    oneshot_label: "c",
+                    on_style: (fg: "yellow", modifiers: "Bold"),
+                    off_style: (fg: "blue", modifiers: "Dim"),
+                    oneshot_style: (fg: "red", modifiers: "Dim"),
+                )))),
+                (kind: Property(Status(SingleV2(
+                    on_label: "v",
+                    off_label: "v",
+                    oneshot_label: "v",
+                    on_style: (fg: "yellow", modifiers: "Bold"),
+                    off_style: (fg: "blue", modifiers: "Dim"),
+                    oneshot_style: (fg: "red", modifiers: "Bold"),
+                )))),
+                (kind: Text("]"), style: (fg: "blue", modifiers: "Bold")),
+            ], align: Right
+        )),
+        "header_left": Split(
+            direction: Vertical,
+            panes: [
+                (size: "1", pane: Component("state")),
+                (size: "1", pane: Component("elapsed_and_bitrate")),
+            ]
+        ),
+        "header_center": Split(
+            direction: Vertical,
+            panes: [
+                (size: "1", pane: Component("title")),
+                (size: "1", pane: Component("artist_and_album")),
+            ]
+        ),
+        "header_right": Split(
+            direction: Vertical,
+            panes: [
+                (size: "1", pane: Component("volume")),
+                (size: "1", pane: Component("states")),
+            ]
+        ),
+    },
 )

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -1,7 +1,31 @@
 #![allow(dead_code)]
 #![allow(clippy::unnecessary_wraps)]
 
+use std::collections::HashMap;
+
 use super::theme::{Modifiers, ScrollbarConfigFile, StyleFile, properties::SongPropertyFile};
+use crate::config::{
+    tabs::{
+        BorderTitlePosition,
+        BordersFile,
+        DirectionFile,
+        PaneOrSplitFile,
+        PaneTypeFile,
+        SubPaneFile,
+        VolumeTypeFile,
+    },
+    theme::{
+        borders::BorderSymbolsFile,
+        properties::{
+            Alignment,
+            PropertyFile,
+            PropertyKindFile,
+            PropertyKindFileOrText,
+            StatusPropertyFile,
+        },
+        volume_slider::VolumeSliderConfigFile,
+    },
+};
 pub fn default_column_widths() -> Vec<u16> {
     vec![20, 38, 42]
 }
@@ -161,4 +185,451 @@ pub fn default_status_bar_background_color() -> StyleFile {
 
 pub fn rating_options() -> Vec<i32> {
     vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+}
+
+pub fn components() -> HashMap<String, PaneOrSplitFile> {
+    HashMap::from([
+        (
+            "state".to_string(),
+            PaneOrSplitFile::Pane(PaneTypeFile::Property {
+                align: Alignment::Left,
+                scroll_speed: 0,
+                content: vec![
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Text("[".to_string()),
+                        style: Some(StyleFile {
+                            fg: Some("yellow".to_string()),
+                            bg: None,
+                            modifiers: Some(Modifiers::Bold),
+                        }),
+                        default: None,
+                    },
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Property(PropertyKindFile::Status(
+                            StatusPropertyFile::StateV2 {
+                                playing_label: default_playing_label(),
+                                paused_label: default_paused_label(),
+                                stopped_label: default_stopped_label(),
+                                playing_style: None,
+                                paused_style: None,
+                                stopped_style: None,
+                            },
+                        )),
+                        style: Some(StyleFile {
+                            fg: Some("yellow".to_string()),
+                            bg: None,
+                            modifiers: Some(Modifiers::Bold),
+                        }),
+                        default: None,
+                    },
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Text("]".to_string()),
+                        style: Some(StyleFile {
+                            fg: Some("yellow".to_string()),
+                            bg: None,
+                            modifiers: Some(Modifiers::Bold),
+                        }),
+                        default: None,
+                    },
+                ],
+            }),
+        ),
+        (
+            "elapsed_and_bitrate".to_string(),
+            PaneOrSplitFile::Pane(PaneTypeFile::Property {
+                align: Alignment::Left,
+                scroll_speed: 0,
+                content: vec![
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Property(PropertyKindFile::Status(
+                            StatusPropertyFile::Elapsed,
+                        )),
+                        style: None,
+                        default: None,
+                    },
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Text(" / ".to_string()),
+                        style: None,
+                        default: None,
+                    },
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Property(PropertyKindFile::Status(
+                            StatusPropertyFile::Duration,
+                        )),
+                        style: None,
+                        default: None,
+                    },
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Group(vec![
+                            PropertyFile {
+                                kind: PropertyKindFileOrText::Text(" (".to_string()),
+                                style: None,
+                                default: None,
+                            },
+                            PropertyFile {
+                                kind: PropertyKindFileOrText::Property(PropertyKindFile::Status(
+                                    StatusPropertyFile::Bitrate,
+                                )),
+                                style: None,
+                                default: None,
+                            },
+                            PropertyFile {
+                                kind: PropertyKindFileOrText::Text(" kbps)".to_string()),
+                                style: None,
+                                default: None,
+                            },
+                        ]),
+                        style: None,
+                        default: None,
+                    },
+                ],
+            }),
+        ),
+        (
+            "title".to_string(),
+            PaneOrSplitFile::Pane(PaneTypeFile::Property {
+                align: Alignment::Center,
+                scroll_speed: 1,
+                content: vec![PropertyFile {
+                    kind: PropertyKindFileOrText::Property(PropertyKindFile::Song(
+                        SongPropertyFile::Title,
+                    )),
+                    style: Some(StyleFile { fg: None, bg: None, modifiers: Some(Modifiers::Bold) }),
+                    default: Some(Box::new(PropertyFile {
+                        kind: PropertyKindFileOrText::Text("No Song".to_string()),
+                        style: Some(StyleFile {
+                            fg: None,
+                            bg: None,
+                            modifiers: Some(Modifiers::Bold),
+                        }),
+                        default: None,
+                    })),
+                }],
+            }),
+        ),
+        (
+            "artist_and_album".to_string(),
+            PaneOrSplitFile::Pane(PaneTypeFile::Property {
+                align: Alignment::Center,
+                scroll_speed: 1,
+                content: vec![
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Property(PropertyKindFile::Song(
+                            SongPropertyFile::Artist,
+                        )),
+                        style: Some(StyleFile {
+                            fg: Some("yellow".to_string()),
+                            bg: None,
+                            modifiers: Some(Modifiers::Bold),
+                        }),
+                        default: Some(Box::new(PropertyFile {
+                            kind: PropertyKindFileOrText::Text("Unknown".to_string()),
+                            style: Some(StyleFile {
+                                fg: Some("yellow".to_string()),
+                                bg: None,
+                                modifiers: Some(Modifiers::Bold),
+                            }),
+                            default: None,
+                        })),
+                    },
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Text(" - ".to_string()),
+                        style: None,
+                        default: None,
+                    },
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Property(PropertyKindFile::Song(
+                            SongPropertyFile::Album,
+                        )),
+                        style: None,
+                        default: Some(Box::new(PropertyFile {
+                            kind: PropertyKindFileOrText::Text("Unknown Album".to_string()),
+                            style: None,
+                            default: None,
+                        })),
+                    },
+                ],
+            }),
+        ),
+        ("volume".to_string(), PaneOrSplitFile::Split {
+            direction: DirectionFile::Horizontal,
+            borders: BordersFile::NONE,
+            panes: vec![
+                SubPaneFile {
+                    size: "1".to_string(),
+                    borders: BordersFile::NONE,
+                    border_title: Vec::new(),
+                    border_title_position: BorderTitlePosition::Top,
+                    border_title_alignment: Alignment::Left,
+                    border_symbols: BorderSymbolsFile::default(),
+                    pane: PaneOrSplitFile::Pane(PaneTypeFile::Property {
+                        align: Alignment::Left,
+                        scroll_speed: 0,
+                        content: vec![PropertyFile {
+                            kind: PropertyKindFileOrText::Text(String::new()),
+                            style: None,
+                            default: None,
+                        }],
+                    }),
+                },
+                SubPaneFile {
+                    size: "100%".to_string(),
+                    borders: BordersFile::NONE,
+                    border_title: Vec::new(),
+                    border_title_position: BorderTitlePosition::Top,
+                    border_title_alignment: Alignment::Left,
+                    border_symbols: BorderSymbolsFile::default(),
+                    pane: PaneOrSplitFile::Pane(PaneTypeFile::Volume {
+                        kind: VolumeTypeFile::Slider(VolumeSliderConfigFile {
+                            symbols: crate::config::theme::volume_slider::Symbols {
+                                start: None,
+                                filled: "─".to_string(),
+                                thumb: "●".to_string(),
+                                track: "─".to_string(),
+                                end: None,
+                            },
+                            track_style: None,
+                            filled_style: None,
+                            thumb_style: None,
+                        }),
+                    }),
+                },
+                SubPaneFile {
+                    size: "3".to_string(),
+                    borders: BordersFile::NONE,
+                    border_title: Vec::new(),
+                    border_title_position: BorderTitlePosition::Top,
+                    border_title_alignment: Alignment::Left,
+                    border_symbols: BorderSymbolsFile::default(),
+                    pane: PaneOrSplitFile::Pane(PaneTypeFile::Property {
+                        align: Alignment::Right,
+                        scroll_speed: 0,
+                        content: vec![PropertyFile {
+                            kind: PropertyKindFileOrText::Property(PropertyKindFile::Status(
+                                StatusPropertyFile::Volume,
+                            )),
+                            style: Some(StyleFile {
+                                fg: Some("blue".to_string()),
+                                bg: None,
+                                modifiers: None,
+                            }),
+                            default: None,
+                        }],
+                    }),
+                },
+                SubPaneFile {
+                    size: "2".to_string(),
+                    borders: BordersFile::NONE,
+                    border_title: Vec::new(),
+                    border_title_position: BorderTitlePosition::Top,
+                    border_title_alignment: Alignment::Left,
+                    border_symbols: BorderSymbolsFile::default(),
+                    pane: PaneOrSplitFile::Pane(PaneTypeFile::Property {
+                        align: Alignment::Left,
+                        scroll_speed: 0,
+                        content: vec![PropertyFile {
+                            kind: PropertyKindFileOrText::Text("%".to_string()),
+                            style: Some(StyleFile {
+                                fg: Some("blue".to_string()),
+                                bg: None,
+                                modifiers: None,
+                            }),
+                            default: None,
+                        }],
+                    }),
+                },
+            ],
+        }),
+        (
+            "states".to_string(),
+            PaneOrSplitFile::Pane(PaneTypeFile::Property {
+                align: Alignment::Right,
+                scroll_speed: 0,
+                content: vec![
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Text("[".to_string()),
+                        style: Some(StyleFile {
+                            fg: Some("blue".to_string()),
+                            bg: None,
+                            modifiers: Some(Modifiers::Bold),
+                        }),
+                        default: None,
+                    },
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Property(PropertyKindFile::Status(
+                            StatusPropertyFile::RepeatV2 {
+                                on_label: "z".to_string(),
+                                off_label: "z".to_string(),
+                                on_style: Some(StyleFile {
+                                    fg: Some("yellow".to_string()),
+                                    bg: None,
+                                    modifiers: Some(Modifiers::Bold),
+                                }),
+                                off_style: Some(StyleFile {
+                                    fg: Some("blue".to_string()),
+                                    bg: None,
+                                    modifiers: Some(Modifiers::Dim),
+                                }),
+                            },
+                        )),
+                        style: None,
+                        default: None,
+                    },
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Property(PropertyKindFile::Status(
+                            StatusPropertyFile::RandomV2 {
+                                on_label: "x".to_string(),
+                                off_label: "x".to_string(),
+                                on_style: Some(StyleFile {
+                                    fg: Some("yellow".to_string()),
+                                    bg: None,
+                                    modifiers: Some(Modifiers::Bold),
+                                }),
+                                off_style: Some(StyleFile {
+                                    fg: Some("blue".to_string()),
+                                    bg: None,
+                                    modifiers: Some(Modifiers::Dim),
+                                }),
+                            },
+                        )),
+                        style: None,
+                        default: None,
+                    },
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Property(PropertyKindFile::Status(
+                            StatusPropertyFile::ConsumeV2 {
+                                on_label: "c".to_string(),
+                                off_label: "c".to_string(),
+                                oneshot_label: "c".to_string(),
+                                on_style: Some(StyleFile {
+                                    fg: Some("yellow".to_string()),
+                                    bg: None,
+                                    modifiers: Some(Modifiers::Bold),
+                                }),
+                                off_style: Some(StyleFile {
+                                    fg: Some("blue".to_string()),
+                                    bg: None,
+                                    modifiers: Some(Modifiers::Dim),
+                                }),
+                                oneshot_style: Some(StyleFile {
+                                    fg: Some("red".to_string()),
+                                    bg: None,
+                                    modifiers: Some(Modifiers::Dim),
+                                }),
+                            },
+                        )),
+                        style: None,
+                        default: None,
+                    },
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Property(PropertyKindFile::Status(
+                            StatusPropertyFile::SingleV2 {
+                                on_label: "v".to_string(),
+                                off_label: "v".to_string(),
+                                oneshot_label: "v".to_string(),
+                                on_style: Some(StyleFile {
+                                    fg: Some("yellow".to_string()),
+                                    bg: None,
+                                    modifiers: Some(Modifiers::Bold),
+                                }),
+                                off_style: Some(StyleFile {
+                                    fg: Some("blue".to_string()),
+                                    bg: None,
+                                    modifiers: Some(Modifiers::Dim),
+                                }),
+                                oneshot_style: Some(StyleFile {
+                                    fg: Some("red".to_string()),
+                                    bg: None,
+                                    modifiers: Some(Modifiers::Bold),
+                                }),
+                            },
+                        )),
+                        style: None,
+                        default: None,
+                    },
+                    PropertyFile {
+                        kind: PropertyKindFileOrText::Text("]".to_string()),
+                        style: Some(StyleFile {
+                            fg: Some("blue".to_string()),
+                            bg: None,
+                            modifiers: Some(Modifiers::Bold),
+                        }),
+                        default: None,
+                    },
+                ],
+            }),
+        ),
+        ("header_left".to_string(), PaneOrSplitFile::Split {
+            direction: DirectionFile::Vertical,
+            borders: BordersFile::NONE,
+            panes: vec![
+                SubPaneFile {
+                    size: "1".to_string(),
+                    borders: BordersFile::NONE,
+                    border_title: Vec::new(),
+                    border_title_position: BorderTitlePosition::Top,
+                    border_title_alignment: Alignment::Left,
+                    border_symbols: BorderSymbolsFile::default(),
+                    pane: PaneOrSplitFile::Component("state".to_string()),
+                },
+                SubPaneFile {
+                    size: "1".to_string(),
+                    borders: BordersFile::NONE,
+                    border_title: Vec::new(),
+                    border_title_position: BorderTitlePosition::Top,
+                    border_title_alignment: Alignment::Left,
+                    border_symbols: BorderSymbolsFile::default(),
+                    pane: PaneOrSplitFile::Component("elapsed_and_bitrate".to_string()),
+                },
+            ],
+        }),
+        ("header_center".to_string(), PaneOrSplitFile::Split {
+            direction: DirectionFile::Vertical,
+            borders: BordersFile::NONE,
+            panes: vec![
+                SubPaneFile {
+                    size: "1".to_string(),
+                    borders: BordersFile::NONE,
+                    border_title: Vec::new(),
+                    border_title_position: BorderTitlePosition::Top,
+                    border_title_alignment: Alignment::Left,
+                    border_symbols: BorderSymbolsFile::default(),
+                    pane: PaneOrSplitFile::Component("title".to_string()),
+                },
+                SubPaneFile {
+                    size: "1".to_string(),
+                    borders: BordersFile::NONE,
+                    border_title: Vec::new(),
+                    border_title_position: BorderTitlePosition::Top,
+                    border_title_alignment: Alignment::Left,
+                    border_symbols: BorderSymbolsFile::default(),
+                    pane: PaneOrSplitFile::Component("artist_and_album".to_string()),
+                },
+            ],
+        }),
+        ("header_right".to_string(), PaneOrSplitFile::Split {
+            direction: DirectionFile::Vertical,
+            borders: BordersFile::NONE,
+            panes: vec![
+                SubPaneFile {
+                    size: "1".to_string(),
+                    borders: BordersFile::NONE,
+                    border_title: Vec::new(),
+                    border_title_position: BorderTitlePosition::Top,
+                    border_title_alignment: Alignment::Left,
+                    border_symbols: BorderSymbolsFile::default(),
+                    pane: PaneOrSplitFile::Component("volume".to_string()),
+                },
+                SubPaneFile {
+                    size: "1".to_string(),
+                    borders: BordersFile::NONE,
+                    border_title: Vec::new(),
+                    border_title_position: BorderTitlePosition::Top,
+                    border_title_alignment: Alignment::Left,
+                    border_symbols: BorderSymbolsFile::default(),
+                    pane: PaneOrSplitFile::Component("states".to_string()),
+                },
+            ],
+        }),
+    ])
 }

--- a/src/config/theme/borders.rs
+++ b/src/config/theme/borders.rs
@@ -66,23 +66,23 @@ impl<'a> From<&'a BorderSet> for Set<'a> {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BorderSetInherited {
-    parent: Box<BorderSymbolsFile>,
+    pub parent: Box<BorderSymbolsFile>,
     #[serde(default)]
-    top_left: Option<String>,
+    pub top_left: Option<String>,
     #[serde(default)]
-    top_right: Option<String>,
+    pub top_right: Option<String>,
     #[serde(default)]
-    bottom_left: Option<String>,
+    pub bottom_left: Option<String>,
     #[serde(default)]
-    bottom_right: Option<String>,
+    pub bottom_right: Option<String>,
     #[serde(default)]
-    vertical_left: Option<String>,
+    pub vertical_left: Option<String>,
     #[serde(default)]
-    vertical_right: Option<String>,
+    pub vertical_right: Option<String>,
     #[serde(default)]
-    horizontal_top: Option<String>,
+    pub horizontal_top: Option<String>,
     #[serde(default)]
-    horizontal_bottom: Option<String>,
+    pub horizontal_bottom: Option<String>,
 }
 
 impl BorderSetInherited {

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -67,7 +67,6 @@ pub struct UiConfig {
     pub progress_bar: ProgressBarConfig,
     pub tab_bar: TabBar,
     pub scrollbar: Option<ScrollbarConfig>,
-    pub show_song_table_header: bool,
     pub song_table_format: Vec<SongTableColumn>,
     pub song_table_album_separator: AlbumSeparator,
     pub header: HeaderConfig,
@@ -102,6 +101,7 @@ pub struct UiConfigFile {
     pub(super) preview_label_style: StyleFile,
     #[serde(default = "defaults::default_preview_metaga_group_heading_style")]
     pub(super) preview_metadata_group_style: StyleFile,
+    #[deprecated]
     pub(super) header_background_color: Option<String>,
     pub(super) modal_background_color: Option<String>,
     #[serde(default)]
@@ -110,15 +110,18 @@ pub struct UiConfigFile {
     pub(super) highlighted_item_style: Option<StyleFile>,
     pub(super) current_item_style: Option<StyleFile>,
     pub(super) highlight_border_style: Option<StyleFile>,
+    #[deprecated]
+    #[serde(default)]
     pub(super) show_song_table_header: bool,
     pub(super) song_table_format: QueueTableColumnsFile,
     #[serde(default)]
     pub(super) song_table_album_separator: AlbumSeparator,
+    #[serde(default)]
     pub(super) header: HeaderConfigFile,
     pub(super) default_album_art_path: Option<String>,
     #[serde(default)]
     pub(super) layout: PaneOrSplitFile,
-    #[serde(default)]
+    #[serde(default = "defaults::components")]
     pub(super) components: HashMap<String, PaneOrSplitFile>,
     #[serde(default = "defaults::default_tag_separator")]
     pub(super) format_tag_separator: String,
@@ -143,7 +146,7 @@ impl Default for UiConfigFile {
             background_color: None,
             text_color: None,
             header_background_color: None,
-            show_song_table_header: true,
+            show_song_table_header: false,
             header: HeaderConfigFile::default(),
             modal_background_color: None,
             modal_backdrop: false,
@@ -205,7 +208,7 @@ impl Default for UiConfigFile {
                 modifiers: Some(Modifiers::Bold),
             },
             level_styles: LevelStylesFile::default(),
-            components: HashMap::default(),
+            components: defaults::components(),
             lyrics: LyricsConfigFile::default(),
             cava: CavaThemeFile::default(),
             border_symbol_sets: BorderSetLibFile::default(),
@@ -395,7 +398,6 @@ impl TryFrom<UiConfigFile> for UiConfig {
                 .highlight_border_style
                 .to_config_or(Some(Color::Blue), None)?,
             symbols: value.symbols.into(),
-            show_song_table_header: value.show_song_table_header,
             scrollbar: value.scrollbar.map(|sc| sc.into_config(fallback_border_fg)).transpose()?,
             progress_bar: value.progress_bar.into_config()?,
             song_table_format: TryInto::<QueueTableColumns>::try_into(value.song_table_format)?.0,

--- a/src/config/theme/progress_bar.rs
+++ b/src/config/theme/progress_bar.rs
@@ -40,11 +40,11 @@ impl Default for ProgressBarConfigFile {
     fn default() -> Self {
         Self {
             symbols: vec![
-                "[".to_owned(),
-                "-".to_owned(),
-                ">".to_owned(),
-                " ".to_owned(),
-                "]".to_owned(),
+                "[".to_string(),
+                "━".to_string(),
+                "➤".to_string(),
+                " ".to_string(),
+                "]".to_string(),
             ],
             elapsed_style: Some(StyleFile {
                 fg: Some("blue".to_string()),
@@ -53,7 +53,7 @@ impl Default for ProgressBarConfigFile {
             }),
             thumb_style: Some(StyleFile {
                 fg: Some("blue".to_string()),
-                bg: Some("#1e2030".to_string()),
+                bg: None,
                 modifiers: None,
             }),
             track_style: Some(StyleFile {

--- a/src/config/theme/properties.rs
+++ b/src/config/theme/properties.rs
@@ -595,7 +595,7 @@ impl TryFrom<SongFormatFile> for SongFormat {
     type Error = anyhow::Error;
 
     fn try_from(value: SongFormatFile) -> Result<Self, Self::Error> {
-        let properties: Vec<_> = value.0.into_iter().map(|v| v.try_into()).try_collect()?;
+        let properties: Vec<_> = value.0.into_iter().map(|v| v.convert()).try_collect()?;
         Ok(SongFormat(properties))
     }
 }

--- a/src/config/theme/volume_slider.rs
+++ b/src/config/theme/volume_slider.rs
@@ -27,10 +27,10 @@ pub struct VolumeSliderConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct VolumeSliderConfigFile {
     #[serde(default)]
-    pub(super) symbols: Symbols,
-    pub(super) track_style: Option<StyleFile>,
-    pub(super) filled_style: Option<StyleFile>,
-    pub(super) thumb_style: Option<StyleFile>,
+    pub symbols: Symbols,
+    pub track_style: Option<StyleFile>,
+    pub filled_style: Option<StyleFile>,
+    pub thumb_style: Option<StyleFile>,
 }
 #[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Symbols {

--- a/src/shared/ext.rs
+++ b/src/shared/ext.rs
@@ -529,6 +529,7 @@ pub mod btreeset_ranges {
 pub mod rect {
     use ratatui::layout::Rect;
 
+    #[allow(unused)]
     pub trait RectExt {
         fn shrink_from_top(self, amount: u16) -> Rect;
         fn shrink_horizontally(self, amount: u16) -> Rect;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,8 +16,7 @@ use ratatui::{
     Frame,
     layout::Rect,
     style::{Color, Style},
-    symbols::border,
-    widgets::{Block, Borders},
+    widgets::Block,
 };
 use tab_screen::TabScreen;
 
@@ -911,6 +910,7 @@ impl<'ui> Ui<'ui> {
                 #[cfg(debug_assertions)]
                 Panes::Logs(p) => p.on_event(&mut event, visible, ctx),
                 Panes::Queue(p) => p.on_event(&mut event, visible, ctx),
+                Panes::QueueHeader(p) => p.on_event(&mut event, visible, ctx),
                 Panes::Directories(p) => p.on_event(&mut event, visible, ctx),
                 Panes::Albums(p) => p.on_event(&mut event, visible, ctx),
                 Panes::Artists(p) => p.on_event(&mut event, visible, ctx),
@@ -956,6 +956,7 @@ impl<'ui> Ui<'ui> {
                     #[cfg(debug_assertions)]
                     Panes::Logs(p) => p.on_query_finished(id, data, visible, ctx),
                     Panes::Queue(p) => p.on_query_finished(id, data, visible, ctx),
+                    Panes::QueueHeader(p) => p.on_query_finished(id, data, visible, ctx),
                     Panes::Directories(p) => p.on_query_finished(id, data, visible, ctx),
                     Panes::Albums(p) => p.on_query_finished(id, data, visible, ctx),
                     Panes::Artists(p) => p.on_query_finished(id, data, visible, ctx),
@@ -1104,24 +1105,6 @@ impl Config {
             })
             .unwrap_or(current_screen)
             .clone()
-    }
-
-    fn as_header_table_block(&self) -> ratatui::widgets::Block<'_> {
-        if !self.theme.draw_borders {
-            return ratatui::widgets::Block::default();
-        }
-        Block::default().border_style(self.as_border_style())
-    }
-
-    fn as_tabs_block<'block>(&self) -> ratatui::widgets::Block<'block> {
-        if !self.theme.draw_borders {
-            return ratatui::widgets::Block::default()/* .padding(Padding::new(0, 0, 1, 1)) */;
-        }
-
-        ratatui::widgets::Block::default()
-            .borders(Borders::TOP | Borders::BOTTOM)
-            .border_set(border::ONE_EIGHTH_WIDE)
-            .border_style(self.as_border_style())
     }
 
     fn as_border_style(&self) -> ratatui::style::Style {

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -63,7 +63,11 @@ use crate::{
         keys::ActionEvent,
         mouse_event::MouseEvent,
     },
-    ui::{input::InputResultEvent, widgets::header::PropertyTemplates},
+    ui::{
+        input::InputResultEvent,
+        panes::queue_header::QueueHeaderPane,
+        widgets::header::PropertyTemplates,
+    },
 };
 
 pub mod album_art;
@@ -80,6 +84,7 @@ pub mod playlists;
 pub mod progress_bar;
 pub mod property;
 pub mod queue;
+pub mod queue_header;
 pub mod search;
 pub mod tabs;
 pub mod tag_browser;
@@ -88,6 +93,7 @@ pub mod volume;
 #[derive(Debug, Display, strum::EnumDiscriminants)]
 pub enum Panes<'pane_ref, 'pane> {
     Queue(&'pane_ref mut QueuePane),
+    QueueHeader(&'pane_ref mut QueueHeaderPane),
     #[cfg(debug_assertions)]
     Logs(&'pane_ref mut LogsPane),
     Directories(&'pane_ref mut DirectoriesPane),
@@ -116,6 +122,7 @@ impl<P: Pane + std::fmt::Debug> BoxedPane for P {}
 #[derive(Debug)]
 pub struct PaneContainer<'panes> {
     pub queue: QueuePane,
+    pub queue_header: QueueHeaderPane,
     #[cfg(debug_assertions)]
     pub logs: LogsPane,
     pub directories: DirectoriesPane,
@@ -139,6 +146,7 @@ impl<'panes> PaneContainer<'panes> {
     pub fn new(ctx: &Ctx) -> Result<Self> {
         Ok(Self {
             queue: QueuePane::new(ctx),
+            queue_header: QueueHeaderPane::new(ctx),
             #[cfg(debug_assertions)]
             logs: LogsPane::new(),
             directories: DirectoriesPane::new(ctx),
@@ -193,6 +201,7 @@ impl<'panes> PaneContainer<'panes> {
     ) -> Result<Panes<'pane_ref, 'panes>> {
         match pane {
             PaneType::Queue => Ok(Panes::Queue(&mut self.queue)),
+            PaneType::QueueHeader() => Ok(Panes::QueueHeader(&mut self.queue_header)),
             #[cfg(debug_assertions)]
             PaneType::Logs => Ok(Panes::Logs(&mut self.logs)),
             PaneType::Directories => Ok(Panes::Directories(&mut self.directories)),
@@ -231,6 +240,7 @@ macro_rules! pane_call {
     ($screen:ident, $fn:ident($($param:expr),+)) => {
         match &mut $screen {
             Panes::Queue(s) => s.$fn($($param),+),
+            Panes::QueueHeader(s) => s.$fn($($param),+),
             #[cfg(debug_assertions)]
             Panes::Logs(s) => s.$fn($($param),+),
             Panes::Directories(s) => s.$fn($($param),+),

--- a/src/ui/panes/queue_header.rs
+++ b/src/ui/panes/queue_header.rs
@@ -1,0 +1,236 @@
+use std::{cmp::Ordering, collections::HashMap};
+
+use anyhow::Result;
+use itertools::Itertools;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Flex, Layout, Rect},
+    widgets::{Row, Table},
+};
+
+use crate::{
+    config::theme::properties::{Property, PropertyKindOrText, SongProperty},
+    ctx::Ctx,
+    mpd::{commands::Song, mpd_client::MpdCommand, proto_client::ProtoClient},
+    shared::{
+        cmp::StringCompare,
+        keys::ActionEvent,
+        mouse_event::{MouseEvent, MouseEventKind},
+    },
+    ui::{
+        UiEvent,
+        panes::{Pane, queue::QueuePane},
+    },
+};
+
+#[derive(Debug)]
+pub struct QueueHeaderPane {
+    area: Rect,
+    column_widths: Vec<Constraint>,
+    column_formats: Vec<Property<SongProperty>>,
+    song: Song,
+}
+
+impl QueueHeaderPane {
+    pub fn new(ctx: &Ctx) -> Self {
+        let (column_widths, column_formats) = QueuePane::init(ctx);
+        Self { area: Rect::default(), column_widths, column_formats, song: Song::default() }
+    }
+
+    fn calculate_swaps<T: AsRef<str>>(
+        mut desired: Vec<(u32, T)>,
+        ctx: &Ctx,
+    ) -> Result<Vec<(usize, usize)>> {
+        let cmp = StringCompare::builder().fold_case(true).build();
+        let is_non_decreasing = desired.is_sorted_by(|(_, a), (_, b)| {
+            matches!(cmp.compare(a.as_ref(), b.as_ref()), Ordering::Less | Ordering::Equal)
+        });
+
+        if is_non_decreasing {
+            desired.sort_by(|(_, a), (_, b)| cmp.compare(a.as_ref(), b.as_ref()).reverse());
+        } else {
+            desired.sort_by(|(_, a), (_, b)| cmp.compare(a.as_ref(), b.as_ref()));
+        }
+
+        let mut current: Vec<u32> = ctx.queue.iter().map(|s| s.id).collect();
+        let mut index: HashMap<u32, usize> =
+            current.iter().enumerate().map(|(i, id)| (*id, i)).collect();
+        let mut swaps = Vec::new();
+
+        for i in 0..current.len() {
+            let target_id = desired[i].0;
+            if current[i] == target_id {
+                continue; // already at the correct position
+            }
+
+            let j = *index
+                .get(&target_id)
+                .ok_or_else(|| anyhow::anyhow!("desired contains an ID not present in current"))?;
+
+            swaps.push((i, j));
+
+            let ai = current[i];
+            current.swap(i, j);
+
+            index.insert(ai, j);
+            index.insert(target_id, i);
+        }
+
+        Ok(swaps)
+    }
+
+    pub fn sort_by_column(
+        column_formats: &[Property<SongProperty>],
+        idx: usize,
+        ctx: &Ctx,
+    ) -> Result<()> {
+        let swaps = match column_formats.get(idx).as_ref().map(|v| &v.kind) {
+            Some(PropertyKindOrText::Text(_)) => {
+                // Do nothing, everything is a constant text
+                Vec::new()
+            }
+            Some(PropertyKindOrText::Sticker(sticker_name)) => {
+                let evald = ctx
+                    .queue
+                    .iter()
+                    .map(|song| {
+                        (
+                            song.id,
+                            ctx.song_stickers(&song.file)
+                                .and_then(|s| s.get(sticker_name))
+                                .map(|s| s.as_str())
+                                .unwrap_or_default(),
+                        )
+                    })
+                    .collect_vec();
+
+                Self::calculate_swaps(evald, ctx)?
+            }
+            Some(PropertyKindOrText::Property(_))
+            | Some(PropertyKindOrText::Group(_))
+            | Some(PropertyKindOrText::Transform(_)) => {
+                let evald = ctx
+                    .queue
+                    .iter()
+                    .map(|song| {
+                        (
+                            song.id,
+                            column_formats[idx]
+                                .as_string(
+                                    Some(song),
+                                    "",
+                                    ctx.config.theme.multiple_tag_resolution_strategy,
+                                    ctx,
+                                )
+                                .unwrap_or_default(),
+                        )
+                    })
+                    .collect_vec();
+
+                Self::calculate_swaps(evald, ctx)?
+            }
+            None => {
+                // Should not really ever happen. But no reason to handle this as a hard error.
+                log::warn!("Tried to sort by non-existing column index {idx}");
+                Vec::new()
+            }
+        };
+
+        ctx.command(move |client| {
+            client.send_start_cmd_list()?;
+            for swap in swaps {
+                client.send_swap_position(swap.0, swap.1)?;
+            }
+            client.send_execute_cmd_list()?;
+            client.read_ok()?;
+            Ok(())
+        });
+
+        Ok(())
+    }
+}
+
+impl Pane for QueueHeaderPane {
+    fn render(&mut self, frame: &mut Frame, mut area: Rect, ctx: &Ctx) -> Result<()> {
+        // Reserve space for the queue scrollbar and padding on the right
+        area.width = area.width.saturating_sub(2);
+        self.area = area;
+
+        let widths = Layout::horizontal(self.column_widths.as_slice())
+            .flex(Flex::Start)
+            .spacing(1)
+            .split(self.area);
+
+        let header = ctx
+            .config
+            .theme
+            .song_table_format
+            .iter()
+            .enumerate()
+            .map(|(idx, format)| {
+                let max_len: usize = widths[idx].width.into();
+                self.song
+                    .as_line_ellipsized(
+                        &format.label,
+                        max_len,
+                        &ctx.config.theme.symbols,
+                        &ctx.config.theme.format_tag_separator,
+                        ctx.config.theme.multiple_tag_resolution_strategy,
+                        ctx,
+                    )
+                    .unwrap_or_default()
+                    .alignment(format.alignment.into())
+            })
+            .collect_vec();
+        let header_table = Table::new(std::iter::once(Row::new(header)), &self.column_widths);
+        frame.render_widget(header_table, self.area);
+
+        Ok(())
+    }
+
+    fn handle_action(&mut self, _event: &mut ActionEvent, _ctx: &mut Ctx) -> Result<()> {
+        Ok(())
+    }
+
+    fn handle_mouse_event(&mut self, event: MouseEvent, ctx: &Ctx) -> Result<()> {
+        let position = event.into();
+
+        if !self.area.contains(position) {
+            return Ok(());
+        }
+
+        match event.kind {
+            MouseEventKind::LeftClick | MouseEventKind::DoubleClick => {
+                if self.area.contains(event.into()) {
+                    let widths = Layout::horizontal(self.column_widths.as_slice())
+                        .flex(Flex::Start)
+                        .spacing(1)
+                        .split(self.area);
+                    if let Some(header_idx) = widths.iter().position(|w| w.contains(position)) {
+                        Self::sort_by_column(self.column_formats.as_slice(), header_idx, ctx)?;
+                    }
+                    ctx.render()?;
+                }
+            }
+            MouseEventKind::MiddleClick => {}
+            MouseEventKind::RightClick => {}
+            MouseEventKind::ScrollDown => {}
+            MouseEventKind::ScrollUp => {}
+            MouseEventKind::Drag { .. } => {}
+        }
+
+        Ok(())
+    }
+
+    fn on_event(&mut self, event: &mut UiEvent, _is_visible: bool, ctx: &Ctx) -> Result<()> {
+        match event {
+            UiEvent::ConfigChanged => {
+                let (column_widths, column_formats) = QueuePane::init(ctx);
+                self.column_formats = column_formats;
+                self.column_widths = column_widths;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/src/ui/panes/tabs.rs
+++ b/src/ui/panes/tabs.rs
@@ -44,7 +44,6 @@ impl TabsPane<'_> {
     fn init_tabs<'a>(tab_names: Vec<String>, ctx: &Ctx) -> Tabs<'a> {
         Tabs::new(tab_names)
             .divider("")
-            .block(ctx.config.as_tabs_block())
             .style(ctx.config.theme.tab_bar.inactive_style)
             .alignment(ratatui::prelude::Alignment::Center)
             .highlight_style(ctx.config.theme.tab_bar.active_style)


### PR DESCRIPTION
## Description

Added new `QueueHeader` pane to allow for more flexible theming. This also removes the current queue table header and `show_song_table_border` which means that users will unfortunately have to update their configs. Additionally `draw_borders` has been soft deprecated and no longer affects the queue table or the `Tabs` pane in any way since everything is now possible with the pane borders, only thing this still affects are borders in the browser panes, but this will be removed in the future as well.

The default theme and config have been updated to use more of the new features.

This is what the default theme and config looks like now:
<img width="1324" height="764" alt="image" src="https://github.com/user-attachments/assets/22b91884-ccfa-4a3d-a84f-1e1cfb56923c" />


### Related issues

docs pr: https://github.com/rmpc-org/rmpc-org.github.io/pull/22/

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
