### PR TITLE
fix(flake): re-add rust-analyzer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -147,7 +147,12 @@
         # Development shell, initialized either with `nix develop` or using direnv. Crane
         # automatically sets up all the rust-specific packages & environment variables,
         # so nothing else needs to be added.
-        devShells.default = craneLib.devShell {};
+        devShells.default = craneLib.devShell {
+          # For some reason rust-analyzer isn't included in the default shell.
+          buildInputs = with pkgs; [
+            rust-analyzer
+          ];
+        };
       }
     );
 }


### PR DESCRIPTION
## Description

Just found out that it isn't included in the default shell, probably because they assume it'd already be installed system-wide, and it's version doesn't need to be in sync with the project.

Unfortunately I often only notice stuff like this a minute after changes have been merged. 😅

### Related issues

### Checklist

- [ ] All tests passed
- [ ] Code has been formatted with rustfmt (nightly)
- [ ] Code has been checked with clippy (stable)
- [ ] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [ ] Changelog has been updated
