### PR TITLE
feat: add --clean arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ after starting a ytdlp download
 - Added `scroll_amount` config option
 - Added `Added()` and `LastModified()` song properties
 - Added `NotExact` and `NotRegex` search options
+- Added `--clean` aragument
 
 ### Changed
 

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -16,6 +16,9 @@ pub struct Args {
     pub config: Option<PathBuf>,
     #[arg(short, long, value_hint = ValueHint::AnyPath, value_name = "FILE")]
     pub theme: Option<PathBuf>,
+    #[arg(long, exclusive = true)]
+    /// Skip user config and start with defaults, must be the only argument
+    pub clean: bool,
     #[command(subcommand)]
     pub command: Option<Command>,
     #[arg(short, long)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -255,6 +255,10 @@ impl Config {
             )
             .expect("Default config should always convert")
     }
+
+    pub fn default_with_album_art_check() -> Result<Config> {
+        ConfigFile::default().into_config(UiConfig::default(), None, None, false)
+    }
 }
 
 impl ConfigFile {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use crate::{
     shared::{
         config_read::{
             ConfigReadError,
+            ConfigResult,
             find_first_existing_path,
             read_cli_config,
             read_config_and_theme,
@@ -334,8 +335,7 @@ fn main() -> Result<()> {
                 .name("dependency_check".to_string())
                 .spawn(|| DEPENDENCIES.iter().for_each(|d| d.log()))?;
 
-            let (config, config_path) = read_config_and_theme(&mut args)
-                .map(|result| (result.config, Some(result.config_path)))
+            let ConfigResult { config, config_path } = read_config_and_theme(&mut args)
                 .unwrap_or_else(|err| {
                     if let ConfigReadError::ConfigNotFound = err {
                         // Config not being found is not considered an error. But the user should
@@ -363,7 +363,7 @@ fn main() -> Result<()> {
                         );
                     }
 
-                    (Config::default_cli(&mut args), None)
+                    ConfigResult { config: Config::default_cli(&mut args), config_path: None }
                 });
 
             config.validate()?;

--- a/src/shared/config_read.rs
+++ b/src/shared/config_read.rs
@@ -78,10 +78,17 @@ pub fn read_config_for_debuginfo(
 
 pub struct ConfigResult {
     pub config: Config,
-    pub config_path: PathBuf,
+    pub config_path: Option<PathBuf>,
 }
 
 pub fn read_config_and_theme(args: &mut Args) -> Result<ConfigResult, ConfigReadError> {
+    if args.clean {
+        return Ok(ConfigResult {
+            config: Config::default_with_album_art_check()?,
+            config_path: None,
+        });
+    }
+
     let config_paths = config_paths(args.config.as_deref());
     if config_paths.is_empty() {
         return Err(ConfigReadError::NoConfigPaths);
@@ -114,7 +121,7 @@ pub fn read_config_and_theme(args: &mut Args) -> Result<ConfigResult, ConfigRead
         config: config
             .into_config(theme, args.address.take(), args.password.take(), false)
             .map_err(ConfigReadError::Conversion)?,
-        config_path: chosen_config_path,
+        config_path: Some(chosen_config_path),
     })
 }
 

--- a/src/shared/duration_format.rs
+++ b/src/shared/duration_format.rs
@@ -170,6 +170,7 @@ impl DurationFormat {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Description

Fairly frequently I find myself needing to start with default config and I hack around it by using `--config` with an invalid path. This adds `--clean` which starts with the default theme directly without warnings.

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
