### PR TITLE
fix: debuginfo showing incorrect error about missing components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ keybinds
 - Fixed potential panic in sorting when mixixng numerical and non numerical values for some song properties
 - password and address override parameter not working for rmpc's CLI
 - Config hot reload ignoring disable flag
+- `debuginfo` command no longer shows incorrect errors about missing components
 
 
 ## [0.11.0] - 2026-02-01

--- a/rmpc/src/main.rs
+++ b/rmpc/src/main.rs
@@ -165,30 +165,34 @@ fn main() -> Result<()> {
                 option_env!("VERGEN_GIT_DESCRIBE").map(|g| format!(" git {g}")).unwrap_or_default()
             );
 
-            let (config_file, config, config_path) =
-                read_config_for_debuginfo(args.config.as_deref(), args.address, args.password)
-                    .map_or_else(
-                        |err| {
-                            // use stdout here in case a user pipes the debug info to a
-                            // file/clipboard so its copied to the github issue as well
-                            if let ConfigReadError::ConfigNotFound = err {
-                                // Do not print error when config was not found, this is fine for
-                                // debuginfo
-                                println!("\nWarning:");
-                                println!("No config file was found. Using default values.");
-                            } else {
-                                println!("\nError: Failed to read config");
-                                println!("Caused by:");
-                                println!("  {err}");
-                                println!("\nUsing the default values");
-                            }
+            let (config_file, config, config_path) = read_config_for_debuginfo(
+                args.config.as_deref(),
+                args.theme.as_deref(),
+                args.address,
+                args.password,
+            )
+            .map_or_else(
+                |err| {
+                    // use stdout here in case a user pipes the debug info to a
+                    // file/clipboard so its copied to the github issue as well
+                    if let ConfigReadError::ConfigNotFound = err {
+                        // Do not print error when config was not found, this is fine for
+                        // debuginfo
+                        println!("\nWarning:");
+                        println!("No config file was found. Using default values.");
+                    } else {
+                        println!("\nError: Failed to read config");
+                        println!("Caused by:");
+                        println!("  {err}");
+                        println!("\nUsing the default values");
+                    }
 
-                            (ConfigFile::default(), Config::default(), None)
-                        },
-                        |(config_file, config, config_path)| {
-                            (config_file, config, Some(config_path))
-                        },
-                    );
+                    (ConfigFile::default(), Config::default(), None)
+                },
+                |(config_file, config, config_path, _theme_path)| {
+                    (config_file, config, Some(config_path))
+                },
+            );
 
             let mut mpd_host = ENV.var("MPD_HOST").unwrap_or_else(|_| "unset".to_string());
             if let Some(at_idx) = mpd_host.find('@') {

--- a/rmpc/src/shared/config_read.rs
+++ b/rmpc/src/shared/config_read.rs
@@ -11,7 +11,7 @@ use crate::config::{
     ConfigFile,
     cli::Args,
     cli_config::{CliConfig, CliConfigFile},
-    theme::{UiConfig, UiConfigFile},
+    theme::UiConfigFile,
 };
 
 #[derive(Error, Debug)]
@@ -53,9 +53,10 @@ pub fn read_cli_config(
 
 pub fn read_config_for_debuginfo(
     cli_arg_config_path: Option<&Path>,
+    cli_arg_theme_path: Option<&Path>,
     cli_arg_address: Option<String>,
     cli_arg_password: Option<String>,
-) -> Result<(ConfigFile, Config, PathBuf), ConfigReadError> {
+) -> Result<(ConfigFile, Config, PathBuf, Option<PathBuf>), ConfigReadError> {
     let config_paths = config_paths(cli_arg_config_path);
     if config_paths.is_empty() {
         return Err(ConfigReadError::NoConfigPaths);
@@ -67,10 +68,29 @@ pub fn read_config_for_debuginfo(
 
     let config = read_config_file(&chosen_config_path)?;
 
+    let (chosen_theme_path, theme) = match &config.theme {
+        Some(theme_name) => {
+            let theme_paths = theme_paths(cli_arg_theme_path, &chosen_config_path, theme_name);
+            let chosen_theme_path = find_first_existing_path(theme_paths);
+
+            if let Some(theme_path) = chosen_theme_path {
+                let theme = read_theme_file(&theme_path)?;
+                (Some(theme_path), theme)
+            } else {
+                return Err(ConfigReadError::ThemeNotFound);
+            }
+        }
+        // No theme set in the config file, this is OK, use the default theme
+        None => (None, UiConfigFile::default()),
+    };
+
+    let theme = theme.try_into().map_err(ConfigReadError::Conversion)?;
+
     Ok((
         config.clone(),
-        config.into_config(UiConfig::default(), cli_arg_address, cli_arg_password, false)?,
+        config.into_config(theme, cli_arg_address, cli_arg_password, false)?,
         chosen_config_path,
+        chosen_theme_path,
     ))
 }
 


### PR DESCRIPTION
## Description

### Related issues

fixes https://github.com/mierak/rmpc/issues/964

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
