### PR TITLE
feat: add inverted_bar_as_mask config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ keybinds if they contained either `{` or `}`. You will now need to escape these 
 - Added `quit_closes_modal`
 - `remove` to the CLI allowing you to remove songs from the queue
 - `Pause` and `Unpause` actions
+- `inverted_bar_as_mask` option to cava
 
 ### Changed
 

--- a/rmpc/src/config/theme/cava.rs
+++ b/rmpc/src/config/theme/cava.rs
@@ -14,6 +14,7 @@ use crate::shared::ext::vec::VecExt;
 pub struct CavaThemeFile {
     pub bar_symbols: Vec<char>,
     pub inverted_bar_symbols: Vec<char>,
+    pub inverted_bar_as_mask: bool,
     pub bg_color: Option<String>,
     pub bar_color: CavaColorFile,
     pub bar_spacing: u16,
@@ -26,6 +27,7 @@ impl Default for CavaThemeFile {
         Self {
             bar_symbols: "▁▂▃▄▅▆▇█".chars().collect(),
             inverted_bar_symbols: "▔🮂🮃▀🮄🮅🮆█".chars().collect(),
+            inverted_bar_as_mask: false,
             bg_color: None,
             bar_color: CavaColorFile::Single("blue".into()),
             bar_spacing: 1,
@@ -39,6 +41,7 @@ impl Default for CavaThemeFile {
 pub struct CavaTheme {
     pub bar_symbols: Vec<String>,
     pub inverted_bar_symbols: Vec<String>,
+    pub inverted_bar_as_mask: bool,
     pub bar_symbols_count: usize,
     pub inverted_bar_symbols_count: usize,
     pub bg_color: CrosstermColor,
@@ -55,6 +58,7 @@ impl Default for CavaTheme {
             inverted_bar_symbols_count: 8,
             bar_symbols: "▁▂▃▄▅▆▇█".chars().map(|c| c.to_string()).collect(),
             inverted_bar_symbols: "▔🮂🮃▀🮄🮅🮆█".chars().map(|c| c.to_string()).collect(),
+            inverted_bar_as_mask: false,
             bg_color: CrosstermColor::Black,
             bar_color: CavaColor::Single(CrosstermColor::Blue),
             bar_spacing: 1,
@@ -118,6 +122,7 @@ impl CavaThemeFile {
                 .into_iter()
                 .map(|c| c.to_string().repeat(self.bar_width as usize))
                 .collect(),
+            inverted_bar_as_mask: self.inverted_bar_as_mask,
             bar_spacing: self.bar_spacing,
             bar_width: self.bar_width,
             orientation: self.orientation,

--- a/rmpc/src/ui/panes/cava.rs
+++ b/rmpc/src/ui/panes/cava.rs
@@ -167,10 +167,11 @@ impl CavaPane {
                         let char_index = (fill_amount * theme.inverted_bar_symbols_count as f32)
                             .floor() as usize;
                         let fill_char = theme.inverted_bar_symbols[char_index].as_str();
-                        queue!(
-                            writer,
-                            PrintStyledContent(fill_char.with(color).on(theme.bg_color))
-                        )?;
+                        let mut content = fill_char.with(color).on(theme.bg_color);
+                        if theme.inverted_bar_as_mask {
+                            content = content.reverse();
+                        }
+                        queue!(writer, PrintStyledContent(content))?;
                     }
                 }
             }


### PR DESCRIPTION
## Description
- Adds a new `inverted_bar_as_mask` config option for cava, defaulting to false

Mostly intended to circumvent the legacy top aligned block chars, since they can be messy on some fonts. In my case `DejaVuSansM Nerd Mono` didn't play well with it.

|legacy top aligned block chars| masked out bottom aligned block chars |
|-|-|
| <img width="1330" height="830" alt="image" src="https://github.com/user-attachments/assets/ef208bfe-8df9-4a14-9a92-e9774d19bfe8" /> | <img width="1330" height="830" alt="image" src="https://github.com/user-attachments/assets/a55778df-45a2-4178-965b-166578c2af49" /> |

This implementation should be fine even if there is no explicit bg set, since `.reverse()` is just a `\x1b[7m` prefix, but it will clash with the opacity of terminal emulators.

| terminal emulator opacity | WM opacity |
|-|-|
| <img width="1229" height="766" alt="image" src="https://github.com/user-attachments/assets/055bc133-9c9e-40b4-842e-be38769f11b3" /> | <img width="1229" height="766" alt="image" src="https://github.com/user-attachments/assets/a3826276-e6e6-49d3-a38b-282eafbea942" /> |



### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
