### PR TITLE
fix: ellipsis in queue not working correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ should fix cases with `cache_dir` being set inside MPD's music directory
 - `ScanStatus` not working
 - A harmless error about stickers not being supported will no longer show up when previewing a song
 in a browser pane for the first time will no longer show up
+- Ellipsis in Queue now properly works on the fully constructed property instead of on its parts
 
 ### Removed
 


### PR DESCRIPTION
## Description

The ellipsis was being done for every property in the chain instead of once at the end which resulted in an incorrect behavior. Should hopefully correctly handle unicode too.

### Related issues

Fixes https://github.com/mierak/rmpc/issues/837

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
