### PR TITLE
Add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 **.ron
 !assets/**.ron
+# Nix
+/.direnv
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,122 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "naersk",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1752475459,
+        "narHash": "sha256-z6QEu4ZFuHiqdOPbYss4/Q8B0BFhacR8ts6jO/F/aOU=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "bf0d6f70f4c9a9cf8845f992105652173f4b617f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "fenix": "fenix",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769799857,
+        "narHash": "sha256-88IFXZ7Sa1vxbz5pty0Io5qEaMQMMUPMonLa3Ls/ss4=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "9d4ed44d8b8cecdceb1d6fd76e74123d90ae6339",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770141374,
+        "narHash": "sha256-yD4K/vRHPwXbJf5CK3JkptBA6nFWUKNX/jlFp2eKEQc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "41965737c1797c1d83cfb0b644ed0840a6220bd1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752428706,
+        "narHash": "sha256-EJcdxw3aXfP8Ex1Nm3s0awyH9egQvB2Gu+QEnJn2Sfg=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "591e3b7624be97e4443ea7b5542c191311aa141d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,68 @@
+{
+  description = "A modern, configurable, terminal based MPD Client with album art support via various terminal image protocols";
+
+  inputs = {
+    # For packages we pull.
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
+    # So we don't have to manually define things for each os/arch combination.
+    flake-utils.url = "github:numtide/flake-utils";
+    # To cache rust crates.
+    naersk = {
+      url = "github:nix-community/naersk";
+      # Use the same nixpkgs that we've defined above.
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    naersk,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+        naerskLib = pkgs.callPackage naersk {};
+      in {
+        # Rust package, which can be run with `nix run github:mierak/rmpc`
+        # (or without the "github:..." if you're currently in this repository)
+        packages.default = naerskLib.buildPackage {
+          src = ./.;
+          # Since the nix build is isolated, vergen won't have access to the git repository,
+          # so we'll have to set the environment variable ourselves.
+          #
+          # We can't actually (easily) get the equivalent of `git describe` unfortunately,
+          # see https://github.com/NixOS/nix/issues/7201
+          VERGEN_GIT_DESCRIBE = self.shortRev or self.dirtyShortRev;
+
+          # Additional files to be installed if the package is being, well, installed.
+          nativeBuildInputs = with pkgs; [installShellFiles];
+          postInstall = ''
+            installManPage target/man/rmpc.1
+
+            installShellCompletion --cmd rmpc \
+              --bash target/completions/rmpc.bash \
+              --fish target/completions/rmpc.fish \
+              --zsh target/completions/_rmpc
+
+            install -m 444 -D assets/rmpc.desktop $out/share/applications/rmpc.desktop
+          '';
+        };
+
+        # Development shell, initialized either with `nix develop` or using direnv
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            cargo
+            rustc
+            rustfmt
+            clippy
+            rust-analyzer
+          ];
+
+          # Needed so programs like rust-analyzer can find the rust source code.
+          env.RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Description

This flake mainly serves the purpose of allowing people to install the latest git version of rmpc
easily, with having things like shell completions installed by default, as well as providing
another method to try it out without installing.

In addition, it also provides a development shell, so that the rust toolchain is available
immediately on nix-enabled systems. If rmpc ever adds any system dependencies in the future, these
can be added too.

As I understand how intimidating nix can be at first, I made sure to add lots of comments to explain
what is going on, as well as keeping the flake relatively simple, not doing anything complicated like
cross-compilation or anything that will need active maintenance. The only thing is updating the rust
toolchain to the latest version if the MSRV goes above what nixpkgs had at this time (1.92), which
can be done easily with `nix flake update`.

On top of that, you can always mention me if any issues ever arise.

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [ ] Changelog has been updated
