### PR TITLE
Improve styling 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ keybinds
 - also consider `all` when verifying tmux passthrough
 - add `iTerm.app` into emulator env variable detection
 - `PREV_SONG` in `on_song_change` is now correctly tracked with consume on
+- `current_item_style` and `highlighted_item_style` merge on top of `text_color` in modals and search
 
 ## [0.11.0] - 2026-02-01
 

--- a/rmpc/src/config/theme/mod.rs
+++ b/rmpc/src/config/theme/mod.rs
@@ -437,9 +437,11 @@ impl TryFrom<UiConfigFile> for UiConfig {
         let fg_color = StringColor(value.text_color.clone()).to_color()?;
         let bg_color = StringColor(value.background_color).to_color()?;
         let header_bg_color = StringColor(value.header_background_color).to_color()?.or(bg_color);
-        let fallback_border_fg = Color::White;
+        let border = value.borders_style.to_config_or(Some(Color::White), None)?;
         let border_set_lib: BorderSetLib = value.border_symbol_sets.try_into()?;
         let components = convert_components(value.components, &border_set_lib)?;
+        let current_style = value.current_item_style.to_config_or(None, None)?;
+        let highlighted_style = value.highlighted_item_style.to_config_or(None, None)?;
 
         Ok(Self {
             layout: value.layout.convert(&components, &border_set_lib)?,
@@ -455,12 +457,15 @@ impl TryFrom<UiConfigFile> for UiConfig {
             modal_backdrop: value.modal_backdrop,
             text_color: fg_color,
             header_background_color: header_bg_color,
-            borders_style: value.borders_style.to_config_or(Some(fallback_border_fg), None)?,
+            borders_style: border,
             highlight_border_style: value
                 .highlight_border_style
-                .to_config_or(Some(Color::Blue), None)?,
+                .to_config_or(border.fg, border.bg)?,
             symbols: value.symbols.into(),
-            scrollbar: value.scrollbar.map(|sc| sc.into_config(fallback_border_fg)).transpose()?,
+            scrollbar: value
+                .scrollbar
+                .map(|sc| sc.into_config(border.fg.unwrap_or(Color::White)))
+                .transpose()?,
             progress_bar: value.progress_bar.into_config()?,
             song_table_format: TryInto::<QueueTableColumns>::try_into(value.song_table_format)?.0,
             song_table_album_separator: value.song_table_album_separator,
@@ -479,11 +484,14 @@ impl TryFrom<UiConfigFile> for UiConfig {
                 active_style: value
                     .tab_bar
                     .active_style
-                    .to_config_or(Some(Color::Black), Some(Color::Blue))?,
-                inactive_style: value.tab_bar.inactive_style.to_config_or(None, header_bg_color)?,
+                    .to_config_or(current_style.fg.or(fg_color), current_style.bg)?,
+                inactive_style: value
+                    .tab_bar
+                    .inactive_style
+                    .to_config_or(fg_color, header_bg_color)?,
             },
-            highlighted_item_style: value.highlighted_item_style.to_config_or(None, None)?,
-            current_item_style: value.current_item_style.to_config_or(None, None)?,
+            highlighted_item_style: highlighted_style,
+            current_item_style: current_style,
             default_album_art: value
                 .default_album_art_path
                 .map_or(Ok(DEFAULT_ART as &'static [u8]), |path| -> Result<_> {

--- a/rmpc/src/config/theme/mod.rs
+++ b/rmpc/src/config/theme/mod.rs
@@ -434,6 +434,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
 
     #[allow(clippy::similar_names)]
     fn try_from(value: UiConfigFile) -> Result<Self, Self::Error> {
+        let fg_color = StringColor(value.text_color.clone()).to_color()?;
         let bg_color = StringColor(value.background_color).to_color()?;
         let header_bg_color = StringColor(value.header_background_color).to_color()?.or(bg_color);
         let fallback_border_fg = Color::White;
@@ -452,7 +453,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
                 .to_color()?
                 .or(bg_color),
             modal_backdrop: value.modal_backdrop,
-            text_color: StringColor(value.text_color).to_color()?,
+            text_color: fg_color,
             header_background_color: header_bg_color,
             borders_style: value.borders_style.to_config_or(Some(fallback_border_fg), None)?,
             highlight_border_style: value

--- a/rmpc/src/config/theme/mod.rs
+++ b/rmpc/src/config/theme/mod.rs
@@ -437,7 +437,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
         let fg_color = StringColor(value.text_color.clone()).to_color()?;
         let bg_color = StringColor(value.background_color).to_color()?;
         let header_bg_color = StringColor(value.header_background_color).to_color()?.or(bg_color);
-        let border = value.borders_style.to_config_or(Some(Color::White), None)?;
+        let border = value.borders_style.to_config_or(None, None)?;
         let border_set_lib: BorderSetLib = value.border_symbol_sets.try_into()?;
         let components = convert_components(value.components, &border_set_lib)?;
         let current_style = value.current_item_style.to_config_or(None, None)?;
@@ -464,7 +464,7 @@ impl TryFrom<UiConfigFile> for UiConfig {
             symbols: value.symbols.into(),
             scrollbar: value
                 .scrollbar
-                .map(|sc| sc.into_config(border.fg.unwrap_or(Color::White)))
+                .map(|sc| sc.into_config(border.fg.unwrap_or_default()))
                 .transpose()?,
             progress_bar: value.progress_bar.into_config()?,
             song_table_format: TryInto::<QueueTableColumns>::try_into(value.song_table_format)?.0,

--- a/rmpc/src/config/theme/properties.rs
+++ b/rmpc/src/config/theme/properties.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use anyhow::Result;
 use bon::Builder;
 use itertools::Itertools;
-use ratatui::style::{Color, Style};
+use ratatui::style::Style;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use strum::Display;
@@ -562,9 +562,8 @@ impl TryFrom<PropertyFile<PropertyKindFile>> for Property<PropertyKind> {
                             active_style,
                             separator_style,
                         }) => PropertyKind::Widget(WidgetProperty::States {
-                            active_style: active_style.to_config_or(Some(Color::White), None)?,
-                            separator_style: separator_style
-                                .to_config_or(Some(Color::White), None)?,
+                            active_style: active_style.to_config_or(None, None)?,
+                            separator_style: separator_style.to_config_or(None, None)?,
                         }),
                         PropertyKindFile::Widget(WidgetPropertyFile::ScanStatus) => {
                             PropertyKind::Widget(WidgetProperty::ScanStatus)

--- a/rmpc/src/ui/dirstack/mod.rs
+++ b/rmpc/src/ui/dirstack/mod.rs
@@ -47,47 +47,48 @@ pub trait DirStackItem {
 }
 
 pub fn marker_style(ctx: &Ctx, is_current: bool, matches_filter: bool) -> Style {
+    let style =
+        ctx.config.theme.symbols.marker_style.unwrap_or(ctx.config.theme.highlighted_item_style);
     if is_current {
-        ctx.config.theme.symbols.marker_current_style
+        return style.patch(ctx.config.theme.symbols.marker_current_style.unwrap_or_default());
     } else if matches_filter {
-        ctx.config.theme.symbols.marker_highlighted_style
-    } else {
-        ctx.config.theme.symbols.marker_style
+        return style.patch(ctx.config.theme.symbols.marker_highlighted_style.unwrap_or_default());
     }
-    .unwrap_or(ctx.config.theme.highlighted_item_style)
+    return style;
 }
 
 fn dir_style(ctx: &Ctx, is_current: bool, matches_filter: bool) -> Style {
+    let style =
+        ctx.config.theme.symbols.dir_style.unwrap_or(ctx.config.theme.highlighted_item_style);
     if is_current {
-        ctx.config.theme.symbols.dir_current_style
+        return style.patch(ctx.config.theme.symbols.dir_current_style.unwrap_or_default());
     } else if matches_filter {
-        ctx.config.theme.symbols.dir_highlighted_style
-    } else {
-        ctx.config.theme.symbols.dir_style
+        return style.patch(ctx.config.theme.symbols.dir_highlighted_style.unwrap_or_default());
     }
-    .unwrap_or_default()
+    return style;
 }
 
 fn playlist_style(ctx: &Ctx, is_current: bool, matches_filter: bool) -> Style {
+    let style =
+        ctx.config.theme.symbols.playlist_style.unwrap_or(ctx.config.theme.highlighted_item_style);
     if is_current {
-        ctx.config.theme.symbols.playlist_current_style
+        return style.patch(ctx.config.theme.symbols.playlist_current_style.unwrap_or_default());
     } else if matches_filter {
-        ctx.config.theme.symbols.playlist_highlighted_style
-    } else {
-        ctx.config.theme.symbols.playlist_style
+        return style
+            .patch(ctx.config.theme.symbols.playlist_highlighted_style.unwrap_or_default());
     }
-    .unwrap_or_default()
+    return style;
 }
 
 fn song_style(ctx: &Ctx, is_current: bool, matches_filter: bool) -> Style {
+    let style =
+        ctx.config.theme.symbols.song_style.unwrap_or(ctx.config.theme.highlighted_item_style);
     if is_current {
-        ctx.config.theme.symbols.song_current_style
+        return style.patch(ctx.config.theme.symbols.song_current_style.unwrap_or_default());
     } else if matches_filter {
-        ctx.config.theme.symbols.song_highlighted_style
-    } else {
-        ctx.config.theme.symbols.song_style
+        return style.patch(ctx.config.theme.symbols.song_highlighted_style.unwrap_or_default());
     }
-    .unwrap_or_default()
+    return style;
 }
 
 impl DirStackItem for DirOrSong {

--- a/rmpc/src/ui/dirstack/mod.rs
+++ b/rmpc/src/ui/dirstack/mod.rs
@@ -47,8 +47,7 @@ pub trait DirStackItem {
 }
 
 pub fn marker_style(ctx: &Ctx, is_current: bool, matches_filter: bool) -> Style {
-    let style =
-        ctx.config.theme.symbols.marker_style.unwrap_or(ctx.config.theme.highlighted_item_style);
+    let style = ctx.config.theme.symbols.marker_style.unwrap_or_default();
     if is_current {
         return style.patch(ctx.config.theme.symbols.marker_current_style.unwrap_or_default());
     } else if matches_filter {
@@ -58,8 +57,7 @@ pub fn marker_style(ctx: &Ctx, is_current: bool, matches_filter: bool) -> Style 
 }
 
 fn dir_style(ctx: &Ctx, is_current: bool, matches_filter: bool) -> Style {
-    let style =
-        ctx.config.theme.symbols.dir_style.unwrap_or(ctx.config.theme.highlighted_item_style);
+    let style = ctx.config.theme.symbols.dir_style.unwrap_or_default();
     if is_current {
         return style.patch(ctx.config.theme.symbols.dir_current_style.unwrap_or_default());
     } else if matches_filter {
@@ -69,8 +67,7 @@ fn dir_style(ctx: &Ctx, is_current: bool, matches_filter: bool) -> Style {
 }
 
 fn playlist_style(ctx: &Ctx, is_current: bool, matches_filter: bool) -> Style {
-    let style =
-        ctx.config.theme.symbols.playlist_style.unwrap_or(ctx.config.theme.highlighted_item_style);
+    let style = ctx.config.theme.symbols.playlist_style.unwrap_or_default();
     if is_current {
         return style.patch(ctx.config.theme.symbols.playlist_current_style.unwrap_or_default());
     } else if matches_filter {
@@ -81,8 +78,7 @@ fn playlist_style(ctx: &Ctx, is_current: bool, matches_filter: bool) -> Style {
 }
 
 fn song_style(ctx: &Ctx, is_current: bool, matches_filter: bool) -> Style {
-    let style =
-        ctx.config.theme.symbols.song_style.unwrap_or(ctx.config.theme.highlighted_item_style);
+    let style = ctx.config.theme.symbols.song_style.unwrap_or_default();
     if is_current {
         return style.patch(ctx.config.theme.symbols.song_current_style.unwrap_or_default());
     } else if matches_filter {

--- a/rmpc/src/ui/modals/add_random_modal.rs
+++ b/rmpc/src/ui/modals/add_random_modal.rs
@@ -142,8 +142,8 @@ impl Modal for AddRandomModal<'_> {
 
         let combobox = if matches!(self.active_input, InputType::Tag) {
             combobox
-                .label_style(ctx.config.theme.current_item_style)
-                .input_style(ctx.config.theme.current_item_style)
+                .label_style(ctx.config.as_text_style().patch(ctx.config.theme.current_item_style))
+                .input_style(ctx.config.as_text_style().patch(ctx.config.theme.current_item_style))
                 .call()
         } else {
             combobox
@@ -168,8 +168,8 @@ impl Modal for AddRandomModal<'_> {
 
         let count = if matches!(self.active_input, InputType::Count) {
             count
-                .label_style(ctx.config.theme.current_item_style)
-                .input_style(ctx.config.theme.current_item_style)
+                .label_style(ctx.config.as_text_style().patch(ctx.config.theme.current_item_style))
+                .input_style(ctx.config.as_text_style().patch(ctx.config.theme.current_item_style))
                 .build()
         } else {
             count
@@ -181,7 +181,9 @@ impl Modal for AddRandomModal<'_> {
         };
 
         self.button_group.set_active_style(match self.active_input {
-            InputType::Buttons => ctx.config.theme.current_item_style,
+            InputType::Buttons => {
+                ctx.config.as_text_style().patch(ctx.config.theme.current_item_style)
+            }
             _ => Style::default().reversed(),
         });
 

--- a/rmpc/src/ui/modals/confirm_modal.rs
+++ b/rmpc/src/ui/modals/confirm_modal.rs
@@ -93,7 +93,7 @@ impl<'a> ConfirmModal<'a> {
 
         button_group_state.set_button_count(buttons.len());
         let button_group = ButtonGroup::default()
-            .active_style(ctx.config.theme.current_item_style)
+            .active_style(ctx.config.as_text_style().patch(ctx.config.theme.current_item_style))
             .inactive_style(ctx.config.as_text_style())
             .buttons(buttons)
             .block(

--- a/rmpc/src/ui/modals/info_modal.rs
+++ b/rmpc/src/ui/modals/info_modal.rs
@@ -57,7 +57,7 @@ impl<'a> InfoModal<'a> {
         let buttons = vec![Button::default().label(confirm_label.unwrap_or("Ok"))];
         button_group_state.set_button_count(buttons.len());
         let button_group = ButtonGroup::default()
-            .active_style(ctx.config.theme.current_item_style)
+            .active_style(ctx.config.as_text_style().patch(ctx.config.theme.current_item_style))
             .inactive_style(ctx.config.as_text_style())
             .buttons(buttons)
             .block(

--- a/rmpc/src/ui/modals/input_modal.rs
+++ b/rmpc/src/ui/modals/input_modal.rs
@@ -146,6 +146,7 @@ impl<'a, C: FnOnce(&Ctx, &str) -> Result<()> + 'a> Modal for InputModal<'a, C> {
             .build();
 
         self.button_group.set_active_style(if ctx.input.is_active(self.input_buffer_id) {
+            // !!TODO - Should this have config??
             Style::default().reversed()
         } else {
             ctx.config.as_text_style().patch(ctx.config.theme.current_item_style)

--- a/rmpc/src/ui/modals/input_modal.rs
+++ b/rmpc/src/ui/modals/input_modal.rs
@@ -148,7 +148,7 @@ impl<'a, C: FnOnce(&Ctx, &str) -> Result<()> + 'a> Modal for InputModal<'a, C> {
         self.button_group.set_active_style(if ctx.input.is_active(self.input_buffer_id) {
             Style::default().reversed()
         } else {
-            ctx.config.theme.current_item_style
+            ctx.config.as_text_style().patch(ctx.config.theme.current_item_style)
         });
 
         self.input_area = body_area;

--- a/rmpc/src/ui/modals/input_modal.rs
+++ b/rmpc/src/ui/modals/input_modal.rs
@@ -146,8 +146,7 @@ impl<'a, C: FnOnce(&Ctx, &str) -> Result<()> + 'a> Modal for InputModal<'a, C> {
             .build();
 
         self.button_group.set_active_style(if ctx.input.is_active(self.input_buffer_id) {
-            // !!TODO - Should this have config??
-            Style::default().reversed()
+            ctx.config.as_text_style().patch(ctx.config.theme.highlighted_item_style)
         } else {
             ctx.config.as_text_style().patch(ctx.config.theme.current_item_style)
         });

--- a/rmpc/src/ui/modals/keybinds.rs
+++ b/rmpc/src/ui/modals/keybinds.rs
@@ -256,7 +256,7 @@ impl Modal for KeybindsModal {
         desc_area.width = desc_area.width.saturating_sub(2); // account for the column spacing
 
         let keybinds = &ctx.config.keybinds;
-        let header_style = ctx.config.theme.current_item_style;
+        let header_style = ctx.config.theme.highlighted_item_style;
 
         let global = keybinds.global.sort_by_action().collect_vec();
         let navigation = keybinds.navigation.sort_by_action().collect_vec();

--- a/rmpc/src/ui/modals/keybinds.rs
+++ b/rmpc/src/ui/modals/keybinds.rs
@@ -256,7 +256,8 @@ impl Modal for KeybindsModal {
         desc_area.width = desc_area.width.saturating_sub(2); // account for the column spacing
 
         let keybinds = &ctx.config.keybinds;
-        let header_style = ctx.config.theme.highlighted_item_style;
+        let header_style =
+            ctx.config.as_text_style().patch(ctx.config.theme.highlighted_item_style);
 
         let global = keybinds.global.sort_by_action().collect_vec();
         let navigation = keybinds.navigation.sort_by_action().collect_vec();

--- a/rmpc/src/ui/modals/menu/input_section.rs
+++ b/rmpc/src/ui/modals/menu/input_section.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use ratatui::{
     buffer::Buffer,
     layout::{Position, Rect},
-    style::Style,
     widgets::Widget,
 };
 
@@ -122,17 +121,15 @@ impl Section for InputSection<'_> {
             .borderless(true)
             .label(self.label.as_ref())
             .label_style(if self.is_current && !ctx.input.is_active(self.buffer_id) {
-                ctx.config.theme.current_item_style
+                ctx.config.as_text_style().patch(ctx.config.theme.current_item_style)
             } else if let Some(f) = filter
                 && self.label.to_lowercase().contains(f)
             {
-                ctx.config.theme.highlighted_item_style
+                ctx.config.as_text_style().patch(ctx.config.theme.highlighted_item_style)
             } else {
-                ctx.config.theme.text_color.map_or(Style::default(), |c| Style::default().fg(c))
+                ctx.config.as_text_style()
             })
-            .input_style(
-                ctx.config.theme.text_color.map_or(Style::default(), |c| Style::default().fg(c)),
-            )
+            .input_style(ctx.config.as_text_style())
             .build();
 
         input.render(area, buf);

--- a/rmpc/src/ui/modals/menu/list_section.rs
+++ b/rmpc/src/ui/modals/menu/list_section.rs
@@ -172,14 +172,11 @@ impl Section for ListSection {
             } else if let Some(f) = filter
                 && item.label.to_lowercase().contains(f)
             {
-                text = text.style(ctx.config.theme.highlighted_item_style);
-            } else {
                 text = text.style(
-                    ctx.config
-                        .theme
-                        .text_color
-                        .map_or(Style::default(), |c| Style::default().fg(c)),
+                    ctx.config.as_text_style().patch(ctx.config.theme.highlighted_item_style),
                 );
+            } else {
+                text = text.style(ctx.config.as_text_style());
             }
             let idx = idx.saturating_sub(self.state.offset());
 

--- a/rmpc/src/ui/modals/menu/modal.rs
+++ b/rmpc/src/ui/modals/menu/modal.rs
@@ -394,7 +394,8 @@ impl<'a> MenuModal<'a> {
         ctx: &Ctx,
         cb: impl FnOnce(ListSection) -> Option<ListSection>,
     ) -> Self {
-        let section = ListSection::new(ctx.config.theme.current_item_style);
+        let section =
+            ListSection::new(ctx.config.as_text_style().patch(ctx.config.theme.current_item_style));
         let section = cb(section);
         if let Some(mut section) = section {
             section.state.set_content_len(Some(section.items.len()));
@@ -409,7 +410,9 @@ impl<'a> MenuModal<'a> {
         ctx: &Ctx,
         cb: impl FnOnce(MultiActionSection) -> Option<MultiActionSection<'_>>,
     ) -> Self {
-        let section = MultiActionSection::new(ctx.config.theme.current_item_style);
+        let section = MultiActionSection::new(
+            ctx.config.as_text_style().patch(ctx.config.theme.current_item_style),
+        );
         let section = cb(section);
         if let Some(mut section) = section {
             section.build();
@@ -439,7 +442,9 @@ impl<'a> MenuModal<'a> {
         ctx: &Ctx,
         cb: impl FnOnce(SelectSection) -> Option<SelectSection>,
     ) -> Self {
-        let section = SelectSection::new(ctx.config.theme.current_item_style);
+        let section = SelectSection::new(
+            ctx.config.as_text_style().patch(ctx.config.theme.current_item_style),
+        );
         let section = cb(section);
         if let Some(mut section) = section {
             section.state.set_content_len(Some(section.items.len()));

--- a/rmpc/src/ui/modals/menu/select_section.rs
+++ b/rmpc/src/ui/modals/menu/select_section.rs
@@ -168,7 +168,9 @@ impl Section for SelectSection {
             } else if let Some(f) = filter
                 && item.label.to_lowercase().contains(f)
             {
-                text = text.style(ctx.config.theme.highlighted_item_style);
+                text = text.style(
+                    ctx.config.as_text_style().patch(ctx.config.theme.highlighted_item_style),
+                );
             } else {
                 text = text.style(
                     ctx.config

--- a/rmpc/src/ui/modals/select_modal.rs
+++ b/rmpc/src/ui/modals/select_modal.rs
@@ -131,7 +131,9 @@ impl<V: Display + std::fmt::Debug, Callback: FnOnce(&Ctx, V, usize) -> Result<()
 
         self.button_group.set_active_style(match self.focused {
             FocusedComponent::List => Style::default().reversed(),
-            FocusedComponent::Buttons => ctx.config.theme.current_item_style,
+            FocusedComponent::Buttons => {
+                ctx.config.as_text_style().patch(ctx.config.theme.current_item_style)
+            }
         });
 
         let scrollbar_area =

--- a/rmpc/src/ui/panes/lyrics.rs
+++ b/rmpc/src/ui/panes/lyrics.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
-    style::Style,
     text::Text,
 };
 
@@ -71,10 +70,10 @@ impl Pane for LyricsPane {
         let areas = Layout::vertical((0..rows).map(|_| Constraint::Length(1))).split(area);
         let middle_row = rows.saturating_sub(1) / 2;
 
-        let default_style = Style::default().fg(ctx.config.theme.text_color.unwrap_or_default());
+        let default_style = ctx.config.as_text_style();
 
         let middle_style = if first_line_reached {
-            ctx.config.theme.highlighted_item_style
+            ctx.config.as_text_style().patch(ctx.config.theme.highlighted_item_style)
         } else {
             default_style
         };

--- a/rmpc/src/ui/panes/mod.rs
+++ b/rmpc/src/ui/panes/mod.rs
@@ -422,7 +422,7 @@ impl Property<PropertyKind> {
         tag_separator: &str,
         strategy: TagResolutionStrategy,
     ) -> Option<Either<Span<'s>, Vec<Span<'s>>>> {
-        let style = self.style.unwrap_or_default();
+        let style = ctx.config.as_text_style().patch(self.style.unwrap_or_default());
         let status = &ctx.status;
         match &self.kind {
             PropertyKindOrText::Text(value) => Some(Either::Left(Span::styled(value, style))),

--- a/rmpc/src/ui/panes/search/mod.rs
+++ b/rmpc/src/ui/panes/search/mod.rs
@@ -95,8 +95,8 @@ impl SearchPane {
             .search_button(config.search.search_button)
             .text_style(config.as_text_style())
             .separator_style(config.theme.borders_style)
-            .current_item_style(config.theme.current_item_style)
-            .highlight_item_style(config.theme.highlighted_item_style)
+            .current_item_style(config.as_text_style().patch(config.theme.current_item_style))
+            .highlight_item_style(config.as_text_style().patch(config.theme.highlighted_item_style))
             .stickers_supported(ctx.stickers_supported.into())
             .strip_diacritics_supported(ctx.mpd_version >= Version::new(0, 25, 0))
             .custom_query(config.search.custom_query)
@@ -165,6 +165,7 @@ impl SearchPane {
         let current = List::new(
             self.songs_dir.to_list_items(ctx.config.theme.browser_song_format.0.as_slice(), ctx),
         )
+        .style(config.as_text_style())
         .highlight_style(config.theme.current_item_style);
         let directory = &mut self.songs_dir;
 

--- a/rmpc/src/ui/song_ext.rs
+++ b/rmpc/src/ui/song_ext.rs
@@ -423,7 +423,7 @@ impl SongExt for Song {
         strategy: TagResolutionStrategy,
         ctx: &'stickers Ctx,
     ) -> Option<Line<'song>> {
-        let style = format.style.unwrap_or_default();
+        let style = ctx.config.as_text_style().patch(format.style.unwrap_or_default());
         match &format.kind {
             PropertyKindOrText::Text(value) => Some(Line::styled(value.clone(), style)),
             PropertyKindOrText::Sticker(key) => ctx


### PR DESCRIPTION
## Description

This makes more styles stack on others to make theming more consistent.
- 'current' and 'highlight' versions of symbols styles stack on the base style for that symbol
- Models now use `text_color`
- `highlight_border_style` defaults to `borders_style`
- tab bar defaults to using `current_item_style` for active tab and `text_color` for inactive tab

Only the model change should affect fully defined themes but the rest of the changes make theming more forgiving to incomplete themes and reduce the effects of adding new theme options as they inherit from the existing options.

### Related issues

This is progress on #920 but not a full implementation of text color

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [ ] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated

If these changes are ok I will work on a pr for the docs.