### PR TITLE
fix: unsupported stickers message showing up when not supposed to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ should fix cases with `cache_dir` being set inside MPD's music directory
 - Added missing confirmation when deleting playlist/songs from playlist
 - Some very minor speedups in queue with very large queue sizes
 - `ScanStatus` not working
+- A harmless error about stickers not being supported will no longer show up when previewing a song
+in a browser pane for the first time will no longer show up
 
 ### Removed
 

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -301,6 +301,22 @@ impl Ctx {
         stickers
     }
 
+    /// Search for song stickers only if they are supported, does not trigger
+    /// check for reason.
+    pub(crate) fn song_stickers_if_supported(&self, uri: &str) -> Option<&HashMap<String, String>> {
+        if !matches!(self.stickers_supported, StickersSupport::Supported) {
+            return None;
+        }
+
+        let stickers = self.stickers.get(uri);
+
+        if stickers.is_none() {
+            self.stickers_to_fetch.borrow_mut().insert(uri.to_owned());
+        }
+
+        stickers
+    }
+
     pub(crate) fn set_song_stickers(
         &mut self,
         uri: String,

--- a/src/ui/panes/mod.rs
+++ b/src/ui/panes/mod.rs
@@ -460,7 +460,7 @@ pub(crate) mod browser {
 
             let mut result = vec![info_group, tags_group];
 
-            let stickers = ctx.song_stickers(&self.file);
+            let stickers = ctx.song_stickers_if_supported(&self.file);
             if let Some(stickers) = stickers
                 && !stickers.is_empty()
             {


### PR DESCRIPTION
## Description

The error was benign and would only ever happen once as it was just checking for a specific reason why the stickers are not supported

### Related issues
fixes https://github.com/mierak/rmpc/issues/829

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
