### PR TITLE
fix: ueberzug image backend failing on first start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ should fix cases with `cache_dir` being set inside MPD's music directory
 in a browser pane for the first time will no longer show up
 - Ellipsis in Queue now properly works on the fully constructed property instead of on its parts
 - Fixed the `Block` image backend being cut off a bit
+- ueberzug image backend failing on first start
 
 ### Removed
 

--- a/src/ui/image/ueberzug.rs
+++ b/src/ui/image/ueberzug.rs
@@ -115,6 +115,7 @@ impl Ueberzug {
             .join(format!("ueberzug-{}.pid", std::process::id()))
             .to_string_lossy()
             .into_owned();
+        let _ = std::fs::create_dir_all(std::env::temp_dir().join("rmpc"));
 
         let mut daemon =
             UeberzugDaemon { pid: None, pid_file: pid_file_path, ueberzug_process: None, layer };


### PR DESCRIPTION
## Description

### Related issues

fixes https://github.com/mierak/rmpc/issues/844

### Checklist

- [ ] All tests passed
- [ ] Code has been formatted with rustfmt (nightly)
- [ ] Code has been checked with clippy (stable)
- [ ] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [ ] Changelog has been updated
