### PR TITLE
apply `text_color` to more elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 
 - Improved error message when invalid `default_album_art_path` path is provided
 - Environment variables are now resolved when parsing paths in the config file or theme
+- Apply `text_color` to more elements
 
 ### Fixed
 

--- a/assets/test_theme.ron
+++ b/assets/test_theme.ron
@@ -1,0 +1,316 @@
+#![enable(implicit_some)]
+#![enable(unwrap_newtypes)]
+#![enable(unwrap_variant_newtypes)]
+(
+    default_album_art_path: None,
+    format_tag_separator: " | ",
+    browser_column_widths: [20, 38, 42],
+    background_color: None,
+    text_color: "yellow",
+    header_background_color: None,
+    modal_background_color: None,
+    modal_backdrop: false,
+    preview_label_style: (),
+    preview_metadata_group_style: (modifiers: "Bold"),
+    highlighted_item_style: (modifiers: "Bold"),
+    current_item_style: (bg: "blue", modifiers: "Bold"),
+    borders_style: (fg: "blue"),
+    highlight_border_style: (fg: "blue"),
+    symbols: (
+        song: "S",
+        dir: "D",
+        playlist: "P",
+        marker: "M",
+        ellipsis: "...",
+        song_style: None,
+        dir_style: None,
+        playlist_style: None,
+        marker_style: None,
+        song_highlighted_style: None,
+        dir_highlighted_style: None,
+        playlist_highlighted_style: None,
+        marker_highlighted_style: None,
+        song_current_style: None,
+        dir_current_style: None,
+        playlist_current_style: None,
+        marker_current_style: None,
+    ),
+    level_styles: (
+        info: (fg: "blue", bg: "black"),
+        warn: (fg: "yellow", bg: "black"),
+        error: (fg: "red", bg: "black"),
+        debug: (fg: "light_green", bg: "black"),
+        trace: (fg: "magenta", bg: "black"),
+    ),
+    progress_bar: (
+        symbols: ["█", "█", "█", " ", "█"],
+        track_style: None,
+        elapsed_style: (fg: "blue"),
+        thumb_style: (fg: "blue"),
+        use_track_when_empty: true,
+    ),
+    scrollbar: (
+        symbols: ["│", "█", "▲", "▼"],
+        track_style: (),
+        ends_style: (),
+        thumb_style: (fg: "blue"),
+    ),
+    tab_bar: (
+        active_style: (bg: "blue", modifiers: "Bold"),
+        inactive_style: (),
+    ),
+    lyrics: (
+        timestamp: false
+    ),
+    browser_song_format: [
+        (
+            kind: Group([
+                (kind: Property(Track)),
+                (kind: Text(" ")),
+            ])
+        ),
+        (
+            kind: Group([
+                (kind: Property(Artist)),
+                (kind: Text(" - ")),
+                (kind: Property(Title)),
+            ]),
+            default: (kind: Property(Filename))
+        ),
+    ],
+    song_table_format: [
+        (
+            prop: (kind: Property(Artist),
+                default: (kind: Text("Unknown"))
+            ),
+            label_prop: (kind: Text("Artist")),
+            width: "20%",
+        ),
+        (
+            prop: (kind: Property(Title),
+                default: (kind: Text("Unknown"))
+            ),
+            label_prop: (kind: Text("Title")),
+            width: "35%",
+        ),
+        (
+            prop: (kind: Property(Album),
+                default: (kind: Text("Unknown Album"))
+            ),
+            label_prop: (kind: Text("Album")),
+            width: "30%",
+        ),
+        (
+            prop: (kind: Property(Duration),
+                default: (kind: Text("-"))
+            ),
+            label_prop: (kind: Text("Duration")),
+            width: "15%",
+            alignment: Right,
+        ),
+    ],
+    layout: Split(
+        direction: Vertical,
+        panes: [
+            (
+                size: "4",
+                pane: Split(
+                    direction: Horizontal,
+                    panes: [
+                        (
+                            size: "35",
+                            borders: "LEFT | TOP | BOTTOM",
+                            border_symbols: Inherited(parent: Rounded, bottom_left: "├"),
+                            pane: Component("header_left")
+                        ),
+                        (
+                            size: "100%",
+                            borders: "ALL",
+                            border_symbols: Inherited(parent: Rounded, top_left: "┬", top_right: "┬", bottom_left: "┴", bottom_right: "┴"),
+                            pane: Component("header_center")
+                        ),
+                        (
+                            size: "35",
+                            borders: "RIGHT | TOP | BOTTOM",
+                            border_symbols: Inherited(parent: Rounded, bottom_right: "┤"),
+                            pane: Component("header_right")
+                        ),
+                    ]
+                )
+            ),
+            (
+                pane: Pane(Tabs),
+                borders: "RIGHT | LEFT | BOTTOM",
+                border_symbols: Rounded,
+                size: "2",
+            ),
+            (
+                pane: Pane(TabContent),
+                size: "100%",
+            ),
+            (
+                size: "3",
+                pane: Split(
+                    direction: Horizontal,
+                    panes: [
+                        (
+                            size: "12",
+                            borders: "ALL",
+                            border_symbols: Inherited(parent: Rounded, top_right: "┬", bottom_right: "┴"),
+                            pane: Component("input_mode")
+                        ),
+                        (
+                            size: "100%",
+                            borders: "TOP | BOTTOM | RIGHT",
+                            border_symbols: Rounded,
+                            border_title: [(kind: Text(" ")), (kind: Property(Status(QueueLength()))), (kind: Text(" songs / ")), (kind: Property(Status(QueueTimeTotal()))), (kind: Text(" total time "))],
+                            border_title_alignment: Right,
+                            pane: Component("progress_bar"),
+                        ),
+                    ]
+                ),
+            ),
+        ],
+    ),
+    components: {
+        "state": Pane(Property(
+            content: [
+                (kind: Text("["), style: (modifiers: "Bold")),
+                (kind: Property(Status(StateV2( ))), style: (modifiers: "Bold")),
+                (kind: Text("]"), style: (modifiers: "Bold")),
+            ], align: Left,
+        )),
+        "title": Pane(Property(
+            content: [
+                (kind: Property(Song(Title)), style: (modifiers: "Bold"),
+                    default: (kind: Text("No Song"), style: (modifiers: "Bold"))),
+            ], align: Center, scroll_speed: 1
+        )),
+        "volume": Split(
+            direction: Horizontal,
+            panes: [
+                (size: "1", pane: Pane(Property(content: [(kind: Text(""))]))),
+                (size: "100%", pane: Pane(Volume(kind: Slider(symbols: (filled: "─", thumb: "●", track: "─"))))),
+                (size: "3", pane: Pane(Property(content: [(kind: Property(Status(Volume)))], align: Right))),
+                (size: "2", pane: Pane(Property(content: [(kind: Text("%"))]))),
+            ]
+        ),
+        "elapsed_and_bitrate": Pane(Property(
+            content: [
+                (kind: Property(Status(Elapsed))), 
+                (kind: Text(" / ")), 
+                (kind: Property(Status(Duration))), 
+                (kind: Group([
+                    (kind: Text(" (")), 
+                    (kind: Property(Status(Bitrate))), 
+                    (kind: Text(" kbps)")),
+                ])),
+            ],
+            align: Left,
+        )),
+        "artist_and_album": Pane(Property(
+            content: [
+                (kind: Property(Song(Artist)), style: (modifiers: "Bold"),
+                    default: (kind: Text("Unknown"), style: (modifiers: "Bold"))),
+                (kind: Text(" - ")),
+                (kind: Property(Song(Album)), default: (kind: Text("Unknown Album"))),
+            ], align: Center, scroll_speed: 1
+        )),
+        "states": Split(
+            direction: Horizontal,
+            panes: [
+                (
+                    size: "1",
+                    pane: Pane(Empty())
+                ),
+                (
+                    size: "100%",
+                    pane: Pane(Property(content: [(kind: Property(Status(InputBuffer())), align: Left)]))
+                ),
+                (
+                    size: "6",
+                    pane: Pane(Property(content: [
+                        (kind: Text("["), style: (modifiers: "Bold")),
+                        (kind: Property(Status(RepeatV2(
+                            on_label: "z",
+                            off_label: "z",
+                            on_style: (modifiers: "Bold"),
+                            off_style: (modifiers: "Dim"),
+                        )))),
+                        (kind: Property(Status(RandomV2(
+                            on_label: "x",
+                            off_label: "x",
+                            on_style: (modifiers: "Bold"),
+                            off_style: (modifiers: "Dim"),
+                        )))),
+                        (kind: Property(Status(ConsumeV2(
+                            on_label: "c",
+                            off_label: "c",
+                            oneshot_label: "c",
+                            on_style: (modifiers: "Bold"),
+                            off_style: (modifiers: "Dim"),
+                            oneshot_style: (modifiers: "Dim"),
+                        )))),
+                        (kind: Property(Status(SingleV2(
+                            on_label: "v",
+                            off_label: "v",
+                            oneshot_label: "v",
+                            on_style: (modifiers: "Bold"),
+                            off_style: (modifiers: "Dim"),
+                            oneshot_style: (modifiers: "Bold"),
+                        )))),
+                        (kind: Text("]"), style: (modifiers: "Bold")),
+                        ],
+                        align: Right
+                    ))
+                ),
+            ]
+        ),
+        "input_mode": Pane(Property(
+            content: [
+                (kind: Transform(Replace(content: (kind: Property(Status(InputMode()))), replacements: [
+                    (match: "Normal", replace: (kind: Text(" NORMAL "), style: (bg: "blue"))),
+                    (match: "Insert", replace: (kind: Text(" INSERT "), style: (bg: "green"))),
+                ])))
+            ], align: Center
+        )),
+        "header_left": Split(
+            direction: Vertical,
+            panes: [
+                (size: "1", pane: Component("state")),
+                (size: "1", pane: Component("elapsed_and_bitrate")),
+            ]
+        ),
+        "header_center": Split(
+            direction: Vertical,
+            panes: [
+                (size: "1", pane: Component("title")),
+                (size: "1", pane: Component("artist_and_album")),
+            ]
+        ),
+        "header_right": Split(
+            direction: Vertical,
+            panes: [
+                (size: "1", pane: Component("volume")),
+                (size: "1", pane: Component("states")),
+            ]
+        ),
+        "progress_bar": Split(
+            direction: Horizontal,
+            panes: [
+                (
+                    size: "1",
+                    pane: Pane(Empty())
+                ),
+                (
+                    size: "100%",
+                    pane: Pane(ProgressBar)
+                ),
+                (
+                    size: "1",
+                    pane: Pane(Empty())
+                ),
+            ]
+        )
+    },
+)

