### PR TITLE
feat(theme): header column widths

### DIFF
--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -30,6 +30,10 @@ pub fn default_column_widths() -> Vec<u16> {
     vec![20, 38, 42]
 }
 
+pub fn default_header_column_widths() -> Vec<u16> {
+    vec![30, 40, 30]
+}
+
 pub fn bool<const V: bool>() -> bool {
     V
 }

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -69,6 +69,7 @@ pub struct UiConfig {
     pub scrollbar: Option<ScrollbarConfig>,
     pub song_table_format: Vec<SongTableColumn>,
     pub song_table_album_separator: AlbumSeparator,
+    pub header_column_widths: [u16; 3],
     pub header: HeaderConfig,
     #[debug("{}", default_album_art.len())]
     pub default_album_art: &'static [u8],
@@ -118,6 +119,8 @@ pub struct UiConfigFile {
     pub(super) song_table_format: QueueTableColumnsFile,
     #[serde(default)]
     pub(super) song_table_album_separator: AlbumSeparator,
+    #[serde(default = "defaults::default_header_column_widths")]
+    pub(super) header_column_widths: Vec<u16>,
     #[serde(default)]
     pub(super) header: HeaderConfigFile,
     pub(super) default_album_art_path: Option<String>,
@@ -149,6 +152,7 @@ impl Default for UiConfigFile {
             text_color: None,
             header_background_color: None,
             show_song_table_header: false,
+            header_column_widths: vec![30, 40, 30],
             header: HeaderConfigFile::default(),
             modal_background_color: None,
             modal_backdrop: false,
@@ -401,6 +405,11 @@ impl TryFrom<UiConfigFile> for UiConfig {
             progress_bar: value.progress_bar.into_config()?,
             song_table_format: TryInto::<QueueTableColumns>::try_into(value.song_table_format)?.0,
             song_table_album_separator: value.song_table_album_separator,
+            header_column_widths: [
+                value.header_column_widths[0],
+                value.header_column_widths[1],
+                value.header_column_widths[2],
+            ],
             header: value.header.try_into()?,
             column_widths: [
                 value.browser_column_widths[0],

--- a/src/ui/widgets/header.rs
+++ b/src/ui/widgets/header.rs
@@ -33,9 +33,9 @@ impl Widget for Header<'_> {
         let song = self.ctx.find_current_song_in_queue().map(|(_, song)| song);
         for row in 0..row_count {
             let [left, center, right] = *Layout::horizontal([
-                Constraint::Percentage(30),
-                Constraint::Percentage(40),
-                Constraint::Percentage(30),
+                Constraint::Percentage(config.theme.header_column_widths[0]),
+                Constraint::Percentage(config.theme.header_column_widths[1]),
+                Constraint::Percentage(config.theme.header_column_widths[2]),
             ])
             .split(layouts[row]) else {
                 return;


### PR DESCRIPTION
## Description

This adds a new `header_column_widths` theme config option which allows controlling the width of the left, center and right columns in the header widget.

This is useful if for example you do not want to use the center column, or want to weight any of the columns differently (ie to be able to display longer song titles).

Example:

```ron
header_column_widths: [50, 0, 50],
```

This allows the full album title to be displayed:

<img width="1248" height="229" alt="image" src="https://github.com/user-attachments/assets/0cfc6a4e-9678-4001-87ca-1fa493bde5b0" />

Vs current build with default `[30, 40, 30]` split:

<img width="1243" height="223" alt="image" src="https://github.com/user-attachments/assets/9a6a7c7d-b0b9-4a07-b618-a46f4653c9ac" />


Let me know if you'd like me to update the changelog and docs too - I can address that in the next couple of days hopefully.

### Related issues

None

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [ ] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [ ] Changelog has been updated
