### PR TITLE
feat: copy to clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 keybinds if they contained either `{` or `}`. You will now need to escape these by doubling them up: `{{` and `}}`.
 - `scroll_speed` to `song_table_format`
 - `album_art.custom_loader` to allow for more flexibility when choosing the album art image
+- added `CopyToClipboard()` action
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
+ "base64",
  "bitflags 2.10.0",
  "crossterm_winapi",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ dialoguer = { version = "0.12.0", default-features = false }
 anyhow = "1.0.100"
 bon = "3.8.2"
 base64 = "0.22.1"
-crossterm = { version = "0.29.0", features = ["serde"] }
+crossterm = { version = "0.29.0", features = ["serde", "osc52"] }
 image = "0.25.9"
 ratatui = { version = "0.30.0", features = ["all-widgets"] }
 strum = { workspace = true }

--- a/assets/example_config.ron
+++ b/assets/example_config.ron
@@ -113,6 +113,11 @@
             "<C-s>s":     Save(kind: Modal(all: false, duplicates_strategy: Ask)),
             "<C-s>a":     Save(kind: Modal(all: true, duplicates_strategy: Ask)),
             "r":          Rate(),
+            "Y":          CopyToClipboard(kind: Modal([
+                              ("Displayed value", (content: DisplayedValue, all: false)),
+                              ("Artist - Title", (content: Metadata([(kind: Property(Artist)), (kind: Text(" - ")), (kind: Property(Title))]), all: false)),
+                          ])),
+            "y":          CopyToClipboard(kind: Content(content: DisplayedValue, all : false)),
         },
         queue: {
             "d":          Delete,

--- a/src/config/keys/mod.rs
+++ b/src/config/keys/mod.rs
@@ -17,8 +17,19 @@ use actions::{CommonActionFile, GlobalActionFile, QueueActionsFile};
 pub use key::Key;
 use serde::{Deserialize, Serialize};
 
+#[cfg(debug_assertions)]
+#[cfg(not(debug_assertions))]
+#[cfg(debug_assertions)]
+use crate::config::keys::actions::CopyContentsFile;
 use crate::config::keys::{
-    actions::{DuplicateStrategy, RateKind, SaveKind},
+    actions::{
+        CopyContentFile,
+        CopyContentsFile,
+        CopyContentsKindFile,
+        DuplicateStrategy,
+        RateKind,
+        SaveKind,
+    },
     key::KeySequence,
 };
 
@@ -138,6 +149,8 @@ impl Default for KeyConfigFile {
             (s().char('N'),                       C::PreviousResult),
             (s().char(' '),                       C::Select),
             (s().char(' ').ctrl(),                C::InvertSelection),
+            (s().char('Y'),                       C::CopyToClipboard { kind: CopyContentsKindFile::default() }),
+            (s().char('y'),                       C::CopyToClipboard { kind: CopyContentsKindFile::Content(CopyContentsFile { all: false, content: CopyContentFile::DisplayedValue })}),
             (s().char('a'),                       C::Add),
             (s().char('A'),                       C::AddAll),
             (s().char('D'),                       C::Delete),

--- a/src/config/theme/properties.rs
+++ b/src/config/theme/properties.rs
@@ -240,6 +240,20 @@ pub enum PropertyKindOrText<T> {
     Transform(Transform<T>),
 }
 
+impl<T: Clone> PropertyFile<T> {
+    pub fn text(value: impl Into<String>) -> Self {
+        Self { kind: PropertyKindFileOrText::Text(value.into()), style: None, default: None }
+    }
+
+    pub fn sticker(value: impl Into<String>) -> Self {
+        Self { kind: PropertyKindFileOrText::Sticker(value.into()), style: None, default: None }
+    }
+
+    pub fn property(value: T) -> Self {
+        Self { kind: PropertyKindFileOrText::Property(value), style: None, default: None }
+    }
+}
+
 impl<T: Clone> PropertyKindOrText<T> {
     pub fn contains_stickers(&self) -> bool {
         match self {

--- a/src/shared/clipboard.rs
+++ b/src/shared/clipboard.rs
@@ -1,0 +1,29 @@
+use crossterm::{clipboard::CopyToClipboard, execute};
+
+use crate::shared::{
+    macros::{status_error, status_info},
+    terminal::TERMINAL,
+};
+
+pub struct Clipboard<T> {
+    content: T,
+}
+
+impl<T: AsRef<[u8]>> From<T> for Clipboard<T> {
+    fn from(content: T) -> Self {
+        Self { content }
+    }
+}
+
+impl<T: AsRef<[u8]>> Clipboard<T> {
+    pub fn write(self) -> std::io::Result<()> {
+        execute!(TERMINAL.writer(), CopyToClipboard::to_clipboard_from(self.content))
+    }
+
+    pub fn write_with_status(self) {
+        match self.write() {
+            Ok(()) => status_info!("Copied to clipboard"),
+            Err(err) => status_error!("Failed to copy to clipboard: {err}"),
+        }
+    }
+}

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,5 +1,6 @@
 pub mod album_art;
 pub mod args;
+pub mod clipboard;
 pub mod cmp;
 pub mod config_read;
 pub mod dependencies;

--- a/src/shared/ytdlp/manager.rs
+++ b/src/shared/ytdlp/manager.rs
@@ -21,6 +21,12 @@ use crate::{
 #[derive(Debug, derive_more::Deref, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub struct DownloadId(Id);
 
+impl std::fmt::Display for DownloadId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl DownloadId {
     pub fn new() -> Self {
         Self(id::new())

--- a/src/ui/dirstack/mod.rs
+++ b/src/ui/dirstack/mod.rs
@@ -40,6 +40,7 @@ pub trait DirStackItem {
     fn to_list_item_simple<'a>(&self, ctx: &Ctx) -> ListItem<'a> {
         self.to_list_item(ctx, false, false, None)
     }
+    fn format(&self, format: &[Property<SongProperty>], ctx: &Ctx) -> String;
 }
 
 impl DirStackItem for DirOrSong {
@@ -126,6 +127,13 @@ impl DirStackItem for DirOrSong {
             }
         }
     }
+
+    fn format(&self, format: &[Property<SongProperty>], ctx: &Ctx) -> String {
+        match self {
+            DirOrSong::Dir { name, .. } => name.clone(),
+            DirOrSong::Song(s) => <Song as DirStackItem>::format(s, format, ctx),
+        }
+    }
 }
 
 impl DirStackItem for Song {
@@ -191,6 +199,21 @@ impl DirStackItem for Song {
         } else {
             ListItem::from(value)
         }
+    }
+
+    fn format(&self, format: &[Property<SongProperty>], ctx: &Ctx) -> String {
+        format
+            .iter()
+            .map(|prop| {
+                prop.as_string(
+                    Some(self),
+                    &ctx.config.theme.format_tag_separator,
+                    ctx.config.theme.multiple_tag_resolution_strategy,
+                    ctx,
+                )
+                .unwrap_or_default()
+            })
+            .join(" ")
     }
 }
 
@@ -275,5 +298,9 @@ impl DirStackItem for String {
         } else {
             ListItem::new(Line::from(vec![marker_span, Span::from(self.clone())]))
         }
+    }
+
+    fn format(&self, _format: &[Property<SongProperty>], _ctx: &Ctx) -> String {
+        self.clone()
     }
 }

--- a/src/ui/modals/downloads.rs
+++ b/src/ui/modals/downloads.rs
@@ -352,4 +352,8 @@ impl DirStackItem for DownloadId {
     ) -> ListItem<'a> {
         ListItem::new("")
     }
+
+    fn format(&self, _format: &[Property<SongProperty>], _ctx: &Ctx) -> String {
+        self.to_string()
+    }
 }


### PR DESCRIPTION
## Description

Allows copying items to the clipboard via OSC52

### Related issues

fixes: https://github.com/mierak/rmpc/issues/805
docs pr: https://github.com/rmpc-org/rmpc-org.github.io/pull/37

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
