### PR TITLE
Lyrics tweaks: bias above centre rather than below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ configured with the new `album_art.order` option
 instead of just the first one. When theme file is not found it will now correctly present an error
 instead of silently falling back to the default theme.
 - Improved rendering of the `Block` backend, it should now be less noisy
+- Synchronized lyrics now prefer showing more future lyrics rather than more past lyrics
 
 ### Fixed
 

--- a/src/ui/panes/lyrics.rs
+++ b/src/ui/panes/lyrics.rs
@@ -72,7 +72,6 @@ impl Pane for LyricsPane {
 
         let timestamp = ctx.config.theme.lyrics.timestamp;
 
-        let mut current_area = middle_row as usize;
         let Some(current_line) = lrc.lines.get(current_line_idx) else {
             return Ok(());
         };
@@ -81,7 +80,15 @@ impl Pane for LyricsPane {
         } else {
             &current_line.content
         };
-        for l in textwrap::wrap(formatted_line, area.width as usize) {
+
+        let wrapped_lines = textwrap::wrap(formatted_line, area.width as usize);
+        let wrapped_lines_length = wrapped_lines.len();
+
+        let active_lyric_start_row =
+            (middle_row as usize).saturating_sub(wrapped_lines_length.saturating_sub(1));
+        let mut current_area = active_lyric_start_row;
+
+        for l in wrapped_lines {
             let Some(area) = areas.get(current_area) else {
                 break;
             };
@@ -91,7 +98,7 @@ impl Pane for LyricsPane {
         }
 
         let mut before_lyrics_cursor = current_line_idx;
-        let mut before_area_cursor = middle_row as usize;
+        let mut before_area_cursor = active_lyric_start_row as usize;
         while before_lyrics_cursor > 0 && before_area_cursor > 0 {
             before_lyrics_cursor -= 1;
             let Some(line) = lrc.lines.get(before_lyrics_cursor) else {


### PR DESCRIPTION
Warning: I'm a rust beginner.

## Description

Motivation: I like a very short (3-line) lyrics pane, and when lyrics break to two lines, I was seeing the line before and the current two lines, and nothing after. I would rather see the current two lines and the line after. I think most would agree that seeing more future lyrics is more useful than seeing more past lyrics.

Changes:

1. Adjust calculation for what the "middle line" is, so that it's biased to being above centre rather than below centre. This fixes the issue when there's an even height (easiest to visualize with height 2) and lyric lines do not break to multiple lines: you now always see the current lyric above centre and the next lyric below centre.
2. For when the lyric breaks to multiple lines, *end* it on the "middle line" rather than *starting* it there. This is done by subtracting "wrapped-line-count - 1" from the "middle line" index, and then basing drawing operations on that rather than directly on "middle line". This affects current/"future" lyrics drawing and "previous" lyrics drawing.

Tested with various combinations of pane heights and single/multiple-line lyric combinations.

### Related issues

[Brief exchange on discord](https://discord.com/channels/1392275124962594837/1392275125419900940/1466738273828343839)

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [ ] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
