### PR TITLE
refactor(config): use `#[serde(default)]` at struct level where possible

### DIFF
--- a/src/config/album_art.rs
+++ b/src/config/album_art.rs
@@ -4,20 +4,28 @@ use strum::Display;
 use super::Size;
 use crate::{mpd::mpd_client::AlbumArtOrder, shared::terminal::ImageBackend};
 
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(default)]
 pub struct AlbumArtConfigFile {
-    #[serde(default)]
     pub method: ImageMethodFile,
-    #[serde(default)]
     pub order: AlbumArtOrderFile,
-    #[serde(default)]
     pub max_size_px: Size,
-    #[serde(default = "super::defaults::disabled_album_art_protos")]
     pub disabled_protocols: Vec<String>,
-    #[serde(default)]
     pub vertical_align: VerticalAlignFile,
-    #[serde(default)]
     pub horizontal_align: HorizontalAlignFile,
+}
+
+impl Default for AlbumArtConfigFile {
+    fn default() -> Self {
+        Self {
+            method: ImageMethodFile::default(),
+            order: AlbumArtOrderFile::default(),
+            max_size_px: Size::default(),
+            disabled_protocols: vec!["http://".to_string(), "https://".to_string()],
+            vertical_align: VerticalAlignFile::default(),
+            horizontal_align: HorizontalAlignFile::default(),
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/src/config/artists.rs
+++ b/src/config/artists.rs
@@ -8,17 +8,11 @@ pub struct Artists {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct ArtistsFile {
-    #[serde(default)]
     pub album_display_mode: AlbumDisplayMode,
-    #[serde(default)]
     pub album_sort_by: AlbumSortMode,
-    #[serde(default = "default_album_date_tags")]
     pub album_date_tags: Vec<AlbumDateTag>,
-}
-
-fn default_album_date_tags() -> Vec<AlbumDateTag> {
-    vec![AlbumDateTag::Date]
 }
 
 impl Default for ArtistsFile {
@@ -26,7 +20,7 @@ impl Default for ArtistsFile {
         Self {
             album_display_mode: AlbumDisplayMode::default(),
             album_sort_by: AlbumSortMode::default(),
-            album_date_tags: default_album_date_tags(),
+            album_date_tags: vec![AlbumDateTag::Date],
         }
     }
 }

--- a/src/config/cava.rs
+++ b/src/config/cava.rs
@@ -18,23 +18,32 @@ pub struct Cava {
     pub eq: Vec<f64>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
 pub struct CavaFile {
-    #[serde(default = "defaults::u16::<60>")]
     framerate: u16,
-    #[serde(default = "defaults::bool::<true>")]
     pub autosens: bool,
-    #[serde(default = "defaults::u16::<100>")]
     pub sensitivity: u16,
-    #[serde(default)]
     lower_cutoff_freq: Option<u16>,
-    #[serde(default)]
     higher_cutoff_freq: Option<u32>,
     input: CavaInputFile,
-    #[serde(default)]
     smoothing: CavaSmoothingFile,
-    #[serde(default)]
     eq: Vec<f64>,
+}
+
+impl Default for CavaFile {
+    fn default() -> Self {
+        Self {
+            framerate: 60,
+            autosens: true,
+            sensitivity: 100,
+            lower_cutoff_freq: None,
+            higher_cutoff_freq: None,
+            input: CavaInputFile::default(),
+            smoothing: CavaSmoothingFile::default(),
+            eq: vec![],
+        }
+    }
 }
 
 #[derive(Debug, Display, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/config/cli_config.rs
+++ b/src/config/cli_config.rs
@@ -7,15 +7,23 @@ use super::{Config, ConfigFile, MpdAddress, address::MpdPassword, utils::tilde_e
 use crate::config::utils::tilde_expand_path;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct CliConfigFile {
-    #[serde(default = "super::defaults::mpd_address")]
     pub address: String,
-    #[serde(default)]
     password: Option<String>,
-    #[serde(default)]
     cache_dir: Option<PathBuf>,
-    #[serde(default)]
     lyrics_dir: Option<String>,
+}
+
+impl Default for CliConfigFile {
+    fn default() -> Self {
+        Self {
+            address: "127.0.0.1:6600".to_string(),
+            password: None,
+            cache_dir: None,
+            lyrics_dir: None,
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -1,9 +1,8 @@
-#![allow(dead_code)]
 #![allow(clippy::unnecessary_wraps)]
 
 use std::collections::HashMap;
 
-use super::theme::{Modifiers, ScrollbarConfigFile, StyleFile, properties::SongPropertyFile};
+use super::theme::{Modifiers, StyleFile, properties::SongPropertyFile};
 use crate::config::{
     tabs::{
         BorderTitlePosition,
@@ -28,13 +27,6 @@ use crate::config::{
         volume_slider::VolumeSliderConfigFile,
     },
 };
-pub fn default_column_widths() -> Vec<u16> {
-    vec![20, 38, 42]
-}
-
-pub fn default_header_column_widths() -> Vec<u16> {
-    vec![30, 40, 30]
-}
 
 pub fn bool<const V: bool>() -> bool {
     V
@@ -44,56 +36,8 @@ pub fn u8<const V: u8>() -> u8 {
     V
 }
 
-pub fn u16<const V: u16>() -> u16 {
-    V
-}
-
-pub fn u32<const V: u32>() -> u32 {
-    V
-}
-
-pub fn u64<const V: u64>() -> u64 {
-    V
-}
-
 pub fn i32<const V: i32>() -> i32 {
     V
-}
-
-pub fn i64<const V: i64>() -> i64 {
-    V
-}
-
-pub fn usize<const V: usize>() -> usize {
-    V
-}
-
-pub fn default_bar_symbols() -> Vec<char> {
-    "▁▂▃▄▅▆▇█".chars().collect()
-}
-
-pub fn default_inverted_bar_symbols() -> Vec<char> {
-    "▔🮂🮃▀🮄🮅🮆█".chars().collect()
-}
-
-pub fn default_progress_update_interval_ms() -> Option<u64> {
-    Some(1000)
-}
-
-pub fn mpd_address() -> String {
-    "127.0.0.1:6600".to_string()
-}
-
-pub fn mpd_host() -> String {
-    "127.0.0.1".to_string()
-}
-
-pub fn mpd_port() -> String {
-    "6600".to_string()
-}
-
-pub fn disabled_album_art_protos() -> Vec<String> {
-    ["http://", "https://"].into_iter().map(|p| p.to_owned()).collect()
 }
 
 pub fn default_playing_label() -> String {
@@ -133,72 +77,8 @@ pub fn playlist_symbol() -> String {
     "P".to_owned()
 }
 
-pub fn default_tag_separator() -> String {
-    " | ".to_string()
-}
-
-pub fn current_item_style() -> Option<StyleFile> {
-    Some(StyleFile {
-        fg: Some("black".to_string()),
-        bg: Some("blue".to_string()),
-        modifiers: Some(Modifiers::Bold),
-    })
-}
-
-pub fn highlighted_item_style() -> Option<StyleFile> {
-    Some(StyleFile { fg: Some("blue".to_string()), bg: None, modifiers: Some(Modifiers::Bold) })
-}
-
-pub fn default_preview_label_style() -> StyleFile {
-    StyleFile { fg: Some("yellow".to_string()), bg: None, modifiers: None }
-}
-
-pub fn default_preview_metaga_group_heading_style() -> StyleFile {
-    StyleFile { fg: Some("yellow".to_string()), bg: None, modifiers: Some(Modifiers::Bold) }
-}
-
 pub fn default_thousands_separator() -> String {
     ",".to_string()
-}
-
-pub fn default_time_unit_separator() -> String {
-    ", ".to_string()
-}
-
-pub fn default_optional_time_unit_separator() -> Option<String> {
-    None
-}
-
-pub fn default_scrollbar() -> Option<ScrollbarConfigFile> {
-    Some(ScrollbarConfigFile::default())
-}
-
-pub fn default_trace_color() -> StyleFile {
-    StyleFile { fg: Some("magenta".to_string()), bg: Some("black".to_string()), modifiers: None }
-}
-
-pub fn default_debug_color() -> StyleFile {
-    StyleFile {
-        fg: Some("light_green".to_string()),
-        bg: Some("black".to_string()),
-        modifiers: None,
-    }
-}
-
-pub fn default_info_color() -> StyleFile {
-    StyleFile { fg: Some("blue".to_string()), bg: Some("black".to_string()), modifiers: None }
-}
-
-pub fn default_warn_color() -> StyleFile {
-    StyleFile { fg: Some("yellow".to_string()), bg: Some("black".to_string()), modifiers: None }
-}
-
-pub fn default_error_color() -> StyleFile {
-    StyleFile { fg: Some("red".to_string()), bg: Some("black".to_string()), modifiers: None }
-}
-
-pub fn default_status_bar_background_color() -> StyleFile {
-    StyleFile { fg: Some("black".to_string()), bg: Some("black".to_string()), modifiers: None }
 }
 
 pub fn rating_options() -> Vec<i32> {

--- a/src/config/keys/actions.rs
+++ b/src/config/keys/actions.rs
@@ -488,13 +488,11 @@ pub enum AutoplayKind {
     None,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(default)]
 pub struct AddOpts {
-    #[serde(default)]
     pub autoplay: AutoplayKind,
-    #[serde(default)]
     pub all: bool,
-    #[serde(default)]
     pub position: Position,
 }
 

--- a/src/config/keys/mod.rs
+++ b/src/config/keys/mod.rs
@@ -17,7 +17,6 @@ use actions::{CommonActionFile, GlobalActionFile, QueueActionsFile};
 pub use key::Key;
 use serde::{Deserialize, Serialize};
 
-use super::defaults;
 use crate::config::keys::{
     actions::{DuplicateStrategy, RateKind, SaveKind},
     key::KeySequence,
@@ -40,17 +39,13 @@ pub struct KeyConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
 pub struct KeyConfigFile {
-    #[serde(default = "defaults::bool::<false>")]
     pub clear: bool,
-    #[serde(default)]
     pub global: HashMap<KeySequence, GlobalActionFile>,
-    #[serde(default)]
     pub navigation: HashMap<KeySequence, CommonActionFile>,
     #[cfg(debug_assertions)]
-    #[serde(default)]
     pub logs: HashMap<KeySequence, LogsActionsFile>,
-    #[serde(default)]
     pub queue: HashMap<KeySequence, QueueActionsFile>,
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -108,91 +108,50 @@ pub enum ShowPlaylistsMode {
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
 pub struct ConfigFile {
-    #[serde(default = "defaults::mpd_address")]
     pub address: String,
-    #[serde(default)]
     password: Option<String>,
-    #[serde(default)]
     cache_dir: Option<PathBuf>,
-    #[serde(default)]
     lyrics_dir: Option<String>,
-    #[serde(default = "defaults::i64::<0>")]
     lyrics_offset_ms: i64,
-    #[serde(default = "defaults::bool::<true>")]
     enable_lyrics_index: bool,
-    #[serde(default = "defaults::bool::<false>")]
     enable_lyrics_hot_reload: bool,
-    #[serde(default)]
     pub theme: Option<String>,
-    #[serde(default = "defaults::u8::<5>")]
     volume_step: u8,
-    #[serde(default = "defaults::u32::<30>")]
     pub max_fps: u32,
-    #[serde(default = "defaults::usize::<0>")]
     scrolloff: usize,
-    #[serde(default = "defaults::bool::<false>")]
     wrap_navigation: bool,
-    #[serde(default = "defaults::default_progress_update_interval_ms")]
     status_update_interval_ms: Option<u64>,
-    #[serde(default = "defaults::bool::<false>")]
     select_current_song_on_change: bool,
-    #[serde(default = "defaults::bool::<false>")]
     center_current_song_on_change: bool,
-    #[serde(default = "defaults::bool::<false>")]
     reflect_changes_to_playlist: bool,
-    #[serde(default)]
     rewind_to_start_sec: Option<u64>,
-    #[serde(default = "defaults::bool::<true>")]
     keep_state_on_song_change: bool,
-    #[serde(default = "defaults::u64::<10_000>")]
     mpd_read_timeout_ms: u64,
-    #[serde(default = "defaults::u64::<5_000>")]
     mpd_write_timeout_ms: u64,
-    #[serde(default)]
     mpd_idle_read_timeout_ms: Option<u64>,
-    #[serde(default = "defaults::bool::<true>")]
     enable_mouse: bool,
-    #[serde(default = "defaults::usize::<1>")]
     scroll_amount: usize,
-    #[serde(default = "defaults::bool::<true>")]
     pub enable_config_hot_reload: bool,
-    #[serde(default)]
     keybinds: KeyConfigFile,
-    #[serde(default = "defaults::u64::<1000>")]
     pub normal_timeout_ms: u64,
-    #[serde(default = "defaults::u64::<1000>")]
     pub insert_timeout_ms: u64,
     // Deprecated
-    #[serde(default)]
     image_method: Option<ImageMethodFile>,
-    #[serde(default)]
     album_art_max_size_px: Size,
-    #[serde(default)]
     pub album_art: AlbumArtConfigFile,
-    #[serde(default)]
     on_song_change: Option<Vec<String>>,
-    #[serde(default)]
     exec_on_song_change_at_start: bool,
-    #[serde(default)]
     on_resize: Option<Vec<String>>,
-    #[serde(default)]
     search: SearchFile,
-    #[serde(default)]
     artists: ArtistsFile,
-    #[serde(default)]
     tabs: TabsFile,
-    #[serde(default)]
     pub ignore_leading_the: bool,
-    #[serde(default)]
     pub browser_song_sort: Vec<SongPropertyFile>,
-    #[serde(default)]
     pub show_playlists_in_browser: ShowPlaylistsMode,
-    #[serde(default)]
     pub directories_sort: SortModeFile,
-    #[serde(default)]
     pub cava: CavaFile,
-    #[serde(default = "defaults::bool::<true>")]
     pub auto_open_downloads: bool,
 }
 
@@ -239,7 +198,7 @@ impl Default for ConfigFile {
             center_current_song_on_change: false,
             album_art_max_size_px: Size::default(),
             album_art: AlbumArtConfigFile {
-                disabled_protocols: defaults::disabled_album_art_protos(),
+                disabled_protocols: vec!["http://".to_string(), "https://".to_string()],
                 ..Default::default()
             },
             on_song_change: None,

--- a/src/config/tabs.rs
+++ b/src/config/tabs.rs
@@ -519,18 +519,14 @@ pub enum BorderTitlePosition {
     Bottom,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct SubPaneFile {
     pub size: String,
-    #[serde(default)]
     pub borders: BordersFile,
-    #[serde(default)]
     pub border_title: Vec<PropertyFile<PropertyKindFile>>,
-    #[serde(default)]
     pub border_title_position: BorderTitlePosition,
-    #[serde(default)]
     pub border_title_alignment: Alignment,
-    #[serde(default)]
     pub border_symbols: BorderSymbolsFile,
     pub pane: PaneOrSplitFile,
 }

--- a/src/config/theme/borders.rs
+++ b/src/config/theme/borders.rs
@@ -65,23 +65,16 @@ impl<'a> From<&'a BorderSet> for Set<'a> {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct BorderSetInherited {
     pub parent: Box<BorderSymbolsFile>,
-    #[serde(default)]
     pub top_left: Option<String>,
-    #[serde(default)]
     pub top_right: Option<String>,
-    #[serde(default)]
     pub bottom_left: Option<String>,
-    #[serde(default)]
     pub bottom_right: Option<String>,
-    #[serde(default)]
     pub vertical_left: Option<String>,
-    #[serde(default)]
     pub vertical_right: Option<String>,
-    #[serde(default)]
     pub horizontal_top: Option<String>,
-    #[serde(default)]
     pub horizontal_bottom: Option<String>,
 }
 

--- a/src/config/theme/cava.rs
+++ b/src/config/theme/cava.rs
@@ -6,24 +6,18 @@ use itertools::Itertools;
 use ratatui::{prelude::IntoCrossterm, style::Color as RatatuiColor};
 use serde::{Deserialize, Deserializer, Serialize};
 
-use super::{ConfigColor, defaults};
+use super::ConfigColor;
 use crate::shared::ext::vec::VecExt;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct CavaThemeFile {
-    #[serde(default = "defaults::default_bar_symbols")]
     pub bar_symbols: Vec<char>,
-    #[serde(default = "defaults::default_inverted_bar_symbols")]
     pub inverted_bar_symbols: Vec<char>,
-    #[serde(default)]
     pub bg_color: Option<String>,
-    #[serde(default)]
     pub bar_color: CavaColorFile,
-    #[serde(default = "defaults::u16::<1>")]
     pub bar_spacing: u16,
-    #[serde(default = "defaults::u16::<1>")]
     pub bar_width: u16,
-    #[serde(default)]
     pub orientation: Orientation,
 }
 

--- a/src/config/theme/level_styles.rs
+++ b/src/config/theme/level_styles.rs
@@ -1,7 +1,7 @@
 use ::serde::{Deserialize, Serialize};
 use ratatui::style::Style;
 
-use super::{StyleFile, ToConfigOr, defaults};
+use super::{StyleFile, ToConfigOr};
 
 #[derive(derive_more::Debug, Default, Clone)]
 pub struct LevelStyles {
@@ -13,27 +13,43 @@ pub struct LevelStyles {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct LevelStylesFile {
-    #[serde(default = "defaults::default_trace_color")]
     trace: StyleFile,
-    #[serde(default = "defaults::default_debug_color")]
     debug: StyleFile,
-    #[serde(default = "defaults::default_warn_color")]
     warn: StyleFile,
-    #[serde(default = "defaults::default_error_color")]
     error: StyleFile,
-    #[serde(default = "defaults::default_info_color")]
     info: StyleFile,
 }
 
 impl Default for LevelStylesFile {
     fn default() -> Self {
         Self {
-            trace: defaults::default_trace_color(),
-            debug: defaults::default_debug_color(),
-            warn: defaults::default_warn_color(),
-            error: defaults::default_error_color(),
-            info: defaults::default_info_color(),
+            trace: StyleFile {
+                fg: Some("magenta".to_string()),
+                bg: Some("black".to_string()),
+                modifiers: None,
+            },
+            debug: StyleFile {
+                fg: Some("light_green".to_string()),
+                bg: Some("black".to_string()),
+                modifiers: None,
+            },
+            warn: StyleFile {
+                fg: Some("yellow".to_string()),
+                bg: Some("black".to_string()),
+                modifiers: None,
+            },
+            error: StyleFile {
+                fg: Some("red".to_string()),
+                bg: Some("black".to_string()),
+                modifiers: None,
+            },
+            info: StyleFile {
+                fg: Some("blue".to_string()),
+                bg: Some("black".to_string()),
+                modifiers: None,
+            },
         }
     }
 }

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -84,61 +84,41 @@ pub struct UiConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct UiConfigFile {
-    #[serde(default = "defaults::bool::<true>")]
     pub(super) draw_borders: bool,
     pub(super) symbols: SymbolsFile,
     pub(super) tab_bar: TabBarFile,
     pub(super) progress_bar: ProgressBarConfigFile,
-    #[serde(default = "defaults::default_scrollbar")]
     pub(super) scrollbar: Option<ScrollbarConfigFile>,
-    #[serde(default = "defaults::default_column_widths")]
     pub(super) browser_column_widths: Vec<u16>,
-    #[serde(default)]
     pub(super) browser_song_format: SongFormatFile,
     pub(super) background_color: Option<String>,
     pub(super) text_color: Option<String>,
-    #[serde(default = "defaults::default_preview_label_style")]
     pub(super) preview_label_style: StyleFile,
-    #[serde(default = "defaults::default_preview_metaga_group_heading_style")]
     pub(super) preview_metadata_group_style: StyleFile,
     #[deprecated]
     pub(super) header_background_color: Option<String>,
     pub(super) modal_background_color: Option<String>,
-    #[serde(default)]
     pub(super) modal_backdrop: bool,
     pub(super) borders_style: Option<StyleFile>,
-    #[serde(default = "defaults::highlighted_item_style")]
     pub(super) highlighted_item_style: Option<StyleFile>,
-    #[serde(default = "defaults::current_item_style")]
     pub(super) current_item_style: Option<StyleFile>,
     pub(super) highlight_border_style: Option<StyleFile>,
     #[deprecated]
-    #[serde(default)]
     pub(super) show_song_table_header: bool,
     pub(super) song_table_format: QueueTableColumnsFile,
-    #[serde(default)]
     pub(super) song_table_album_separator: AlbumSeparator,
-    #[serde(default = "defaults::default_header_column_widths")]
     pub(super) header_column_widths: Vec<u16>,
-    #[serde(default)]
     pub(super) header: HeaderConfigFile,
     pub(super) default_album_art_path: Option<String>,
-    #[serde(default)]
     pub(super) layout: PaneOrSplitFile,
-    #[serde(default = "defaults::components")]
     pub(super) components: HashMap<String, PaneOrSplitFile>,
-    #[serde(default = "defaults::default_tag_separator")]
     pub(super) format_tag_separator: String,
-    #[serde(default)]
     pub(super) multiple_tag_resolution_strategy: TagResolutionStrategy,
-    #[serde(default)]
     pub(super) level_styles: LevelStylesFile,
-    #[serde(default)]
     pub(super) lyrics: LyricsConfigFile,
-    #[serde(default)]
     pub(super) cava: CavaThemeFile,
-    #[serde(default)]
     pub border_symbol_sets: BorderSetLibFile,
 }
 

--- a/src/config/theme/progress_bar.rs
+++ b/src/config/theme/progress_bar.rs
@@ -27,12 +27,12 @@ pub struct ProgressBarConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct ProgressBarConfigFile {
     pub(super) symbols: Vec<String>,
     pub(super) track_style: Option<StyleFile>,
     pub(super) elapsed_style: Option<StyleFile>,
     pub(super) thumb_style: Option<StyleFile>,
-    #[serde(default = "super::defaults::bool::<true>")]
     pub(super) use_track_when_empty: bool,
 }
 


### PR DESCRIPTION
## Description

This is a first pass of the config code to remove a lot of the duplicated serde defaults code, deriving from the `Default` impl where possible (and providing one where sensible).

In some cases it didn't make sense as only a single field was being touched. Enum struct variants have also been left alone as this likely needs further refactoring (serde might let you derive it here, not sure...).

There are a few cases where this may change current functionality despite tests passing. I found several cases where the `#[serde(default)]` field attribute did not match the value provided in the `Default` implementation. Careful review of whether any of these have changed for the worse is needed, and I'll aim to do a review of this myself in the next few days.

Based on the above, I'll mark as draft for now.

I've left the separate `*File` structs for now, as I feel that's best tackled separately (and I'm yet to even check how feasible it is).

### Related issues

As discussed in #819 

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [-] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [-] Changelog has been updated
