### PR TITLE
fix: remove extra spaces in copy to clipboard

### DIFF
--- a/src/ui/browser.rs
+++ b/src/ui/browser.rs
@@ -502,7 +502,7 @@ where
                     CopyContent::Metadata(props) => props,
                 };
 
-                let content = items.map(|(_, item)| item.format(format, ctx)).join("\n");
+                let content = items.map(|(_, item)| item.format(format, "", ctx)).join("\n");
 
                 Clipboard::from(content).write_with_status();
             }
@@ -519,6 +519,8 @@ where
                     ctx.config.theme.browser_song_format.0.clone(),
                     items,
                     all_items,
+                    "",
+                    "",
                     ctx,
                 );
 

--- a/src/ui/dirstack/mod.rs
+++ b/src/ui/dirstack/mod.rs
@@ -40,7 +40,7 @@ pub trait DirStackItem {
     fn to_list_item_simple<'a>(&self, ctx: &Ctx) -> ListItem<'a> {
         self.to_list_item(ctx, false, false, None)
     }
-    fn format(&self, format: &[Property<SongProperty>], ctx: &Ctx) -> String;
+    fn format(&self, format: &[Property<SongProperty>], sep: &str, ctx: &Ctx) -> String;
 }
 
 impl DirStackItem for DirOrSong {
@@ -128,10 +128,10 @@ impl DirStackItem for DirOrSong {
         }
     }
 
-    fn format(&self, format: &[Property<SongProperty>], ctx: &Ctx) -> String {
+    fn format(&self, format: &[Property<SongProperty>], sep: &str, ctx: &Ctx) -> String {
         match self {
             DirOrSong::Dir { name, .. } => name.clone(),
-            DirOrSong::Song(s) => <Song as DirStackItem>::format(s, format, ctx),
+            DirOrSong::Song(s) => <Song as DirStackItem>::format(s, format, sep, ctx),
         }
     }
 }
@@ -201,7 +201,7 @@ impl DirStackItem for Song {
         }
     }
 
-    fn format(&self, format: &[Property<SongProperty>], ctx: &Ctx) -> String {
+    fn format(&self, format: &[Property<SongProperty>], sep: &str, ctx: &Ctx) -> String {
         format
             .iter()
             .map(|prop| {
@@ -213,7 +213,7 @@ impl DirStackItem for Song {
                 )
                 .unwrap_or_default()
             })
-            .join(" ")
+            .join(sep)
     }
 }
 
@@ -300,7 +300,7 @@ impl DirStackItem for String {
         }
     }
 
-    fn format(&self, _format: &[Property<SongProperty>], _ctx: &Ctx) -> String {
+    fn format(&self, _format: &[Property<SongProperty>], _sep: &str, _ctx: &Ctx) -> String {
         self.clone()
     }
 }

--- a/src/ui/modals/downloads.rs
+++ b/src/ui/modals/downloads.rs
@@ -353,7 +353,7 @@ impl DirStackItem for DownloadId {
         ListItem::new("")
     }
 
-    fn format(&self, _format: &[Property<SongProperty>], _ctx: &Ctx) -> String {
+    fn format(&self, _format: &[Property<SongProperty>], _sep: &str, _ctx: &Ctx) -> String {
         self.to_string()
     }
 }

--- a/src/ui/modals/menu/mod.rs
+++ b/src/ui/modals/menu/mod.rs
@@ -647,6 +647,8 @@ pub fn create_copy_to_clipboard_modal<'a, I>(
     column_formats: Vec<Property<SongProperty>>,
     items: Vec<I>,
     all_items: Vec<I>,
+    display_value_sep: &'static str,
+    sep: &'static str,
     ctx: &Ctx,
 ) -> MenuModal<'a>
 where
@@ -667,15 +669,15 @@ where
                     return Ok(());
                 };
 
-                let format = match &opt.1.content {
-                    CopyContent::DisplayedValue => &column_formats,
-                    CopyContent::Metadata(props) => props,
+                let (sep, format) = match &opt.1.content {
+                    CopyContent::DisplayedValue => (display_value_sep, &column_formats),
+                    CopyContent::Metadata(props) => (sep, props),
                 };
 
                 let items = if opt.1.all { all_items } else { items };
                 let content = items
                     .into_iter()
-                    .map(|song| <I as DirStackItem>::format(&song, format, ctx))
+                    .map(|song| <I as DirStackItem>::format(&song, format, sep, ctx))
                     .join("\n");
 
                 Clipboard::from(content).write_with_status();

--- a/src/ui/panes/queue.rs
+++ b/src/ui/panes/queue.rs
@@ -1001,13 +1001,13 @@ impl Pane for QueuePane {
                 }
                 CommonAction::CopyToClipboard { kind: CopyContentsKind::Content(content) } => {
                     let items = self.items(content.all);
-                    let format = match &content.content {
-                        CopyContent::DisplayedValue => &self.column_formats,
-                        CopyContent::Metadata(props) => props,
+                    let (sep, format) = match &content.content {
+                        CopyContent::DisplayedValue => (" ", &self.column_formats),
+                        CopyContent::Metadata(props) => ("", props),
                     };
 
                     let content = items
-                        .map(|(_, song)| <Song as DirStackItem>::format(song, format, ctx))
+                        .map(|(_, song)| <Song as DirStackItem>::format(song, format, sep, ctx))
                         .join("\n");
 
                     Clipboard::from(content).write_with_status();
@@ -1027,6 +1027,8 @@ impl Pane for QueuePane {
                         column_formats,
                         items,
                         all_items,
+                        " ",
+                        "",
                         ctx,
                     );
 

--- a/src/ui/panes/search/mod.rs
+++ b/src/ui/panes/search/mod.rs
@@ -647,7 +647,7 @@ impl SearchPane {
                     };
 
                     let content = items
-                        .map(|(_, item)| <Song as DirStackItem>::format(item, format, ctx))
+                        .map(|(_, item)| <Song as DirStackItem>::format(item, format, "", ctx))
                         .join("\n");
 
                     Clipboard::from(content).write_with_status();
@@ -665,6 +665,8 @@ impl SearchPane {
                         ctx.config.theme.browser_song_format.0.clone(),
                         items,
                         all_items,
+                        "",
+                        "",
                         ctx,
                     );
 


### PR DESCRIPTION
## Description

### Related issues

fixes https://github.com/mierak/rmpc/issues/888

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
