### PR TITLE
fix: improve config reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ configured with the new `album_art.order` option
 - The queue table should now be more performant for a very large number of items
 - Default keybinds have been updated. This will not affect you if have a properly setup config file.
 - Default theme has been updated. This will not affect you if have a properly setup config file.
+- Improved how config and theme files are read. Config file will now properly try all available paths
+instead of just the first one. When theme file is not found it will now correctly present an error
+instead of silently falling back to the default theme.
 
 ### Fixed
 

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -471,28 +471,6 @@ pub enum OnOffOneshot {
 }
 
 impl Args {
-    #[must_use]
-    pub fn config_path(&self) -> PathBuf {
-        if let Some(path) = &self.config {
-            return path.to_owned();
-        }
-        let mut path = PathBuf::new();
-        if let Ok(dir) = std::env::var("XDG_CONFIG_HOME") {
-            path.push(dir);
-        } else if let Ok(home) = std::env::var("HOME") {
-            path.push(home);
-            path.push(".config");
-        } else {
-            return path;
-        }
-        path.push(env!("CARGO_CRATE_NAME"));
-        #[cfg(debug_assertions)]
-        path.push("config.debug.ron");
-        #[cfg(not(debug_assertions))]
-        path.push("config.ron");
-        path
-    }
-
     /// Split a shell-like command line into tokens (argv).
     ///
     /// Supports single `'...'` and double `"..."` quotes and backslash escapes.

--- a/src/config/cli_config.rs
+++ b/src/config/cli_config.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use super::{Config, ConfigFile, MpdAddress, address::MpdPassword, utils::tilde_expand};
@@ -26,12 +25,18 @@ impl Default for CliConfigFile {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct CliConfig {
     pub address: MpdAddress,
     pub password: Option<MpdPassword>,
     pub cache_dir: Option<PathBuf>,
     pub lyrics_dir: Option<String>,
+}
+
+impl Default for CliConfig {
+    fn default() -> Self {
+        CliConfigFile::default().into_config(None, None)
+    }
 }
 
 impl From<ConfigFile> for CliConfigFile {
@@ -68,14 +73,6 @@ impl From<&Config> for CliConfig {
 }
 
 impl CliConfigFile {
-    pub fn read(path: &PathBuf) -> Result<Self> {
-        let file = std::fs::File::open(path)?;
-        let read = std::io::BufReader::new(file);
-        let config: CliConfigFile = ron::de::from_reader(read)?;
-
-        Ok(config)
-    }
-
     pub fn into_config(
         self,
         address_cli: Option<String>,

--- a/src/config/theme/mod.rs
+++ b/src/config/theme/mod.rs
@@ -47,7 +47,7 @@ use super::{
 
 const DEFAULT_ART: &[u8; 58599] = include_bytes!("../../../assets/default.jpg");
 
-#[derive(derive_more::Debug, Default, Clone)]
+#[derive(derive_more::Debug, Clone)]
 pub struct UiConfig {
     pub draw_borders: bool,
     pub background_color: Option<Color>,
@@ -81,6 +81,14 @@ pub struct UiConfig {
     pub lyrics: LyricsConfig,
     pub cava: CavaTheme,
     pub border_symbol_sets: BorderSetLib,
+}
+
+impl Default for UiConfig {
+    fn default() -> Self {
+        UiConfigFile::default()
+            .try_into()
+            .expect("Default UiConfigFile should convert successfully")
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,15 @@
 use core::{config_watcher::ERROR_CONFIG_MODAL_ID, scheduler::Scheduler};
 use std::{
-    fs::File,
-    io::{BufRead, Read, Write},
+    io::{BufRead, Write},
     sync::Arc,
     time::Duration,
 };
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use config::{DeserError, cli_config::CliConfigFile};
 use crossbeam::channel::unbounded;
 use ctx::Ctx;
 use log::info;
-use rustix::path::Arg;
 use shared::{
     dependencies::CAVA,
     macros::{status_warn, try_skip},
@@ -20,16 +17,27 @@ use shared::{
 
 use crate::{
     config::{
+        Config,
         ConfigFile,
         cli::{Args, Command},
+        cli_config::CliConfig,
     },
     mpd::{client::Client, mpd_client::MpdClient, proto_client::SocketClient},
     shared::{
+        config_read::{
+            ConfigReadError,
+            find_first_existing_path,
+            read_cli_config,
+            read_config_and_theme,
+            read_config_file,
+            read_config_for_debuginfo,
+        },
         dependencies::{DEPENDENCIES, FFMPEG, FFPROBE, PYTHON3, PYTHON3MUTAGEN, UEBERZUGPP, YTDLP},
         env::ENV,
         events::{AppEvent, ClientRequest, WorkRequest},
         logging,
         mpd_query::{MpdCommand, MpdQuery, MpdQueryResult},
+        paths::{config_paths, theme_paths},
         terminal::{TERMINAL, Terminal},
         tmux::{self, IS_TMUX},
     },
@@ -51,7 +59,6 @@ mod ui;
 
 fn main() -> Result<()> {
     let mut args = Args::parse();
-    let config_path = args.config_path();
     match args.command {
         Some(Command::Config { current: false }) => {
             std::io::stdout().write_all(include_bytes!("../assets/example_config.ron"))?;
@@ -59,57 +66,67 @@ fn main() -> Result<()> {
         Some(Command::Theme { current: false }) => {
             std::io::stdout().write_all(include_bytes!("../assets/example_theme.ron"))?;
         }
-        Some(Command::Config { current: true }) => match File::open(&config_path) {
-            Ok(mut file) => {
-                let mut config = String::new();
-                file.read_to_string(&mut config)?;
-                println!("{config}");
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                eprintln!(
-                    "Config file not found at '{}'. Use 'rmpc config' to see the default config.",
-                    config_path.display()
-                );
+        Some(Command::Config { current: true }) => {
+            let config_paths = config_paths(args.config.as_deref());
+            if config_paths.is_empty() {
+                eprintln!("No available config path");
                 std::process::exit(1);
             }
-            Err(err) => return Err(err.into()),
-        },
-        Some(Command::Theme { current: true }) => {
-            let config_file = match ConfigFile::read(&config_path) {
-                Ok(config) => config,
-                Err(DeserError::NotFound(_)) => {
-                    eprintln!(
-                        "Config file not found at '{}'. No theme file specified. Use 'rmpc theme' to see the default theme.",
-                        config_path.display()
-                    );
-                    std::process::exit(1);
-                }
-                Err(err) => return Err(err.into()),
+
+            let Some(chosen_config_path) = find_first_existing_path(config_paths) else {
+                eprintln!("No config file found to read the theme from.");
+                std::process::exit(1);
             };
-            let config_dir = config_path.parent().with_context(|| {
-                format!("Invalid config path '{}'", config_path.to_string_lossy())
-            })?;
-            let theme_path = config_file
-                .theme_path(config_dir)
-                .context("No theme file specified in the config. Default theme is used.")?;
-            let mut file = File::open(&theme_path).with_context(|| {
-                format!("Theme file was not found at '{}'", theme_path.to_string_lossy())
-            })?;
-            let mut theme = String::new();
-            file.read_to_string(&mut theme)?;
-            println!("{theme}");
+
+            std::io::stdout().write_all(&std::fs::read(chosen_config_path)?)?;
+        }
+        Some(Command::Theme { current: true }) => {
+            let config_paths = config_paths(args.config.as_deref());
+            if config_paths.is_empty() {
+                eprintln!("No available config path");
+                std::process::exit(1);
+            }
+
+            let Some(chosen_config_path) = find_first_existing_path(config_paths) else {
+                eprintln!("No config file found to read the theme from.");
+                std::process::exit(1);
+            };
+
+            let config = read_config_file(&chosen_config_path)?;
+            let theme_path = if let Some(theme_name) = config.theme {
+                let theme_paths =
+                    theme_paths(args.theme.as_deref(), &chosen_config_path, &theme_name);
+                let Some(first_existing_theme_path) = find_first_existing_path(theme_paths) else {
+                    eprintln!(
+                        "Theme '{}' specified in the config file at '{}' was not found",
+                        theme_name,
+                        chosen_config_path.display()
+                    );
+
+                    std::process::exit(1);
+                };
+
+                first_existing_theme_path
+            } else {
+                eprintln!(
+                    "No theme set in the config file at '{}'. Default theme is used.",
+                    chosen_config_path.display()
+                );
+                return Ok(());
+            };
+
+            std::io::stdout().write_all(&std::fs::read(theme_path)?)?;
         }
         Some(Command::Raw { command }) => {
-            let config_file = ConfigFile::read(&config_path)
-                .context("Failed to read config file")
-                .unwrap_or_default();
-            let config = config_file.clone().into_config(
-                Some(&config_path),
-                args.theme.as_deref(),
-                std::mem::take(&mut args.address),
-                std::mem::take(&mut args.password),
-                false,
-            )?;
+            let config = read_cli_config(args.config.as_deref(), args.address, args.password)
+                .unwrap_or_else(|err| {
+                    eprintln!("Error: Failed to read config");
+                    eprintln!("Caused by:");
+                    eprintln!("  {err}");
+                    eprintln!("\nUsing the default values");
+
+                    CliConfig::default()
+                });
 
             let mut client = Client::init(
                 config.address.clone(),
@@ -136,16 +153,37 @@ fn main() -> Result<()> {
             }
         }
         Some(Command::DebugInfo) => {
-            let config_file = ConfigFile::read(&config_path)
-                .context("Failed to read config file")
-                .unwrap_or_default();
-            let config = config_file.clone().into_config(
-                Some(&config_path),
-                args.theme.as_deref(),
-                std::mem::take(&mut args.address),
-                std::mem::take(&mut args.password),
-                false,
-            )?;
+            println!(
+                "rmpc {}{}",
+                env!("CARGO_PKG_VERSION"),
+                option_env!("VERGEN_GIT_DESCRIBE").map(|g| format!(" git {g}")).unwrap_or_default()
+            );
+
+            let (config_file, config, config_path) =
+                read_config_for_debuginfo(args.config.as_deref(), args.address, args.password)
+                    .map_or_else(
+                        |err| {
+                            // use stdout here in case a user pipes the debug info to a
+                            // file/clipboard so its copied to the github issue as well
+                            if let ConfigReadError::ConfigNotFound = err {
+                                // Do not print error when config was not found, this is fine for
+                                // debuginfo
+                                println!("\nWarning:");
+                                println!("No config file was found. Using default values.");
+                            } else {
+                                println!("\nError: Failed to read config");
+                                println!("Caused by:");
+                                println!("  {err}");
+                                println!("\nUsing the default values");
+                            }
+
+                            (ConfigFile::default(), Config::default(), None)
+                        },
+                        |(config_file, config, config_path)| {
+                            (config_file, config, Some(config_path))
+                        },
+                    );
+
             let mut mpd_host = ENV.var("MPD_HOST").unwrap_or_else(|_| "unset".to_string());
             if let Some(at_idx) = mpd_host.find('@') {
                 mpd_host.replace_range(..at_idx, "***");
@@ -186,15 +224,18 @@ fn main() -> Result<()> {
                         Ok((version, commands, not_commands))
                     });
 
-            println!(
-                "rmpc {}{}",
-                env!("CARGO_PKG_VERSION"),
-                option_env!("VERGEN_GIT_DESCRIBE").map(|g| format!(" git {g}")).unwrap_or_default()
-            );
+            let theme_path = config.theme_name.as_ref().and_then(|theme_name| {
+                find_first_existing_path(theme_paths(
+                    args.theme.as_deref(),
+                    config_path.as_ref()?,
+                    theme_name,
+                ))
+            });
 
             println!("\nrmpc:");
-            println!("{:<20} {}", "Config path", config_path.as_str()?);
-            println!("{:<20} {:?}", "Theme path", config_file.theme);
+            println!("{:<20} {:?}", "Config path", config_path.map(|c| c.display().to_string()));
+            println!("{:<20} {:?}", "Theme name", config.theme_name);
+            println!("{:<20} {:?}", "Theme path", theme_path);
             println!("{:<20} {:?}", "Debug mode", cfg!(debug_assertions));
 
             println!("\nMPD:");
@@ -261,18 +302,16 @@ fn main() -> Result<()> {
         }
         Some(cmd) => {
             logging::init_console().expect("Logger to initialize");
-            let config: CliConfigFile = match CliConfigFile::read(&config_path) {
-                Ok(cfg) => cfg,
-                Err(err) => {
-                    log::warn!(
-                        "Failed to read config file at '{}': {}. Using default values.",
-                        config_path.display(),
-                        err
-                    );
-                    ConfigFile::default().into()
-                }
-            };
-            let config = config.into_config(args.address, args.password);
+            let config = read_cli_config(args.config.as_deref(), args.address, args.password)
+                .unwrap_or_else(|err| {
+                    eprintln!("Error: Failed to read config");
+                    eprintln!("Caused by:");
+                    eprintln!("  {err}");
+                    eprintln!("\nUsing the default values");
+
+                    CliConfig::default()
+                });
+
             let result = cmd.execute(&config)?;
             let mut client = Client::init(
                 config.address.clone(),
@@ -295,46 +334,37 @@ fn main() -> Result<()> {
                 .name("dependency_check".to_string())
                 .spawn(|| DEPENDENCIES.iter().for_each(|d| d.log()))?;
 
-            let config = match ConfigFile::read(&config_path).and_then(|val| {
-                val.into_config(
-                    Some(&config_path),
-                    args.theme.as_deref(),
-                    std::mem::take(&mut args.address),
-                    std::mem::take(&mut args.password),
-                    false,
-                )
-            }) {
-                Ok(cfg) => cfg,
-                Err(DeserError::NotFound(err)) => {
-                    status_warn!(err:?; "No config or theme file was found. Using default values.");
-                    ConfigFile::default().into_config(
-                        None,
-                        None,
-                        std::mem::take(&mut args.address),
-                        std::mem::take(&mut args.password),
-                        false,
-                    )?
-                }
-                Err(err) => {
-                    eprintln!("{err}");
-                    try_skip!(
-                        event_tx.send(AppEvent::InfoModal {
-                            message: vec![err.to_string()],
-                            replacement_id: Some(ERROR_CONFIG_MODAL_ID.into()),
-                            title: None,
-                            size: None
-                        }),
-                        "Failed to send info modal request"
-                    );
-                    ConfigFile::default().into_config(
-                        None,
-                        None,
-                        std::mem::take(&mut args.address),
-                        std::mem::take(&mut args.password),
-                        false,
-                    )?
-                }
-            };
+            let (config, config_path) = read_config_and_theme(&mut args)
+                .map(|result| (result.config, Some(result.config_path)))
+                .unwrap_or_else(|err| {
+                    if let ConfigReadError::ConfigNotFound = err {
+                        // Config not being found is not considered an error. But the user should
+                        // still be warned to setup their config file.
+                        status_warn!("No config file was found. Using default values.",);
+                    } else {
+                        eprintln!("Error: Failed to read config");
+                        eprintln!("Caused by:");
+                        eprintln!("  {err}");
+                        eprintln!("Using the default values");
+                        try_skip!(
+                            event_tx.send(AppEvent::InfoModal {
+                                message: vec![
+                                    "Error: Failed to read config".to_string(),
+                                    "Caused by:".to_string(),
+                                    format!("  {err}"),
+                                    String::from("\n"),
+                                    "Using the default values".to_string(),
+                                ],
+                                replacement_id: Some(ERROR_CONFIG_MODAL_ID.into()),
+                                title: None,
+                                size: None
+                            }),
+                            "Failed to send info modal request"
+                        );
+                    }
+
+                    (Config::default_cli(&mut args), None)
+                });
 
             config.validate()?;
 
@@ -386,14 +416,19 @@ fn main() -> Result<()> {
                 core::socket::init(event_tx.clone(), worker_tx.clone(), Arc::clone(&ctx.config))
                     .context("Failed to initialize socket listener")?;
 
-            let _config_watcher_guard = ctx.config.enable_config_hot_reload.then_some(
-                core::config_watcher::init(
-                    config_path,
-                    ctx.config.theme_name.as_ref().map(|n| format!("{n}.ron",)),
-                    event_tx.clone(),
+            let _config_watcher_guard = if let Some(config_path) = config_path {
+                ctx.config.enable_config_hot_reload.then_some(
+                    core::config_watcher::init(
+                        config_path,
+                        ctx.config.theme_name.as_ref().map(|n| format!("{n}.ron",)),
+                        event_tx.clone(),
+                    )
+                    .inspect_err(|e| log::warn!("Failed to initialize config watcher: {e}")),
                 )
-                .inspect_err(|e| log::warn!("Failed to initialize config watcher: {e}")),
-            );
+            } else {
+                log::warn!("No config file was detected, not watching config for changes");
+                None
+            };
 
             let enable_mouse = ctx.config.enable_mouse;
             let terminal = Terminal::setup(enable_mouse).context("Failed to setup terminal")?;

--- a/src/shared/config_read.rs
+++ b/src/shared/config_read.rs
@@ -1,0 +1,150 @@
+use std::{
+    io::Read,
+    path::{Path, PathBuf},
+};
+
+use thiserror::Error;
+
+use crate::{
+    config::{
+        Config,
+        ConfigFile,
+        cli::Args,
+        cli_config::{CliConfig, CliConfigFile},
+        theme::{UiConfig, UiConfigFile},
+    },
+    shared::paths::{config_paths, theme_paths},
+};
+
+#[derive(Error, Debug)]
+pub enum ConfigReadError {
+    #[error("Deserialization error, {0}")]
+    Deserialization(#[from] serde_path_to_error::Error<ron::Error>),
+    #[error("Failed to deserialize ron config file, {0}")]
+    Ron(#[from] ron::error::SpannedError),
+    #[error("Configuration file not found at any of the possible paths")]
+    ConfigNotFound,
+    #[error("Theme file not found at any of the possible paths")]
+    ThemeNotFound,
+    #[error("IO error, {0}")]
+    Io(#[from] std::io::Error),
+    #[error("No configuration paths available")]
+    NoConfigPaths,
+    #[error("{0:?}")]
+    Conversion(#[from] anyhow::Error),
+}
+
+pub fn read_cli_config(
+    cli_arg_config_path: Option<&Path>,
+    cli_arg_address: Option<String>,
+    cli_arg_password: Option<String>,
+) -> Result<CliConfig, ConfigReadError> {
+    let config_paths = config_paths(cli_arg_config_path);
+    if config_paths.is_empty() {
+        return Err(ConfigReadError::NoConfigPaths);
+    }
+
+    let Some(chosen_config_path) = find_first_existing_path(config_paths) else {
+        return Err(ConfigReadError::ConfigNotFound);
+    };
+
+    let config = read_cli_config_file(&chosen_config_path)?;
+
+    Ok(config.into_config(cli_arg_address, cli_arg_password))
+}
+
+pub fn read_config_for_debuginfo(
+    cli_arg_config_path: Option<&Path>,
+    cli_arg_address: Option<String>,
+    cli_arg_password: Option<String>,
+) -> Result<(ConfigFile, Config, PathBuf), ConfigReadError> {
+    let config_paths = config_paths(cli_arg_config_path);
+    if config_paths.is_empty() {
+        return Err(ConfigReadError::NoConfigPaths);
+    }
+
+    let Some(chosen_config_path) = find_first_existing_path(config_paths) else {
+        return Err(ConfigReadError::ConfigNotFound);
+    };
+
+    let config = read_config_file(&chosen_config_path)?;
+
+    Ok((
+        config.clone(),
+        config.into_config(UiConfig::default(), cli_arg_address, cli_arg_password, false)?,
+        chosen_config_path,
+    ))
+}
+
+pub struct ConfigResult {
+    pub config: Config,
+    pub config_path: PathBuf,
+}
+
+pub fn read_config_and_theme(args: &mut Args) -> Result<ConfigResult, ConfigReadError> {
+    let config_paths = config_paths(args.config.as_deref());
+    if config_paths.is_empty() {
+        return Err(ConfigReadError::NoConfigPaths);
+    }
+
+    let Some(chosen_config_path) = find_first_existing_path(config_paths) else {
+        return Err(ConfigReadError::ConfigNotFound);
+    };
+
+    let config = read_config_file(&chosen_config_path)?;
+
+    let theme = match &config.theme {
+        Some(theme_name) => {
+            let theme_paths = theme_paths(args.theme.as_deref(), &chosen_config_path, theme_name);
+            let chosen_theme_path = find_first_existing_path(theme_paths);
+
+            if let Some(theme_path) = chosen_theme_path {
+                read_theme_file(&theme_path)?
+            } else {
+                return Err(ConfigReadError::ThemeNotFound);
+            }
+        }
+        // No theme set in the config file, this is OK, use the default theme
+        None => UiConfigFile::default(),
+    };
+
+    let theme = theme.try_into().map_err(ConfigReadError::Conversion)?;
+
+    Ok(ConfigResult {
+        config: config
+            .into_config(theme, args.address.take(), args.password.take(), false)
+            .map_err(ConfigReadError::Conversion)?,
+        config_path: chosen_config_path,
+    })
+}
+
+pub fn read_cli_config_file(path: &Path) -> Result<CliConfigFile, ConfigReadError> {
+    let file = std::fs::File::open(path)?;
+    let mut read = std::io::BufReader::new(file);
+    let mut buf = Vec::new();
+    read.read_to_end(&mut buf)?;
+
+    Ok(serde_path_to_error::deserialize(&mut ron::de::Deserializer::from_bytes(&buf)?)?)
+}
+
+pub fn read_config_file(path: &Path) -> Result<ConfigFile, ConfigReadError> {
+    let file = std::fs::File::open(path)?;
+    let mut read = std::io::BufReader::new(file);
+    let mut buf = Vec::new();
+    read.read_to_end(&mut buf)?;
+
+    Ok(serde_path_to_error::deserialize(&mut ron::de::Deserializer::from_bytes(&buf)?)?)
+}
+
+pub fn read_theme_file(path: &Path) -> Result<UiConfigFile, ConfigReadError> {
+    let file = std::fs::File::open(path)?;
+    let mut read = std::io::BufReader::new(file);
+    let mut buf = Vec::new();
+    read.read_to_end(&mut buf)?;
+
+    Ok(serde_path_to_error::deserialize(&mut ron::de::Deserializer::from_bytes(&buf)?)?)
+}
+
+pub fn find_first_existing_path(paths: Vec<PathBuf>) -> Option<PathBuf> {
+    paths.into_iter().find(|path| path.exists())
+}

--- a/src/shared/ipc/commands/mod.rs
+++ b/src/shared/ipc/commands/mod.rs
@@ -10,9 +10,9 @@ use switch_tab::SwitchTabCommand;
 use tmux::TmuxHookCommand;
 
 use super::SocketCommand;
-use crate::config::{
-    ConfigFile,
-    cli::{RemoteCmd, SetCommand},
+use crate::{
+    config::cli::{RemoteCmd, SetCommand},
+    shared::config_read::read_config_file,
 };
 
 pub(super) mod index_lrc;
@@ -53,7 +53,7 @@ impl TryFrom<&RemoteCmd> for SocketCommand {
                 )?))))
             }
             RemoteCmd::Set { command: SetCommand::Config { path } } => {
-                let file = ConfigFile::read(&PathBuf::from(&path))
+                let file = read_config_file(&PathBuf::from(&path))
                     .with_context(|| format!("Failed to open config file {path}"))?;
                 Ok(SocketCommand::Set(Box::new(SetIpcCommand::Config(file))))
             }

--- a/src/shared/ipc/commands/set.rs
+++ b/src/shared/ipc/commands/set.rs
@@ -5,7 +5,11 @@ use serde::{Deserialize, Serialize};
 use crate::{
     AppEvent,
     WorkRequest,
-    config::{Config, ConfigFile, theme::UiConfigFile},
+    config::{
+        Config,
+        ConfigFile,
+        theme::{UiConfig, UiConfigFile},
+    },
     shared::ipc::{IpcStream, SocketCommandExecute},
 };
 
@@ -28,7 +32,7 @@ impl SocketCommandExecute for SetIpcCommand {
     ) -> Result<()> {
         match self {
             SetIpcCommand::Config(config) => {
-                let config = Box::new(config.into_config(None, None, None, None, true)?);
+                let config = Box::new(config.into_config(UiConfig::default(), None, None, true)?);
                 Ok(event_tx.send(AppEvent::ConfigChanged { config, keep_old_theme: true })?)
             }
             SetIpcCommand::Theme(theme) => {

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,4 +1,5 @@
 pub mod cmp;
+pub mod config_read;
 pub mod dependencies;
 pub mod env;
 pub mod events;
@@ -15,6 +16,7 @@ pub mod macros;
 pub mod mouse_event;
 pub mod mpd_client_ext;
 pub mod mpd_query;
+pub mod paths;
 pub mod percent;
 pub mod ring_vec;
 pub mod song_ext;

--- a/src/shared/paths.rs
+++ b/src/shared/paths.rs
@@ -1,0 +1,63 @@
+use std::path::{Path, PathBuf};
+
+use crate::{config::utils::tilde_expand, shared::env::ENV};
+
+#[cfg(debug_assertions)]
+const CONFIG_NAME: &str = "config.debug.ron";
+#[cfg(not(debug_assertions))]
+const CONFIG_NAME: &str = "config.ron";
+const CRATE_NAME: &str = env!("CARGO_CRATE_NAME");
+
+pub fn home_dir() -> Option<PathBuf> {
+    ENV.var_os("HOME")
+        .and_then(|home| if home.is_empty() { None } else { Some(home) })
+        .map(PathBuf::from)
+}
+
+pub fn config_dir() -> Option<PathBuf> {
+    ENV.var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
+        .or_else(|| home_dir().map(|home| home.join(".config")))
+        .map(|p| p.join(CRATE_NAME))
+}
+
+pub fn config_paths(cli_arg_config_path: Option<&Path>) -> Vec<PathBuf> {
+    if let Some(path) = cli_arg_config_path {
+        return vec![path.to_path_buf()];
+    }
+
+    let mut result = Vec::new();
+    match config_dir() {
+        Some(config_dir) => result.push(config_dir.join(CONFIG_NAME)),
+        None => log::warn!("Could not determine configuration directory"),
+    }
+
+    if let Some(home) = home_dir() {
+        result.push(home.join(CRATE_NAME).join(CONFIG_NAME));
+    }
+
+    result
+}
+
+pub fn theme_paths(
+    cli_arg_theme: Option<&Path>,
+    config_path: &Path,
+    theme_name: &str,
+) -> Vec<PathBuf> {
+    if let Some(path) = cli_arg_theme {
+        return vec![path.to_path_buf()];
+    }
+
+    let config_dir = config_path.parent().unwrap_or_else(|| {
+        panic!("Expected config path to have parent directory. Path: '{}'", config_path.display())
+    });
+
+    vec![
+        config_dir.join("themes").join(format!("{theme_name}.ron")),
+        config_dir.join("themes").join(theme_name),
+        config_dir.join(format!("{theme_name}.ron")),
+        config_dir.join(theme_name),
+        PathBuf::from(tilde_expand(theme_name).into_owned()),
+    ]
+}

--- a/src/tests/fixtures/mod.rs
+++ b/src/tests/fixtures/mod.rs
@@ -10,7 +10,7 @@ use ratatui::{Terminal, backend::TestBackend};
 use rstest::fixture;
 
 use crate::{
-    config::{Config, ConfigFile, tabs::TabName},
+    config::{Config, tabs::TabName},
     core::scheduler::Scheduler,
     ctx::{Ctx, StickersSupport},
     mpd::{commands::Status, version::Version},
@@ -59,9 +59,7 @@ pub fn ctx(
     work_request_channel: (Sender<WorkRequest>, Receiver<WorkRequest>),
     client_request_channel: (Sender<ClientRequest>, Receiver<ClientRequest>),
 ) -> Ctx {
-    let config = ConfigFile::default()
-        .into_config(None, None, None, None, true)
-        .expect("Test default config to convert correctly");
+    let config = Config::default();
 
     let scheduler = Scheduler::new((app_event_channel.0.clone(), unbounded().0));
     let key_resolver = KeyResolver::new(&config);

--- a/src/tests/remote_ipc.rs
+++ b/src/tests/remote_ipc.rs
@@ -6,7 +6,7 @@ mod remote_ipc_tests {
     use crate::{
         AppEvent,
         WorkRequest,
-        config::{Config, ConfigFile, cli::RemoteCmd},
+        config::{Config, cli::RemoteCmd},
         shared::ipc::{
             SocketCommand,
             SocketCommandExecute,
@@ -18,9 +18,7 @@ mod remote_ipc_tests {
     fn setup_test() -> (Sender<AppEvent>, Receiver<AppEvent>, Sender<WorkRequest>, Config) {
         let (event_tx, event_rx) = channel::unbounded();
         let (work_tx, _work_rx) = channel::unbounded();
-        let config = ConfigFile::default()
-            .into_config(None, None, None, None, true)
-            .expect("Failed to create test config");
+        let config = Config::default();
         (event_tx, event_rx, work_tx, config)
     }
 


### PR DESCRIPTION
## Description

The config and theme file reading was a convoluted, half broken mess with file access being sprinkled around in the config structs themselves. This moves the file access to a separate module and makes error handling more sane. A configured theme not being found will now actually present an error to the user instead of falling back silently to the default.

Config file reading will now actually check all the paths mentioned in the docs instead of trying the first valid path (valid being the keyword here, not existing file).

And as a bonus, a tiny bit nicer error should be shown to the user now. Also added theme path to the debug info and config watcher will not be started if no config file was found anymore.

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
