### PR TITLE
feat(rmpcd): log externally ran commands

### DIFF
--- a/rmpcd/src/lua/lualib/process.rs
+++ b/rmpcd/src/lua/lualib/process.rs
@@ -1,35 +1,38 @@
 use mlua::{Lua, Table};
-use tracing::error;
+use tracing::{debug, error};
 
 pub fn create(lua: &Lua) -> mlua::Result<Table> {
     let tbl = lua.create_table()?;
 
     let spawn_process = lua.create_async_function(
         async |_, cmd: Vec<String>| -> mlua::Result<(Option<u32>, Option<String>)> {
-            let Some(first) = cmd.first().cloned() else {
+            let Some((program, args)) = cmd.split_first() else {
                 return Ok((None, Some("No command provided".to_string())));
             };
 
-            let mut child = tokio::process::Command::new(&first)
-                .args(cmd[1..].iter())
+            debug!(program = %program, args = ?args, "Running command");
+
+            let mut child = tokio::process::Command::new(program)
+                .args(args)
                 .kill_on_drop(true)
                 .spawn()
                 .map_err(mlua::Error::external)?;
             let pid = child.id();
 
+            let program = program.clone();
             tokio::task::spawn(async move {
                 match child.wait().await {
                     Ok(status) => {
                         if !status.success() {
                             error!(
                                 status = %status,
-                                program = %first,
+                                program = %program,
                                 "Process exited with non-zero status"
                             );
                         }
                     }
                     Err(err) => {
-                        error!(err = ?err, program = %first, "Failed to wait on child process");
+                        error!(err = ?err, program = %program, "Failed to wait on child process");
                     }
                 }
             });


### PR DESCRIPTION
## Description

- Log (in `DEBUG` level) external commands ran by `rmpcd` plugins
- Also refactor a bit to make use of [`split_first`](https://doc.rust-lang.org/stable/std/primitive.slice.html#method.split_first)

### Related issues

### Checklist

- [ ] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [ ] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [ ] Changelog has been updated
