### PR TITLE
fix: recognize "all" in allow-passthrough and detect iTerm.app in TER…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@ keybinds
 - password and address override parameter not working for rmpc's CLI
 - Config hot reload ignoring disable flag
 - `debuginfo` command no longer shows incorrect errors about missing components
-
+- also consider `all` when verifying tmux passthrough
+- add `iTerm.app` into emulator env variable detection
 
 ## [0.11.0] - 2026-02-01
 

--- a/rmpc/src/shared/terminal/emulator.rs
+++ b/rmpc/src/shared/terminal/emulator.rs
@@ -59,6 +59,7 @@ impl Emulator {
             "WezTerm" => Some(Emulator::WezTerm),
             "vscode" => Some(Emulator::VSCode),
             "Tabby" => Some(Emulator::Tabby),
+            "iTerm.app" => Some(Emulator::Iterm2),
             _ => None,
         };
 

--- a/rmpc/src/shared/tmux.rs
+++ b/rmpc/src/shared/tmux.rs
@@ -154,7 +154,8 @@ pub fn is_passthrough_enabled() -> anyhow::Result<bool> {
     let cmd = cmd.args(["show", "-Ap", "allow-passthrough"]);
     let stdout = cmd.output()?.stdout;
 
-    Ok(String::from_utf8_lossy(&stdout).trim_end().ends_with("on"))
+    let val = String::from_utf8_lossy(&stdout).trim_end().to_lowercase();
+    Ok(val.ends_with("on") || val.ends_with("all"))
 }
 
 pub fn enable_passthrough() -> anyhow::Result<()> {


### PR DESCRIPTION
## Description

### Related issues
https://github.com/mierak/rmpc/pull/953

### Checklist

- [ ] All tests passed
- [ ] Code has been formatted with rustfmt (nightly)
- [ ] Code has been checked with clippy (stable)
- [ ] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [ ] Changelog has been updated
