### PR TITLE
feat: support music.youtube.com URLs

### DIFF
--- a/src/shared/ytdlp/ytdlp_item.rs
+++ b/src/shared/ytdlp/ytdlp_item.rs
@@ -118,7 +118,7 @@ impl FromStr for YtDlpContent {
         };
 
         match host.strip_prefix("www.").unwrap_or(host) {
-            "youtube.com" => {
+            "youtube.com" | "music.youtube.com" => {
                 let segments = url
                     .path_segments()
                     .ok_or_else(|| YtDlpParseError::invalid_yt(s, "cannot-be-a-base"))?


### PR DESCRIPTION
  ## Summary
  - Users can now add YouTube Music playlists and videos directly using `music.youtube.com` URLs
  - Previously, these URLs would return an "Unsupported host" error
  - The underlying `yt-dlp` tool already supports `music.youtube.com` URLs, so this was just a
  parsing limitation in rmpc

  ## Context
  When users browse YouTube Music and copy a URL to add via `rmpc addyt`, they get URLs like:
  - `https://music.youtube.com/playlist?list=...`
  - `https://music.youtube.com/watch?v=...`

  These would fail with "Unsupported host" unless the user manually removed the "music" subdomain.

  ## Changes
  - Modified URL parsing in `src/shared/ytdlp/ytdlp_item.rs` to accept `music.youtube.com`
  alongside `youtube.com`

  ## Test plan
  - [x] All existing tests pass (952 tests)
  - [x] Clippy shows no warnings
  - [x] Code formatted with `cargo +nightly fmt`

  Manual verification (TODO for reviewer/user):
  - [ ] Test adding a YouTube Music playlist: `rmpc addyt
  'https://music.youtube.com/playlist?list=...'`
  - [ ] Test adding a YouTube Music video: `rmpc addyt 'https://music.youtube.com/watch?v=...'`
  - [ ] Verify existing YouTube URLs still work