### PR TITLE
chore(flake): refactor, add rmpcd package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,24 +1,17 @@
 {
   "nodes": {
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "naersk",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
+    "crane": {
       "locked": {
-        "lastModified": 1752475459,
-        "narHash": "sha256-z6QEu4ZFuHiqdOPbYss4/Q8B0BFhacR8ts6jO/F/aOU=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "bf0d6f70f4c9a9cf8845f992105652173f4b617f",
+        "lastModified": 1773189535,
+        "narHash": "sha256-E1G/Or6MWeP+L6mpQ0iTFLpzSzlpGrITfU2220Gq47g=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "6fa2fb4cf4a89ba49fc9dd5a3eb6cde99d388269",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
+        "owner": "ipetkov",
+        "repo": "crane",
         "type": "github"
       }
     },
@@ -40,27 +33,6 @@
         "type": "github"
       }
     },
-    "naersk": {
-      "inputs": {
-        "fenix": "fenix",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769799857,
-        "narHash": "sha256-88IFXZ7Sa1vxbz5pty0Io5qEaMQMMUPMonLa3Ls/ss4=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "9d4ed44d8b8cecdceb1d6fd76e74123d90ae6339",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1770141374,
@@ -79,26 +51,9 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
-        "naersk": "naersk",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1752428706,
-        "narHash": "sha256-EJcdxw3aXfP8Ex1Nm3s0awyH9egQvB2Gu+QEnJn2Sfg=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "591e3b7624be97e4443ea7b5542c191311aa141d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,65 +7,147 @@
     # So we don't have to manually define things for each os/arch combination.
     flake-utils.url = "github:numtide/flake-utils";
     # To cache rust crates.
-    naersk = {
-      url = "github:nix-community/naersk";
-      # Use the same nixpkgs that we've defined above.
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
   };
 
+  # NOTE: much of the following is taken from https://crane.dev/examples/quick-start-workspace.html.
   outputs = {
     self,
     nixpkgs,
     flake-utils,
-    naersk,
+    crane,
   }:
     flake-utils.lib.eachDefaultSystem (
       system: let
         pkgs = nixpkgs.legacyPackages.${system};
-        naerskLib = pkgs.callPackage naersk {};
+        lib = pkgs.lib;
+        craneLib = crane.mkLib pkgs;
+        # Only includes rust/cargo files in the build source, meaning that rebuilds won't happen for unrelated files.
+        src = craneLib.cleanCargoSource ./.;
+
+        # Common arguments shared across workspace dependency and package builds
+        commonArgs = {
+          inherit src;
+          # Doesn't seem to be documented, but it was used in the crane quickstart.
+          strictDeps = true;
+        };
+
+        # Build dependencies of the entire workspace, so that they can be re-used.
+        cargoArtifacts = craneLib.buildDepsOnly (commonArgs
+          // {
+            # To suppress warnings when building the workspace dependencies, see
+            # https://github.com/ipetkov/crane/issues/281#issuecomment-1487845029
+            # for other available workarounds.
+            pname = "rmpc-workspace";
+            version = "0.0.0";
+          });
+
+        # Common attributes shared between packages
+        individualCrateArgs = pname:
+          commonArgs
+          // {
+            # Use the shared built/cached workspace dependencies.
+            inherit cargoArtifacts;
+
+            # Sets pname and version of the package from keys extracted from the Cargo.toml
+            inherit (craneLib.crateNameFromCargoToml {cargoToml = ./${pname}/Cargo.toml;}) version pname;
+
+            # Build the specified package
+            cargoExtraArgs = "-p ${pname}";
+          };
+
+        # Helper function to add files to the build source based on their file extension.
+        workspace.root = ./.;
+        sourcesWithExt = ext: lib.fileset.fileFilter (file: file.hasExt ext) workspace.root;
+
+        # Main rust package, which can be run with `nix run github:mierak/rmpc`
+        # (or just `nix run` if you're currently in this repository)
+        rmpc = craneLib.buildPackage (
+          individualCrateArgs "rmpc"
+          # This "//" syntax just merges the two sets, preferring the values on the right-side set.
+          // {
+            # A little more complicated source, as non-rust/cargo files are needed for the
+            # package/build.
+            src = lib.fileset.toSource {
+              inherit (workspace) root;
+              fileset = lib.fileset.unions [
+                # Will handle all rust/cargo related files.
+                (craneLib.fileset.commonCargoSources workspace.root)
+                # Ron files sourced for some commands.
+                (sourcesWithExt "ron")
+                # Default cover art.
+                (sourcesWithExt "jpg")
+                # Desktop file.
+                (sourcesWithExt "desktop")
+              ];
+            };
+
+            # Since the nix build is isolated, vergen won't have access to the git repository,
+            # so we'll have to set the environment variable ourselves.
+            #
+            # We can't actually (easily) get the equivalent of `git describe` unfortunately,
+            # see https://github.com/NixOS/nix/issues/7201
+            VERGEN_GIT_DESCRIBE = self.shortRev or self.dirtyShortRev;
+
+            # Additional files to be installed if the package is being, well, installed.
+            nativeBuildInputs = with pkgs; [installShellFiles];
+            postInstall = ''
+              installManPage target/man/rmpc.1
+
+              installShellCompletion --cmd rmpc \
+                --bash target/completions/rmpc.bash \
+                --fish target/completions/rmpc.fish \
+                --zsh target/completions/_rmpc
+
+              install -m 444 -D assets/rmpc.desktop $out/share/applications/rmpc.desktop
+            '';
+          }
+        );
+
+        # Can be run with `nix run github:mierak/rmpc#rmpcd` (or similar to above, instead run
+        # `nix run .#rmpcd` if you're currently in this repository)
+        rmpcd = craneLib.buildPackage (individualCrateArgs "rmpcd"
+          // {
+            # Like the rmpc package, we need to add extra files to the source.
+            src = lib.fileset.toSource {
+              inherit (workspace) root;
+              fileset = lib.fileset.unions [
+                # Will handle all rust/cargo related files.
+                (craneLib.fileset.commonCargoSources workspace.root)
+                # Builtin scripts
+                (sourcesWithExt "lua")
+              ];
+            };
+
+            # Run-time binary dependencies. We wrap the program to prepend the PATH with the
+            # required binaries.
+            nativeBuildInputs = with pkgs; [makeWrapper];
+            postInstall = ''
+              wrapProgram $out/bin/rmpcd \
+                --prefix PATH : ${with pkgs;
+                lib.makeBinPath [
+                  # Provides `notify-send` binary for builtin notify script.
+                  libnotify
+                  # Provides `xdg-open` binary for builtin lastfm script.
+                  xdg-utils
+                  # For lyrics script, and probably other things too.
+                  rmpc
+                ]}
+            '';
+          });
       in {
-        # Rust package, which can be run with `nix run github:mierak/rmpc`
-        # (or without the "github:..." if you're currently in this repository)
-        packages.default = naerskLib.buildPackage {
-          src = ./.;
-          # Avoid naersk's dummy dependency derivation; it conflicts with
-          # workspace-level `unused_crate_dependencies = "deny"` lints.
-          singleStep = true;
-          # Since the nix build is isolated, vergen won't have access to the git repository,
-          # so we'll have to set the environment variable ourselves.
-          #
-          # We can't actually (easily) get the equivalent of `git describe` unfortunately,
-          # see https://github.com/NixOS/nix/issues/7201
-          VERGEN_GIT_DESCRIBE = self.shortRev or self.dirtyShortRev;
+        packages = {
+          # Add the packages defined above to the packages set, so that they can be run/built.
+          inherit rmpc rmpcd;
 
-          # Additional files to be installed if the package is being, well, installed.
-          nativeBuildInputs = with pkgs; [installShellFiles];
-          postInstall = ''
-            installManPage target/man/rmpc.1
-
-            installShellCompletion --cmd rmpc \
-              --bash target/completions/rmpc.bash \
-              --fish target/completions/rmpc.fish \
-              --zsh target/completions/_rmpc
-
-            install -m 444 -D assets/rmpc.desktop $out/share/applications/rmpc.desktop
-          '';
+          # Make the default package just be rmpc.
+          default = rmpc;
         };
 
-        # Development shell, initialized either with `nix develop` or using direnv
-        devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            cargo
-            rustc
-            rustfmt
-            clippy
-            rust-analyzer
-          ];
-
-          # Needed so programs like rust-analyzer can find the rust source code.
-          env.RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
-        };
+        # Development shell, initialized either with `nix develop` or using direnv. Crane
+        # automatically sets up all the rust-specific packages & environment variables,
+        # so nothing else needs to be added.
+        devShells.default = craneLib.devShell {};
       }
     );
 }


### PR DESCRIPTION
## Description

Switched from using naersk to crane, as it has better support for workspaces.
It also doesn't have that bug causing the `unused_crate_dependencies` to fail, which is a nice plus.

I also added the `rmpcd` binary to the flake, so that can be used as well.

Since `rmpcd` doesn't have any documentation on the website from what I've seen, I haven't added any for this PR either.

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [ ] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [ ] Changelog has been updated
