### PR TITLE
flake: avoid naersk dummy-src lint failure with strict unused_crate_d…

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,9 @@
         # (or without the "github:..." if you're currently in this repository)
         packages.default = naerskLib.buildPackage {
           src = ./.;
+          # Avoid naersk's dummy dependency derivation; it conflicts with
+          # workspace-level `unused_crate_dependencies = "deny"` lints.
+          singleStep = true;
           # Since the nix build is isolated, vergen won't have access to the git repository,
           # so we'll have to set the environment variable ourselves.
           #


### PR DESCRIPTION
## Summary
Fix flake builds that fail under the current workspace lint policy by disabling naersk's two-step dummy dependency build.

This PR sets `singleStep = true` in `flake.nix` package build.

## Reproduction (before this change)
```bash
nix build .#default
```

Failure:

- rust-workspace-deps-unknown fails
- rmpc-mpd reports extern crate ... is unused
- lint source: workspace sets unused_crate_dependencies = "deny"

## Root cause

naersk default mode builds an intermediate dummy-src dependency derivation.
That stub source does not reflect real crate usage, so strict unused_crate_dependencies linting
triggers false-positive failures during the dependency phase.

## Fix

In flake.nix:

- add singleStep = true; to naerskLib.buildPackage { ... }

This skips the intermediate dummy dependency derivation and builds directly from real sources,
preserving strict linting while making flake builds pass.

## Validation

Commands executed successfully after this change:

```bash
nix flake metadata
nix build .#default --print-build-logs
nix shell .#default -c rmpc version
nix shell .#default -c rmpc --help
nix develop -c cargo check --workspace
nix develop -c cargo test --workspace
nix develop -c cargo clippy --workspace --all-targets -- -D warnings
```

Packaging artifacts present in result/share:

- applications/rmpc.desktop
- man/man1/rmpc.1.gz
- bash-completion/completions/rmpc.bash
- fish/vendor_completions.d/rmpc.fish
- zsh/site-functions/_rmpc

## Notes

- This change is minimal and scoped to flake packaging behavior.
- No Rust source changes were required.