### PR TITLE
feat: mark songs of album around selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - Added alignment config to lyrics
 - Song info modal now respects `duration_format`
 - Add `-v`/`--version` args to cli
+- `SelectAlbum` queue keybind
 
 ### Changed
 

--- a/assets/example_config.ron
+++ b/assets/example_config.ron
@@ -127,7 +127,7 @@
             "D":          DeleteAll,
             "<CR>":       Play,
             "C":          JumpToCurrent,
-            "L":          SelectAlbum,
+            "L":          SelectAlbum(),
             "X":          Shuffle,
         },
     ),

--- a/assets/example_config.ron
+++ b/assets/example_config.ron
@@ -127,6 +127,7 @@
             "D":          DeleteAll,
             "<CR>":       Play,
             "C":          JumpToCurrent,
+            "L":          SelectAlbum,
             "X":          Shuffle,
         },
     ),

--- a/rmpc/src/config/keys/actions.rs
+++ b/rmpc/src/config/keys/actions.rs
@@ -352,6 +352,7 @@ pub enum QueueActionsFile {
     Sort {
         kind: SortFile,
     },
+    SelectAlbum,
 }
 
 #[derive(Debug, Display, Clone, EnumDiscriminants, PartialEq, Eq)]
@@ -363,6 +364,7 @@ pub enum QueueActions {
     JumpToCurrent,
     Shuffle,
     Unused,
+    SelectAlbum,
     SortByColumn(usize),
     Sort { kind: Sort },
 }
@@ -379,6 +381,7 @@ impl TryFrom<QueueActionsFile> for QueueActions {
             QueueActionsFile::AddToPlaylist => Ok(QueueActions::Unused),
             QueueActionsFile::ShowInfo => Ok(QueueActions::Unused),
             QueueActionsFile::JumpToCurrent => Ok(QueueActions::JumpToCurrent),
+            QueueActionsFile::SelectAlbum => Ok(QueueActions::SelectAlbum),
             QueueActionsFile::Shuffle => Ok(QueueActions::Shuffle),
             QueueActionsFile::SortByColumn(idx) => {
                 let idx = idx.checked_sub(1);
@@ -418,6 +421,7 @@ impl ToDescription for QueueActions {
             QueueActions::JumpToCurrent => {
                 "Moves the cursor in Queue table to the currently playing song".into()
             }
+            QueueActions::SelectAlbum => "Marks songs of album around selected song".into(),
             QueueActions::Shuffle => "Shuffles the current queue".into(),
             QueueActions::SortByColumn(idx) => {
                 format!("Sort the queue by the {idx}. column").into()

--- a/rmpc/src/config/keys/actions.rs
+++ b/rmpc/src/config/keys/actions.rs
@@ -352,7 +352,7 @@ pub enum QueueActionsFile {
     Sort {
         kind: SortFile,
     },
-    SelectAlbum,
+    SelectAlbum(),
 }
 
 #[derive(Debug, Display, Clone, EnumDiscriminants, PartialEq, Eq)]
@@ -381,7 +381,7 @@ impl TryFrom<QueueActionsFile> for QueueActions {
             QueueActionsFile::AddToPlaylist => Ok(QueueActions::Unused),
             QueueActionsFile::ShowInfo => Ok(QueueActions::Unused),
             QueueActionsFile::JumpToCurrent => Ok(QueueActions::JumpToCurrent),
-            QueueActionsFile::SelectAlbum => Ok(QueueActions::SelectAlbum),
+            QueueActionsFile::SelectAlbum() => Ok(QueueActions::SelectAlbum),
             QueueActionsFile::Shuffle => Ok(QueueActions::Shuffle),
             QueueActionsFile::SortByColumn(idx) => {
                 let idx = idx.checked_sub(1);

--- a/rmpc/src/config/keys/mod.rs
+++ b/rmpc/src/config/keys/mod.rs
@@ -168,7 +168,7 @@ impl Default for KeyConfigFile {
             (s().char('D'),                       Q::DeleteAll),
             (s().cr(),                            Q::Play),
             (s().char('C'),                       Q::JumpToCurrent),
-            (s().char('L'),                       Q::SelectAlbum),
+            (s().char('L'),                       Q::SelectAlbum()),
             (s().char('X'),                       Q::Shuffle),
         ]);
 

--- a/rmpc/src/config/keys/mod.rs
+++ b/rmpc/src/config/keys/mod.rs
@@ -168,6 +168,7 @@ impl Default for KeyConfigFile {
             (s().char('D'),                       Q::DeleteAll),
             (s().cr(),                            Q::Play),
             (s().char('C'),                       Q::JumpToCurrent),
+            (s().char('L'),                       Q::SelectAlbum),
             (s().char('X'),                       Q::Shuffle),
         ]);
 

--- a/rmpc/src/ui/panes/queue.rs
+++ b/rmpc/src/ui/panes/queue.rs
@@ -847,6 +847,20 @@ impl Pane for QueuePane {
                         status_info!("No song is currently playing");
                     }
                 }
+
+                QueueActions::SelectAlbum => {
+                    if let Some(selected_idx) = self.queue.selected_idx() {
+                        let mut album_ranges = self.queue.items.as_slice().to_album_ranges();
+
+                        if let Some(range) = album_ranges.find(|r| r.contains(&selected_idx)) {
+                            for idx in range {
+                                self.queue.state.toggle_mark(idx);
+                            }
+                            ctx.render()?;
+                        }
+                    }
+                }
+
                 QueueActions::Shuffle if !self.queue.marked().is_empty() => {
                     for range in self.queue.marked().ranges().rev() {
                         ctx.command(move |client| {


### PR DESCRIPTION
## Description

Queue key bind for marking songs of album around selected song.

### Related issues

https://github.com/mierak/rmpc/issues/978

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [ ] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
