### PR TITLE
fix: recognize 'all' in allow-passthrough and detect iTerm.app

### DIFF
--- a/rmpc/src/shared/terminal/emulator.rs
+++ b/rmpc/src/shared/terminal/emulator.rs
@@ -59,6 +59,7 @@ impl Emulator {
             "WezTerm" => Some(Emulator::WezTerm),
             "vscode" => Some(Emulator::VSCode),
             "Tabby" => Some(Emulator::Tabby),
+            "iTerm.app" | "iTerm2" => Some(Emulator::Iterm2),
             _ => None,
         };
 

--- a/rmpc/src/shared/tmux.rs
+++ b/rmpc/src/shared/tmux.rs
@@ -154,7 +154,8 @@ pub fn is_passthrough_enabled() -> anyhow::Result<bool> {
     let cmd = cmd.args(["show", "-Ap", "allow-passthrough"]);
     let stdout = cmd.output()?.stdout;
 
-    Ok(String::from_utf8_lossy(&stdout).trim_end().ends_with("on"))
+    let val = String::from_utf8_lossy(&stdout).trim_end().to_lowercase();
+    Ok(val.ends_with("on") || val.ends_with("all"))
 }
 
 pub fn enable_passthrough() -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary
- `is_passthrough_enabled()` only checked `.ends_with("on")`, missing tmux's `allow-passthrough all` setting. Added `"all"` as a valid value.
- `Emulator::detect()` TERM_PROGRAM fallback did not include `"iTerm.app"` or `"iTerm2"`, causing iTerm2 to go undetected when DA1 query fails (e.g., inside tmux with passthrough issues).

## Context
When running rmpc inside tmux on iTerm2:
1. `tmux show -Ap allow-passthrough` returns `"all"` by default, but `is_passthrough_enabled()` only matches `"on"` — users must explicitly set `on` instead of `all` as a workaround.
2. Inside tmux, the DA1 query (`\x1b[>q`) often fails to reach the outer terminal. The TERM_PROGRAM fallback then checks env vars, but `"iTerm.app"` (the value iTerm2 sets) was not in the match list, so iTerm2 goes undetected.

## Test plan
- [ ] Verify `is_passthrough_enabled()` returns `true` when `allow-passthrough` is set to `all`
- [ ] Verify `Emulator::detect()` correctly identifies iTerm2 via `TERM_PROGRAM=iTerm.app` fallback
- [ ] Verify album art displays correctly in tmux on iTerm2

🗿 MoAI <email@mo.ai.kr>