--- a/rmpc/src/config/theme/mod.rs
+++ b/rmpc/src/config/theme/mod.rs
@@ -439,6 +439,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
         let fallback_border_fg = Color::White;
         let border_set_lib: BorderSetLib = value.border_symbol_sets.try_into()?;
         let components = convert_components(value.components, &border_set_lib)?;
+        let text_color = StringColor(value.text_color).to_color()?;
 
         Ok(Self {
             layout: value.layout.convert(&components, &border_set_lib)?,
@@ -452,7 +453,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
                 .to_color()?
                 .or(bg_color),
             modal_backdrop: value.modal_backdrop,
-            text_color: StringColor(value.text_color).to_color()?,
+            text_color,
             header_background_color: header_bg_color,
             borders_style: value.borders_style.to_config_or(Some(fallback_border_fg), None)?,
             highlight_border_style: value
@@ -478,11 +479,14 @@ impl TryFrom<UiConfigFile> for UiConfig {
                 active_style: value
                     .tab_bar
                     .active_style
-                    .to_config_or(Some(Color::Black), Some(Color::Blue))?,
-                inactive_style: value.tab_bar.inactive_style.to_config_or(None, header_bg_color)?,
+                    .to_config_or(text_color, Some(Color::Blue))?,
+                inactive_style: value
+                    .tab_bar
+                    .inactive_style
+                    .to_config_or(text_color, header_bg_color)?,
             },
-            highlighted_item_style: value.highlighted_item_style.to_config_or(None, None)?,
-            current_item_style: value.current_item_style.to_config_or(None, None)?,
+            highlighted_item_style: value.highlighted_item_style.to_config_or(text_color, None)?,
+            current_item_style: value.current_item_style.to_config_or(text_color, None)?,
             default_album_art: value
                 .default_album_art_path
                 .map_or(Ok(DEFAULT_ART as &'static [u8]), |path| -> Result<_> {
@@ -492,10 +496,10 @@ impl TryFrom<UiConfigFile> for UiConfig {
                 })
                 .context("Failed to read 'default_album_art_path'")?,
             browser_song_format: TryInto::<SongFormat>::try_into(value.browser_song_format)?,
-            preview_label_style: value.preview_label_style.to_config_or(None, None)?,
+            preview_label_style: value.preview_label_style.to_config_or(text_color, None)?,
             preview_metadata_group_style: value
                 .preview_metadata_group_style
-                .to_config_or(None, None)?,
+                .to_config_or(text_color, None)?,
             level_styles: value.level_styles.try_into()?,
             lyrics: value.lyrics.into(),
             border_symbol_sets: border_set_lib,

--- a/rmpc/src/config/theme/properties.rs
+++ b/rmpc/src/config/theme/properties.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use anyhow::Result;
 use bon::Builder;
 use itertools::Itertools;
-use ratatui::style::{Color, Style};
+use ratatui::style::Style;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use strum::Display;
@@ -562,9 +562,8 @@ impl TryFrom<PropertyFile<PropertyKindFile>> for Property<PropertyKind> {
                             active_style,
                             separator_style,
                         }) => PropertyKind::Widget(WidgetProperty::States {
-                            active_style: active_style.to_config_or(Some(Color::White), None)?,
-                            separator_style: separator_style
-                                .to_config_or(Some(Color::White), None)?,
+                            active_style: active_style.to_config_or(None, None)?,
+                            separator_style: separator_style.to_config_or(None, None)?,
                         }),
                         PropertyKindFile::Widget(WidgetPropertyFile::ScanStatus) => {
                             PropertyKind::Widget(WidgetProperty::ScanStatus)

--- a/rmpc/src/ui/mod.rs
+++ b/rmpc/src/ui/mod.rs
@@ -1194,7 +1194,7 @@ impl Config {
         self.theme.highlight_border_style
     }
 
-    fn as_text_style(&self) -> ratatui::style::Style {
+    pub(crate) fn as_text_style(&self) -> ratatui::style::Style {
         self.theme.text_color.map(|color| Style::default().fg(color)).unwrap_or_default()
     }
 

--- a/rmpc/src/ui/panes/mod.rs
+++ b/rmpc/src/ui/panes/mod.rs
@@ -422,7 +422,7 @@ impl Property<PropertyKind> {
         tag_separator: &str,
         strategy: TagResolutionStrategy,
     ) -> Option<Either<Span<'s>, Vec<Span<'s>>>> {
-        let style = self.style.unwrap_or_default();
+        let style = ctx.config.as_text_style().patch(self.style.unwrap_or_default());
         let status = &ctx.status;
         match &self.kind {
             PropertyKindOrText::Text(value) => Some(Either::Left(Span::styled(value, style))),
@@ -464,7 +464,7 @@ impl Property<PropertyKind> {
                         State::Stop => stopped_style,
                         State::Pause => paused_style,
                     }
-                    .unwrap_or(style),
+                    .map_or(style, |s| style.patch(s))
                 ))),
                 StatusProperty::Duration => {
                     Some(Either::Left(Span::styled(status.duration.to_string(), style)))
@@ -481,13 +481,15 @@ impl Property<PropertyKind> {
                 StatusProperty::Repeat { on_label, off_label, on_style, off_style } => {
                     Some(Either::Left(Span::styled(
                         if status.repeat { on_label } else { off_label },
-                        if status.repeat { on_style } else { off_style }.unwrap_or(style),
+                        if status.repeat { on_style } else { off_style }
+                            .map_or(style, |s| style.patch(s))
                     )))
                 }
                 StatusProperty::Random { on_label, off_label, on_style, off_style } => {
                     Some(Either::Left(Span::styled(
                         if status.random { on_label } else { off_label },
-                        if status.random { on_style } else { off_style }.unwrap_or(style),
+                        if status.random { on_style } else { off_style }
+                            .map_or(style, |s| style.patch(s))
                     )))
                 }
                 StatusProperty::Consume {
@@ -508,7 +510,7 @@ impl Property<PropertyKind> {
                         OnOffOneshot::Off => off_style,
                         OnOffOneshot::Oneshot => oneshot_style,
                     }
-                    .unwrap_or(style),
+                    .map_or(style, |s| style.patch(s))
                 ))),
                 StatusProperty::Single {
                     on_label,
@@ -528,7 +530,7 @@ impl Property<PropertyKind> {
                         OnOffOneshot::Off => off_style,
                         OnOffOneshot::Oneshot => oneshot_style,
                     }
-                    .unwrap_or(style),
+                    .map_or(style, |s| style.patch(s))
                 ))),
                 StatusProperty::Bitrate => status.bitrate.as_ref().map_or_else(
                     || self.default_as_span(song, ctx, tag_separator, strategy),
@@ -599,22 +601,32 @@ impl Property<PropertyKind> {
                     Some(Either::Left(Span::styled(Volume::get_str(*status.volume.value()), style)))
                 }
                 WidgetProperty::States { active_style, separator_style } => {
-                    let separator = Span::styled(" / ", *separator_style);
+                    let separator = Span::styled(" / ", style.patch(*separator_style));
                     Some(Either::Right(vec![
-                        Span::styled("Repeat", if status.repeat { *active_style } else { style }),
+                        Span::styled(
+                            "Repeat",
+                            if status.repeat { style.patch(*active_style) } else { style },
+                        ),
                         separator.clone(),
-                        Span::styled("Random", if status.random { *active_style } else { style }),
+                        Span::styled(
+                            "Random",
+                            if status.random { style.patch(*active_style) } else { style },
+                        ),
                         separator.clone(),
                         match status.consume {
-                            OnOffOneshot::On => Span::styled("Consume", *active_style),
+                            OnOffOneshot::On => Span::styled("Consume", style.patch(*active_style)),
                             OnOffOneshot::Off => Span::styled("Consume", style),
-                            OnOffOneshot::Oneshot => Span::styled("Oneshot(C)", *active_style),
+                            OnOffOneshot::Oneshot => {
+                                Span::styled("Oneshot(C)", style.patch(*active_style))
+                            }
                         },
                         separator,
                         match status.single {
-                            OnOffOneshot::On => Span::styled("Single", *active_style),
+                            OnOffOneshot::On => Span::styled("Single", style.patch(*active_style)),
                             OnOffOneshot::Off => Span::styled("Single", style),
-                            OnOffOneshot::Oneshot => Span::styled("Oneshot(S)", *active_style),
+                            OnOffOneshot::Oneshot => {
+                                Span::styled("Oneshot(S)", style.patch(*active_style))
+                            }
                         },
                     ]))
                 }

--- a/rmpc/src/ui/song_ext.rs
+++ b/rmpc/src/ui/song_ext.rs
@@ -423,7 +423,7 @@ impl SongExt for Song {
         strategy: TagResolutionStrategy,
         ctx: &'stickers Ctx,
     ) -> Option<Line<'song>> {
-        let style = format.style.unwrap_or_default();
+        let style = ctx.config.as_text_style().patch(format.style.unwrap_or_default());
         match &format.kind {
             PropertyKindOrText::Text(value) => Some(Line::styled(value.clone(), style)),
             PropertyKindOrText::Sticker(key) => ctx


### PR DESCRIPTION
## Description
This PR applies `text_color` to more elements.
I also added a test theme with relevant `fg:` values removed to make verification easier. It should be removed before merging.

### Related issues
https://github.com/mierak/rmpc/issues/920

### Checklist

- [X] All tests passed
- [X] Code has been formatted with rustfmt (nightly)
- [X] Code has been checked with clippy (stable)
- [ ] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [X] Changelog has been updated
