### PR TITLE
fix: preview_metadata_group_style not workin in search pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ keybinds if they contained either `{` or `}`. You will now need to escape these 
 keybinds
 - Fixed a benign error when deleting items from the queue really fast
 - Attempt to fix sync issues with cava visualiser
+- `preview_metadata_group_style` not being applied in the search pane
 
 
 ## [0.11.0] - 2026-02-01

--- a/rmpc/src/ui/panes/search/mod.rs
+++ b/rmpc/src/ui/panes/search/mod.rs
@@ -5,7 +5,6 @@ use enum_map::EnumMap;
 use itertools::Itertools;
 use ratatui::{
     layout::{Constraint, Layout, Rect},
-    style::Stylize,
     text::Span,
     widgets::{Block, Borders, List, ListItem, ListState, Padding},
 };
@@ -1087,7 +1086,11 @@ impl Pane for SearchPane {
                     let mut result = Vec::new();
                     for group in preview {
                         if let Some(name) = group.name {
-                            result.push(ListItem::new(name).yellow().bold());
+                            let mut item = ListItem::new(name);
+                            if let Some(style) = group.header_style {
+                                item = item.style(style);
+                            }
+                            result.push(item);
                         }
                         result.extend(group.items.clone());
                         result.push(ListItem::new(Span::raw("")));


### PR DESCRIPTION
## Description

### Related issues

fixes: https://github.com/mierak/rmpc/issues/896

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
