### PR TITLE
fix: correctly track PREV_SONG in on_song_change with consume on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ keybinds
 - `debuginfo` command no longer shows incorrect errors about missing components
 - also consider `all` when verifying tmux passthrough
 - add `iTerm.app` into emulator env variable detection
+- `PREV_SONG` in `on_song_change` is now correctly tracked with consume on
 
 ## [0.11.0] - 2026-02-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3315,6 +3315,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "derive_more",
+ "enum-map",
  "itertools 0.14.0",
  "log",
  "rand 0.9.2",

--- a/rmpc-mpd/Cargo.toml
+++ b/rmpc-mpd/Cargo.toml
@@ -9,14 +9,15 @@ rust-version.workspace = true
 
 [dependencies]
 rmpc-shared = { path = "../rmpc-shared" }
-log = { workspace = true }
 anyhow = { workspace = true }
-strum = { workspace = true }
 chrono = { workspace = true }
-serde = { workspace = true }
 derive_more = { workspace = true }
-rand = { workspace = true }
+enum-map = { workspace = true }
 itertools = { workspace = true }
+log = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+strum = { workspace = true }
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/rmpc-mpd/src/commands/idle.rs
+++ b/rmpc-mpd/src/commands/idle.rs
@@ -3,7 +3,7 @@ use crate::{
     from_mpd::{FromMpd, LineHandled},
 };
 
-#[derive(Debug, Clone, Copy, strum::Display, Eq, Hash, PartialEq)]
+#[derive(Debug, Clone, Copy, strum::Display, Eq, Hash, PartialEq, enum_map::Enum)]
 #[strum(serialize_all = "snake_case")]
 pub enum IdleEvent {
     Player,   /* the player has been started, stopped or seeked or tags of

--- a/rmpc-mpd/src/tests/fixtures/mpd_client.rs
+++ b/rmpc-mpd/src/tests/fixtures/mpd_client.rs
@@ -148,7 +148,7 @@ impl MpdClient for TestMpdClient {
     }
 
     fn noidle(&mut self) -> MpdResult<()> {
-        todo!()
+        todo!("Not yet implemented")
     }
 
     fn get_volume(&mut self) -> MpdResult<Volume> {
@@ -312,6 +312,10 @@ impl MpdClient for TestMpdClient {
 
     fn playlist_info(&mut self) -> MpdResult<Option<Vec<Song>>> {
         Ok(Some(self.queue.iter().map(|idx| self.songs[*idx].clone()).collect()))
+    }
+
+    fn playlist_id(&mut self, _id: u32) -> MpdResult<Option<Song>> {
+        todo!("Not yet implemented")
     }
 
     /// `FilterKind` not implemented, everything is treated as Contains

--- a/rmpc/src/core/client.rs
+++ b/rmpc/src/core/client.rs
@@ -229,7 +229,7 @@ fn client_task(
                                     continue;
                                 }
 
-                                match handle_client_request(&mut client, request) {
+                                match handle_client_request(&mut client, event_tx, request) {
                                     Ok(result) => {
                                         health!(
                                             event_tx.send(AppEvent::WorkDone(Ok(result))),
@@ -355,7 +355,11 @@ fn check_connection(
     }
 }
 
-fn handle_client_request(client: &mut Client<'_>, request: ClientRequest) -> Result<WorkDone> {
+fn handle_client_request(
+    client: &mut Client<'_>,
+    event_tx: &Sender<AppEvent>,
+    request: ClientRequest,
+) -> Result<WorkDone> {
     match request {
         ClientRequest::Query(query) => Ok(WorkDone::MpdCommandFinished {
             id: query.id,
@@ -363,7 +367,7 @@ fn handle_client_request(client: &mut Client<'_>, request: ClientRequest) -> Res
             data: (query.callback)(client)?,
         }),
         ClientRequest::Command(command) => {
-            (command.callback)(client)?;
+            (command.callback)(event_tx, client)?;
             Ok(WorkDone::None)
         }
         ClientRequest::QuerySync(query) => {

--- a/rmpc/src/core/command.rs
+++ b/rmpc/src/core/command.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use anyhow::{Result, bail};
+use crossbeam::channel::Sender;
 use itertools::Itertools;
 use rmpc_mpd::{
     client::Client,
@@ -26,6 +27,7 @@ use crate::{
     ctx::Ctx,
     shared::{
         args,
+        events::AppEvent,
         ext::duration::DurationExt,
         lrc::{LrcIndex, get_lrc_path},
         macros::status_error,
@@ -34,7 +36,7 @@ use crate::{
     },
 };
 
-type CommandFn = Box<dyn FnOnce(&mut Client<'_>) -> Result<()> + Send + 'static>;
+type CommandFn = Box<dyn FnOnce(&Sender<AppEvent>, &mut Client<'_>) -> Result<()> + Send + 'static>;
 
 impl Command {
     pub fn execute(mut self, config: &CliConfig) -> Result<CommandFn> {
@@ -45,7 +47,7 @@ impl Command {
             Command::DebugInfo => bail!("Cannot use debuginfo command here."),
             Command::Raw { .. } => bail!("Cannot use raw command here."),
             Command::Remote { .. } => bail!("Cannot use remote command here."),
-            Command::AddRandom { tag, count } => Ok(Box::new(move |client| {
+            Command::AddRandom { tag, count } => Ok(Box::new(move |_, client| {
                 match tag {
                     AddRandom::Song => {
                         client.add_random_songs(count, None)?;
@@ -67,7 +69,7 @@ impl Command {
             })),
             Command::Update { ref mut path, wait } | Command::Rescan { ref mut path, wait } => {
                 let path = path.take();
-                Ok(Box::new(move |client| {
+                Ok(Box::new(move |_, client| {
                     let rmpc_mpd::commands::Update { job_id } =
                         if matches!(self, Command::Update { .. }) {
                             client.update(path.as_deref())?
@@ -96,7 +98,7 @@ impl Command {
             }
             Command::LyricsIndex => {
                 let lyrics_dir = config.lyrics_dir.clone();
-                Ok(Box::new(|_| {
+                Ok(Box::new(|_, _| {
                     let Some(dir) = lyrics_dir else {
                         bail!("Lyrics dir is not configured");
                     };
@@ -107,7 +109,7 @@ impl Command {
                     Ok(())
                 }))
             }
-            Command::Queue => Ok(Box::new(|client| {
+            Command::Queue => Ok(Box::new(|_, client| {
                 let queue = client.playlist_info()?;
                 if let Some(queue) = queue {
                     println!("{}", serde_json::ser::to_string(&queue)?);
@@ -116,7 +118,7 @@ impl Command {
                     std::process::exit(1);
                 }
             })),
-            Command::ListAll { files } => Ok(Box::new(|client| {
+            Command::ListAll { files } => Ok(Box::new(|_, client| {
                 let result = if files.is_empty() {
                     client.list_all(None)?
                 } else {
@@ -131,12 +133,12 @@ impl Command {
                 result.into_files().for_each(|file| println!("{file}"));
                 Ok(())
             })),
-            Command::Play { position: None } => Ok(Box::new(|client| Ok(client.play()?))),
+            Command::Play { position: None } => Ok(Box::new(|_, client| Ok(client.play()?))),
             Command::Play { position: Some(pos) } => {
-                Ok(Box::new(move |client| Ok(client.play_pos(pos)?)))
+                Ok(Box::new(move |_, client| Ok(client.play_pos(pos)?)))
             }
-            Command::Pause => Ok(Box::new(|client| Ok(client.pause()?))),
-            Command::TogglePause => Ok(Box::new(|client| {
+            Command::Pause => Ok(Box::new(|_, client| Ok(client.pause()?))),
+            Command::TogglePause => Ok(Box::new(|_, client| {
                 let status = client.get_status()?;
                 if matches!(status.state, State::Play | State::Pause) {
                     client.pause_toggle()?;
@@ -145,20 +147,20 @@ impl Command {
                 }
                 Ok(())
             })),
-            Command::Unpause => Ok(Box::new(|client| Ok(client.unpause()?))),
-            Command::Stop => Ok(Box::new(|client| Ok(client.stop()?))),
+            Command::Unpause => Ok(Box::new(|_, client| Ok(client.unpause()?))),
+            Command::Stop => Ok(Box::new(|_, client| Ok(client.stop()?))),
             Command::Volume { value: Some(value) } => {
-                Ok(Box::new(move |client| Ok(client.volume(value.parse()?)?)))
+                Ok(Box::new(move |_, client| Ok(client.volume(value.parse()?)?)))
             }
-            Command::Volume { value: None } => Ok(Box::new(|client| {
+            Command::Volume { value: None } => Ok(Box::new(|_, client| {
                 println!("{}", client.get_status()?.volume.value());
                 Ok(())
             })),
-            Command::Next { keep_state } => Ok(Box::new(move |client| {
+            Command::Next { keep_state } => Ok(Box::new(move |_, client| {
                 let status = client.get_status()?;
                 Ok(client.next_keep_state(keep_state, status.state)?)
             })),
-            Command::Prev { rewind_to_start, keep_state } => Ok(Box::new(move |client| {
+            Command::Prev { rewind_to_start, keep_state } => Ok(Box::new(move |_, client| {
                 let status = client.get_status()?;
                 match rewind_to_start {
                     Some(value) if status.elapsed.as_secs() >= value => {
@@ -174,26 +176,26 @@ impl Command {
                 Ok(())
             })),
             Command::Repeat { value } => {
-                Ok(Box::new(move |client| Ok(client.repeat((value).into())?)))
+                Ok(Box::new(move |_, client| Ok(client.repeat((value).into())?)))
             }
             Command::Random { value } => {
-                Ok(Box::new(move |client| Ok(client.random((value).into())?)))
+                Ok(Box::new(move |_, client| Ok(client.random((value).into())?)))
             }
             Command::Single { value } => {
-                Ok(Box::new(move |client| Ok(client.single((value).into())?)))
+                Ok(Box::new(move |_, client| Ok(client.single((value).into())?)))
             }
             Command::Consume { value } => {
-                Ok(Box::new(move |client| Ok(client.consume((value).into())?)))
+                Ok(Box::new(move |_, client| Ok(client.consume((value).into())?)))
             }
-            Command::ToggleRepeat => Ok(Box::new(move |client| {
+            Command::ToggleRepeat => Ok(Box::new(move |_, client| {
                 let status = client.get_status()?;
                 Ok(client.repeat(!status.repeat)?)
             })),
-            Command::ToggleRandom => Ok(Box::new(move |client| {
+            Command::ToggleRandom => Ok(Box::new(move |_, client| {
                 let status = client.get_status()?;
                 Ok(client.random(!status.random)?)
             })),
-            Command::ToggleSingle { skip_oneshot } => Ok(Box::new(move |client| {
+            Command::ToggleSingle { skip_oneshot } => Ok(Box::new(move |_, client| {
                 let status = client.get_status()?;
                 if skip_oneshot || client.version() < Version::new(0, 21, 0) {
                     client.single(status.single.cycle_skip_oneshot())?;
@@ -202,7 +204,7 @@ impl Command {
                 }
                 Ok(())
             })),
-            Command::ToggleConsume { skip_oneshot } => Ok(Box::new(move |client| {
+            Command::ToggleConsume { skip_oneshot } => Ok(Box::new(move |_, client| {
                 let status = client.get_status()?;
                 if skip_oneshot || client.version() < Version::new(0, 24, 0) {
                     client.consume(status.consume.cycle_skip_oneshot())?;
@@ -212,13 +214,13 @@ impl Command {
                 Ok(())
             })),
             Command::Seek { value } => {
-                Ok(Box::new(move |client| Ok(client.seek_current(value.parse()?)?)))
+                Ok(Box::new(move |_, client| Ok(client.seek_current(value.parse()?)?)))
             }
-            Command::Clear => Ok(Box::new(|client| Ok(client.clear()?))),
+            Command::Clear => Ok(Box::new(|_, client| Ok(client.clear()?))),
             Command::Add { files, skip_ext_check, position }
                 if files.iter().any(|path| path.is_absolute()) =>
             {
-                Ok(Box::new(move |client| {
+                Ok(Box::new(move |_, client| {
                     let Some(MpdConfig { music_directory, .. }) = client.config() else {
                         status_error!("Cannot add absolute path without socket connection to MPD");
                         return Ok(());
@@ -272,7 +274,7 @@ impl Command {
                     Ok(())
                 }))
             }
-            Command::Add { mut files, position, .. } => Ok(Box::new(move |client| {
+            Command::Add { mut files, position, .. } => Ok(Box::new(move |_, client| {
                 if let Some(QueuePosition::Absolute(_) | QueuePosition::RelativeAdd(_)) = position {
                     files.reverse();
                 }
@@ -282,7 +284,7 @@ impl Command {
 
                 Ok(())
             })),
-            Command::Remove { positions } => Ok(Box::new(move |client| {
+            Command::Remove { positions } => Ok(Box::new(move |_, client| {
                 let mut positions: BTreeSet<_> = positions.into_iter().collect();
                 let status = client.get_status()?;
 
@@ -316,7 +318,7 @@ impl Command {
             })),
             Command::AddYt { url, position } => {
                 let config = config.clone();
-                Ok(Box::new(move |client| {
+                Ok(Box::new(move |_, client| {
                     // Idle with message subsystem, the cli client is never subscribed to any
                     // channels so this will idle indefinitely
                     client.enter_idle(Some(IdleEvent::Message))?;
@@ -351,7 +353,7 @@ impl Command {
                 };
 
                 let config = config.clone();
-                Ok(Box::new(move |client| {
+                Ok(Box::new(move |_, client| {
                     // Idle with message subsystem, the cli client is never subscribed to any
                     // channels so this will idle indefinitely
                     client.enter_idle(Some(IdleEvent::Message))?;
@@ -371,11 +373,11 @@ impl Command {
                     Ok(())
                 }))
             }
-            Command::Save { name } => Ok(Box::new(move |client| {
+            Command::Save { name } => Ok(Box::new(move |_, client| {
                 client.save_queue_as_playlist(&name, None)?;
                 Ok(())
             })),
-            Command::Load { names } => Ok(Box::new(|client| {
+            Command::Load { names } => Ok(Box::new(|_, client| {
                 client.send_start_cmd_list()?;
                 for name in names {
                     client.send_load_playlist(&name, None)?;
@@ -384,29 +386,29 @@ impl Command {
                 client.read_ok()?;
                 Ok(())
             })),
-            Command::Decoders => Ok(Box::new(|client| {
+            Command::Decoders => Ok(Box::new(|_, client| {
                 println!("{}", serde_json::ser::to_string(&client.decoders()?)?);
                 Ok(())
             })),
-            Command::Outputs => Ok(Box::new(|client| {
+            Command::Outputs => Ok(Box::new(|_, client| {
                 println!("{}", serde_json::ser::to_string(&client.outputs()?)?);
                 Ok(())
             })),
             Command::ToggleOutput { id } => {
-                Ok(Box::new(move |client| Ok(client.toggle_output(id)?)))
+                Ok(Box::new(move |_, client| Ok(client.toggle_output(id)?)))
             }
             Command::EnableOutput { id } => {
-                Ok(Box::new(move |client| Ok(client.enable_output(id)?)))
+                Ok(Box::new(move |_, client| Ok(client.enable_output(id)?)))
             }
             Command::DisableOutput { id } => {
-                Ok(Box::new(move |client| Ok(client.disable_output(id)?)))
+                Ok(Box::new(move |_, client| Ok(client.disable_output(id)?)))
             }
-            Command::Status => Ok(Box::new(|client| {
+            Command::Status => Ok(Box::new(|_, client| {
                 println!("{}", serde_json::ser::to_string(&client.get_status()?)?);
                 Ok(())
             })),
             Command::Song { path: Some(paths) } if paths.len() == 1 => {
-                Ok(Box::new(move |client| {
+                Ok(Box::new(move |_, client| {
                     let path = &paths[0];
                     if let Some(song) = client.find_one(&[Filter::new(Tag::File, path.as_str())])? {
                         println!("{}", serde_json::ser::to_string(&song)?);
@@ -417,7 +419,7 @@ impl Command {
                     }
                 }))
             }
-            Command::Song { path: Some(paths) } => Ok(Box::new(move |client| {
+            Command::Song { path: Some(paths) } => Ok(Box::new(move |_, client| {
                 let mut songs = Vec::new();
                 for path in &paths {
                     if let Some(song) = client.find_one(&[Filter::new(Tag::File, path.as_str())])? {
@@ -430,7 +432,7 @@ impl Command {
                 println!("{}", serde_json::ser::to_string(&songs)?);
                 Ok(())
             })),
-            Command::Song { path: None } => Ok(Box::new(|client| {
+            Command::Song { path: None } => Ok(Box::new(|_, client| {
                 let current_song = client.get_current_song()?;
                 if let Some(song) = current_song {
                     println!("{}", serde_json::ser::to_string(&song)?);
@@ -440,18 +442,18 @@ impl Command {
                 }
             })),
             Command::Mount { name, path } => {
-                Ok(Box::new(move |client| Ok(client.mount(&name, &path)?)))
+                Ok(Box::new(move |_, client| Ok(client.mount(&name, &path)?)))
             }
-            Command::Unmount { name } => Ok(Box::new(move |client| Ok(client.unmount(&name)?))),
-            Command::ListMounts => Ok(Box::new(|client| {
+            Command::Unmount { name } => Ok(Box::new(move |_, client| Ok(client.unmount(&name)?))),
+            Command::ListMounts => Ok(Box::new(|_, client| {
                 println!("{}", serde_json::ser::to_string(&client.list_mounts()?)?);
                 Ok(())
             })),
-            Command::ListPartitions => Ok(Box::new(|client| {
+            Command::ListPartitions => Ok(Box::new(|_, client| {
                 println!("{}", serde_json::ser::to_string(&client.list_partitions()?.0)?);
                 Ok(())
             })),
-            Command::AlbumArt { output } => Ok(Box::new(move |client| {
+            Command::AlbumArt { output } => Ok(Box::new(move |_, client| {
                 let Some(song) = client.get_current_song()? else {
                     std::process::exit(3);
                 };
@@ -477,47 +479,49 @@ impl Command {
                 }
             })),
             Command::Sticker { cmd: StickerCmd::Set { uri, key, value } } => {
-                Ok(Box::new(move |client| {
+                Ok(Box::new(move |_, client| {
                     client.set_sticker(&uri, &key, &value)?;
                     Ok(())
                 }))
             }
-            Command::Sticker { cmd: StickerCmd::Get { uri, key } } => Ok(Box::new(move |client| {
-                match client.sticker(&uri, &key)? {
-                    Some(sticker) => {
-                        println!("{}", serde_json::ser::to_string(&sticker)?);
+            Command::Sticker { cmd: StickerCmd::Get { uri, key } } => {
+                Ok(Box::new(move |_, client| {
+                    match client.sticker(&uri, &key)? {
+                        Some(sticker) => {
+                            println!("{}", serde_json::ser::to_string(&sticker)?);
+                        }
+                        None => {
+                            std::process::exit(1);
+                        }
                     }
-                    None => {
-                        std::process::exit(1);
-                    }
-                }
-                Ok(())
-            })),
+                    Ok(())
+                }))
+            }
             Command::Sticker { cmd: StickerCmd::Delete { uri, key } } => {
-                Ok(Box::new(move |client| {
+                Ok(Box::new(move |_, client| {
                     client.delete_sticker(&uri, &key)?;
                     Ok(())
                 }))
             }
             Command::Sticker { cmd: StickerCmd::DeleteAll { uri } } => {
-                Ok(Box::new(move |client| {
+                Ok(Box::new(move |_, client| {
                     client.delete_all_stickers(&uri)?;
                     Ok(())
                 }))
             }
-            Command::Sticker { cmd: StickerCmd::List { uri } } => Ok(Box::new(move |client| {
+            Command::Sticker { cmd: StickerCmd::List { uri } } => Ok(Box::new(move |_, client| {
                 let stickers = client.list_stickers(&uri)?;
                 println!("{}", serde_json::ser::to_string(&stickers)?);
                 Ok(())
             })),
             Command::Sticker { cmd: StickerCmd::Find { uri, key } } => {
-                Ok(Box::new(move |client| {
+                Ok(Box::new(move |_, client| {
                     let stickers = client.find_stickers(&uri, &key, None)?;
                     println!("{}", serde_json::ser::to_string(&stickers)?);
                     Ok(())
                 }))
             }
-            Command::SendMessage { channel, content } => Ok(Box::new(move |client| {
+            Command::SendMessage { channel, content } => Ok(Box::new(move |_, client| {
                 client.send_message(&channel, &content)?;
                 Ok(())
             })),
@@ -615,7 +619,7 @@ pub fn create_env<'a>(
 ) -> Vec<(String, String)> {
     let mut result = Vec::new();
 
-    if let Some((_, current)) = ctx.find_current_song_in_queue() {
+    if let Some(current) = ctx.current_song().as_ref() {
         result.push(("CURRENT_SONG".to_owned(), current.file.clone()));
         result.extend(
             current.metadata.iter().map(|(k, v)| (k.to_ascii_uppercase(), v.last().to_owned())),

--- a/rmpc/src/core/event_loop.rs
+++ b/rmpc/src/core/event_loop.rs
@@ -1,11 +1,11 @@
 use std::{
-    collections::HashSet,
     path::PathBuf,
     sync::{Arc, LazyLock},
     time::{Duration, Instant},
 };
 
 use crossbeam::channel::{Receiver, RecvTimeoutError};
+use enum_map::{EnumMap, enum_map};
 use ratatui::{Terminal, layout::Rect, prelude::Backend};
 use rmpc_mpd::{
     commands::{IdleEvent, State},
@@ -71,11 +71,13 @@ fn main_task<B: Backend + std::io::Write>(
     let mut last_render = std::time::Instant::now()
         .checked_sub(Duration::from_secs(10))
         .unwrap_or_else(std::time::Instant::now);
-    let mut additional_evs = HashSet::new();
     let mut connected = true;
     ui.before_show(area, &mut ctx).expect("Initial render init to succeed");
     let mut _update_loop_guard = None;
     let mut _update_db_loop_guard = None;
+    let mut events_to_ignore: EnumMap<IdleEvent, usize> = EnumMap::default();
+    let mut reconcile_pending: EnumMap<IdleEvent, bool> = EnumMap::default();
+    let reconcile_id: EnumMap<IdleEvent, Id> = enum_map! { _ => id::new() };
 
     // Tmux hooks have to be initialized after ui, because ueberzugpp replaces all
     // hooks on its init instead of simply appending and might break rmpc's hooks
@@ -91,7 +93,7 @@ fn main_task<B: Backend + std::io::Write>(
     // Execute on_song_change at startup if
     // configured and current song is available.
     if ctx.config.exec_on_song_change_at_start
-        && let Some((_, _song)) = ctx.find_current_song_in_queue()
+        && let Some(_song) = ctx.current_song()
         && let Some(command) = &ctx.config.on_song_change
     {
         let env = create_env(&ctx, std::iter::empty());
@@ -144,6 +146,32 @@ fn main_task<B: Backend + std::io::Write>(
 
         if let Some(event) = event {
             match event {
+                AppEvent::IgnoreIdleEvent(ev) => {
+                    events_to_ignore[ev] += 1;
+                    if reconcile_pending[ev] {
+                        ctx.scheduler.cancel(reconcile_id[ev]);
+                        reconcile_pending[ev] = false;
+                    }
+                }
+                AppEvent::UnIgnoreIdleEvent(ev) => {
+                    events_to_ignore[ev] -= 1;
+                    if events_to_ignore[ev] == 0 {
+                        reconcile_pending[ev] = true;
+                        let timeout = Duration::from_millis(100);
+                        ctx.scheduler.schedule_replace(
+                            reconcile_id[ev],
+                            timeout,
+                            move |(tx, _)| {
+                                tx.send(AppEvent::ReconcileIdleEvent(ev))
+                                    .map_err(|err| anyhow::anyhow!(err))
+                            },
+                        );
+                    }
+                }
+                AppEvent::ReconcileIdleEvent(ev) => {
+                    reconcile_pending[ev] = false;
+                    handle_idle_event(ev, &ctx);
+                }
                 AppEvent::ConfigChanged { config: mut new_config, keep_old_theme } => {
                     // Technical limitation. Keep the old image backend because it was not rechecked
                     // anyway. Sending the escape sequences to determine image support would mess up
@@ -316,11 +344,16 @@ fn main_task<B: Backend + std::io::Write>(
                     }
                 }
                 AppEvent::IdleEvent(event) => {
-                    handle_idle_event(event, &ctx, &mut additional_evs);
-                    for ev in additional_evs.drain().filter_map(|ev| UiEvent::try_from(ev).ok()) {
-                        if let Err(err) = ui.on_event(ev, &mut ctx) {
-                            status_error!(error:? = err, event:?; "UI failed to handle idle event, event: '{:?}', error: '{}'", event, err.to_status());
-                        }
+                    if events_to_ignore[event] > 0 || reconcile_pending[event] {
+                        log::debug!(event:?; "Ignoring idle event due to previous ignore request");
+                        continue;
+                    }
+
+                    handle_idle_event(event, &ctx);
+                    if let Ok(ev) = event.try_into()
+                        && let Err(err) = ui.on_event(ev, &mut ctx)
+                    {
+                        status_error!(error:? = err, event:?; "UI failed to handle idle event, event: '{:?}', error: '{}'", event, err.to_status());
                     }
                     render_wanted = true;
                 }
@@ -372,7 +405,7 @@ fn main_task<B: Backend + std::io::Write>(
                         match ctx.ytdlp_manager.resolve_download(id, result) {
                             Ok((path, position)) => {
                                 let cache_dir = ctx.config.cache_dir.clone();
-                                ctx.command(move |client| {
+                                ctx.command(move |_, client| {
                                     client.add_downloaded_file_to_queue(
                                         path,
                                         cache_dir.as_deref(),
@@ -476,10 +509,13 @@ fn main_task<B: Backend + std::io::Write>(
                         (
                             GLOBAL_STATUS_UPDATE,
                             None,
-                            MpdQueryResult::Status { data: status, source_event },
+                            MpdQueryResult::Status {
+                                status,
+                                current_song: new_current_song,
+                                source_event,
+                            },
                         ) => {
-                            let current_song_id =
-                                ctx.find_current_song_in_queue().map(|(_, song)| song.id);
+                            let current_song_id = ctx.current_song().map(|s| s.id);
                             let previous_state = ctx.status.state;
                             let current_updating_db = ctx.status.updating_db;
                             let current_playlist = ctx.status.lastloadedplaylist.take();
@@ -497,7 +533,7 @@ fn main_task<B: Backend + std::io::Write>(
                                     && &current_playlist == new_playlist
                                 {
                                     let playlist_name = current_playlist.clone();
-                                    ctx.command(move |client| {
+                                    ctx.command(move |_, client| {
                                         client.save_queue_as_playlist(
                                             &playlist_name,
                                             Some(SaveMode::Replace),
@@ -569,16 +605,14 @@ fn main_task<B: Backend + std::io::Write>(
                                 }
                             }
 
-                            if let Some((_, song)) = ctx.find_current_song_in_queue()
+                            if let Some(song) = new_current_song.as_ref()
                                 && Some(song.id) != current_song_id
                             {
                                 if let Some(command) = &ctx.config.on_song_change {
                                     let mut env = create_env(&ctx, std::iter::empty());
 
                                     let prev_song_file = (previous_status.state != State::Stop)
-                                        .then_some(previous_status.song.and_then(|idx| {
-                                            ctx.queue.get(idx).map(|song| song.file.clone())
-                                        }))
+                                        .then(|| ctx.current_song().map(|s| s.file.clone()))
                                         .flatten();
 
                                     if let (Some(prev_song), Some(played)) =
@@ -602,6 +636,7 @@ fn main_task<B: Backend + std::io::Write>(
                                 status_error!(error:? = err; "UI failed to handle idle event, error: '{}'", err.to_status());
                             }
 
+                            ctx.set_current_song(new_current_song);
                             ctx.last_status_update = Instant::now();
                             render_wanted = true;
                         }
@@ -714,7 +749,7 @@ fn main_task<B: Backend + std::io::Write>(
                 }
                 AppEvent::Reconnected => {
                     for ev in [IdleEvent::Player, IdleEvent::Playlist, IdleEvent::Options] {
-                        handle_idle_event(ev, &ctx, &mut additional_evs);
+                        handle_idle_event(ev, &ctx);
                     }
                     if let Err(err) = ui.on_event(UiEvent::Reconnected, &mut ctx) {
                         log::error!(error:? = err, event:?; "UI failed to handle resize event");
@@ -780,7 +815,7 @@ fn main_task<B: Backend + std::io::Write>(
     terminal
 }
 
-fn handle_idle_event(event: IdleEvent, ctx: &Ctx, result_ui_evs: &mut HashSet<IdleEvent>) {
+fn handle_idle_event(event: IdleEvent, ctx: &Ctx) {
     match event {
         IdleEvent::Mixer if ctx.supported_commands.contains("getvol") => {
             ctx.query()
@@ -790,24 +825,30 @@ fn handle_idle_event(event: IdleEvent, ctx: &Ctx, result_ui_evs: &mut HashSet<Id
         }
         IdleEvent::Mixer => {
             ctx.query().id(GLOBAL_STATUS_UPDATE).replace_id("status").query(move |client| {
+                let (status, current_song) = client.get_status_and_current_song()?;
                 Ok(MpdQueryResult::Status {
-                    data: client.get_status()?,
+                    status,
+                    current_song,
                     source_event: Some(IdleEvent::Mixer),
                 })
             });
         }
         IdleEvent::Options => {
             ctx.query().id(GLOBAL_STATUS_UPDATE).replace_id("status").query(move |client| {
+                let (status, current_song) = client.get_status_and_current_song()?;
                 Ok(MpdQueryResult::Status {
-                    data: client.get_status()?,
+                    status,
+                    current_song,
                     source_event: Some(IdleEvent::Options),
                 })
             });
         }
         IdleEvent::Player => {
             ctx.query().id(GLOBAL_STATUS_UPDATE).replace_id("status").query(move |client| {
+                let (status, current_song) = client.get_status_and_current_song()?;
                 Ok(MpdQueryResult::Status {
-                    data: client.get_status()?,
+                    status,
+                    current_song,
                     source_event: Some(IdleEvent::Player),
                 })
             });
@@ -823,8 +864,10 @@ fn handle_idle_event(event: IdleEvent, ctx: &Ctx, result_ui_evs: &mut HashSet<Id
             // during queue update (shuffle, move, ...)
             ctx.query().id(GLOBAL_STATUS_UPDATE).replace_id("status_from_playlist").query(
                 move |client| {
+                    let (status, current_song) = client.get_status_and_current_song()?;
                     Ok(MpdQueryResult::Status {
-                        data: client.get_status()?,
+                        status,
+                        current_song,
                         source_event: Some(IdleEvent::Playlist),
                     })
                 },
@@ -843,16 +886,20 @@ fn handle_idle_event(event: IdleEvent, ctx: &Ctx, result_ui_evs: &mut HashSet<Id
         IdleEvent::StoredPlaylist => {}
         IdleEvent::Database => {
             ctx.query().id(GLOBAL_STATUS_UPDATE).replace_id("status").query(move |client| {
+                let (status, current_song) = client.get_status_and_current_song()?;
                 Ok(MpdQueryResult::Status {
-                    data: client.get_status()?,
+                    status,
+                    current_song,
                     source_event: Some(IdleEvent::Database),
                 })
             });
         }
         IdleEvent::Update => {
             ctx.query().id(GLOBAL_STATUS_UPDATE).replace_id("status").query(move |client| {
+                let (status, current_song) = client.get_status_and_current_song()?;
                 Ok(MpdQueryResult::Status {
-                    data: client.get_status()?,
+                    status,
+                    current_song,
                     source_event: Some(IdleEvent::Update),
                 })
             });
@@ -866,6 +913,4 @@ fn handle_idle_event(event: IdleEvent, ctx: &Ctx, result_ui_evs: &mut HashSet<Id
             log::warn!(event:?; "Received unhandled event");
         }
     }
-
-    result_ui_evs.insert(event);
 }

--- a/rmpc/src/ctx.rs
+++ b/rmpc/src/ctx.rs
@@ -50,6 +50,10 @@ pub struct Ctx {
     pub(crate) mpd_version: Version,
     pub(crate) config: std::sync::Arc<Config>,
     pub(crate) status: Status,
+    #[cfg(test)]
+    pub(crate) current_song: Option<Song>,
+    #[cfg(not(test))]
+    current_song: Option<Song>,
     pub(crate) queue: Vec<Song>,
     #[cfg(test)]
     pub(crate) stickers: HashMap<String, HashMap<String, String>>,
@@ -101,6 +105,7 @@ impl Ctx {
 
         let status = client.get_status()?;
         let queue = client.playlist_info()?.unwrap_or_default();
+        let current_song = client.get_current_song()?;
         let cached_queue_time_total = queue.iter().filter_map(|s| s.duration).sum();
 
         if !supported_commands.contains("albumart") || !supported_commands.contains("readpicture") {
@@ -121,6 +126,7 @@ impl Ctx {
             config: std::sync::Arc::new(config),
             status,
             queue,
+            current_song,
             stickers: HashMap::new(),
             active_tab,
             supported_commands,
@@ -165,7 +171,7 @@ impl Ctx {
                     self.stickers_supported = StickersSupport::UnsupportedAndChecked;
                     // Shoot a dummy sticker request to MPD to see what error we get to determine
                     // what exactly is wrong.
-                    self.command(|client| {
+                    self.command(|_, client| {
                         if let Err(err) = client.sticker("", "test") {
                             status_error!(
                                 "Stickers are not supported by MPD server: '{}'",
@@ -235,7 +241,7 @@ impl Ctx {
 
     pub(crate) fn command(
         &self,
-        callback: impl FnOnce(&mut Client<'_>) -> Result<()> + Send + 'static,
+        callback: impl FnOnce(&Sender<AppEvent>, &mut Client<'_>) -> Result<()> + Send + 'static,
     ) {
         if let Err(err) = self
             .client_request_sender
@@ -245,26 +251,26 @@ impl Ctx {
         }
     }
 
-    pub(crate) fn find_current_song_in_queue(&self) -> Option<(usize, &Song)> {
+    pub(crate) fn set_current_song(&mut self, song: Option<Song>) {
+        self.current_song = song;
+    }
+
+    pub(crate) fn current_song(&self) -> Option<&Song> {
         if self.status.state == State::Stop {
             return None;
         }
+        self.current_song.as_ref()
+    }
 
-        // Use indexing by "song" instead of finding the song by id when the queue is
-        // very large to avoid performance issues. The indexing is not used by default
-        // because it can cause small/short desyncs when queue is being updated by
-        // moving/shuffling the songs.
-        if self.queue.len() > 3_000 {
-            self.status.song.and_then(|idx| self.queue.get(idx).map(|song| (idx, song)))
-        } else {
-            self.status
-                .songid
-                .and_then(|id| self.queue.iter().enumerate().find(|(_, song)| song.id == id))
+    pub(crate) fn current_song_index(&self) -> Option<usize> {
+        if self.status.state == State::Stop {
+            return None;
         }
+        self.status.song
     }
 
     pub(crate) fn find_current_lyrics_path(&self) -> Option<PathBuf> {
-        let (_, song) = self.find_current_song_in_queue()?;
+        let song = self.current_song()?;
         let lyrics_dir = self.config.lyrics_dir.as_ref()?;
         let path = crate::shared::lrc::get_lrc_path(lyrics_dir, &song.file)
             .ok()

--- a/rmpc/src/main.rs
+++ b/rmpc/src/main.rs
@@ -331,7 +331,8 @@ fn main() -> Result<()> {
                 args.partition.autocreate,
             )?;
             client.set_read_timeout(None)?;
-            result(&mut client)?;
+            let (sender, _receiver) = crossbeam::channel::unbounded();
+            result(&sender, &mut client)?;
         }
         None => {
             if args.version {

--- a/rmpc/src/shared/album_art.rs
+++ b/rmpc/src/shared/album_art.rs
@@ -12,7 +12,7 @@ pub fn fetch_album_art(ctx: &Ctx) -> Option<()> {
         return None;
     }
 
-    let (_, current_song) = ctx.find_current_song_in_queue()?;
+    let current_song = ctx.current_song()?;
 
     if let Some(loader) = &ctx.config.album_art.custom_loader {
         ctx.work_sender

--- a/rmpc/src/shared/events.rs
+++ b/rmpc/src/shared/events.rs
@@ -122,7 +122,7 @@ pub(crate) enum WorkDone {
 // The instances are short lived events, boxing would most likely only hurt
 // here.
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
+#[derive(Debug, strum::EnumDiscriminants)]
 pub(crate) enum AppEvent {
     UserKeyInput(KeyEvent),
     UserMouseInput(MouseEvent),
@@ -169,6 +169,9 @@ pub(crate) enum AppEvent {
         stream: IpcStream,
         targets: Vec<RemoteCommandQuery>,
     },
+    IgnoreIdleEvent(IdleEvent),
+    UnIgnoreIdleEvent(IdleEvent),
+    ReconcileIdleEvent(IdleEvent),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Copy, Eq, Hash, PartialEq)]

--- a/rmpc/src/shared/mpd_client_ext.rs
+++ b/rmpc/src/shared/mpd_client_ext.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow::Context;
 use itertools::Itertools;
 use rmpc_mpd::{
-    commands::{IdleEvent, State, Status, outputs::Outputs, stickers::Stickers},
+    commands::{IdleEvent, Song, State, Status, outputs::Outputs, stickers::Stickers},
     errors::{ErrorCode, MpdError, MpdFailureResponse},
     filter::{Filter, FilterKind, Tag},
     mpd_client::{AlbumArtOrder, MpdClient, MpdCommand},
@@ -48,7 +48,7 @@ pub trait MpdClientExt {
             }
         };
 
-        ctx.command(move |client| {
+        ctx.command(move |_, client| {
             client.enqueue_multiple(items, autoplay_idx, position, replace)?;
             Ok(())
         });
@@ -96,6 +96,7 @@ pub trait MpdClientExt {
         path: &str,
         order: AlbumArtOrder,
     ) -> Result<Option<Vec<u8>>, MpdError>;
+    fn get_status_and_current_song(&mut self) -> Result<(Status, Option<Song>), MpdError>;
 }
 
 #[derive(Debug, Clone)]
@@ -605,6 +606,19 @@ impl<T: MpdClient + MpdCommand + ProtoClient> MpdClientExt for T {
                 Ok(None)
             }
         }
+    }
+
+    fn get_status_and_current_song(&mut self) -> Result<(Status, Option<Song>), MpdError> {
+        self.send_start_cmd_list_ok()?;
+        self.send_get_status()?;
+        self.send_get_current_song()?;
+        self.send_execute_cmd_list()?;
+
+        let status = self.read_response()?;
+        let current_song = self.read_opt_response()?;
+        self.read_ok()?;
+
+        Ok((status, current_song))
     }
 }
 

--- a/rmpc/src/shared/mpd_query.rs
+++ b/rmpc/src/shared/mpd_query.rs
@@ -7,13 +7,12 @@ use ratatui::{style::Style, widgets::ListItem};
 use rmpc_mpd::{
     client::Client,
     commands::{Decoder, IdleEvent, Song, Status, Volume},
-    mpd_client::MpdClient,
 };
 
 use super::{events::AppEvent, mpd_client_ext::PartitionedOutput};
 use crate::{
     config::tabs::PaneType,
-    shared::{events::ClientRequest, macros::try_skip},
+    shared::{events::ClientRequest, macros::try_skip, mpd_client_ext::MpdClientExt},
     ui::{dir_or_song::DirOrSong, dirstack::Path},
 };
 
@@ -42,7 +41,7 @@ pub(crate) struct MpdQuerySync {
 #[derive(derive_more::Debug)]
 pub struct MpdCommand {
     #[debug(skip)]
-    pub callback: Box<dyn FnOnce(&mut Client<'_>) -> Result<()> + Send>,
+    pub callback: Box<dyn FnOnce(&Sender<AppEvent>, &mut Client<'_>) -> Result<()> + Send>,
 }
 
 impl MpdQuery {
@@ -87,7 +86,7 @@ pub(crate) enum MpdQueryResult {
     AddToPlaylist { playlists: Vec<String>, song_file: String },
     AddToPlaylistMultiple { playlists: Vec<String>, song_files: Vec<String> },
     AlbumArt(Option<Vec<u8>>),
-    Status { data: Status, source_event: Option<IdleEvent> },
+    Status { status: Status, current_song: Option<Song>, source_event: Option<IdleEvent> },
     Queue(Option<Vec<Song>>),
     Volume(Volume),
     Outputs(Vec<PartitionedOutput>),
@@ -105,10 +104,10 @@ pub fn run_status_update((_, client_tx): &(Sender<AppEvent>, Sender<ClientReques
             id: GLOBAL_STATUS_UPDATE,
             target: None,
             replace_id: Some("status"),
-            callback: Box::new(move |client| Ok(MpdQueryResult::Status {
-                data: client.get_status()?,
-                source_event: None
-            })),
+            callback: Box::new(move |client| {
+                let (status, current_song) = client.get_status_and_current_song()?;
+                Ok(MpdQueryResult::Status { status, current_song, source_event: None })
+            }),
         })),
         "Failed to send status update query"
     );

--- a/rmpc/src/tests/fixtures/mod.rs
+++ b/rmpc/src/tests/fixtures/mod.rs
@@ -88,6 +88,7 @@ pub fn ctx(
         input: InputManager::default(),
         key_resolver,
         cached_queue_time_total: Duration::default(),
+        current_song: None,
     }
 }
 

--- a/rmpc/src/ui/browser.rs
+++ b/rmpc/src/ui/browser.rs
@@ -328,7 +328,7 @@ where
                     if let Some(item) = self.stack().current().selected() {
                         let (items, _) = self.enqueue(std::iter::once(item));
                         if !items.is_empty() {
-                            ctx.command(move |client| {
+                            ctx.command(move |_, client| {
                                 client.enqueue_multiple(items, None, None, false)?;
                                 Ok(())
                             });
@@ -546,7 +546,7 @@ where
                                 confirm_label: Some("Delete"),
                                 cancel_label: None,
                                 on_confirm: Box::new(move |ctx| {
-                                    ctx.command(move |client| {
+                                    ctx.command(move |_, client| {
                                         client.delete_multiple(items)?;
                                         Ok(())
                                     });
@@ -586,7 +586,7 @@ where
                 let (enqueue, hovered_idx) = self.enqueue_items(options.all);
                 if !enqueue.is_empty() {
                     let queue_len = ctx.queue.len();
-                    let current_song_idx = ctx.find_current_song_in_queue().map(|(i, _)| i);
+                    let current_song_idx = ctx.current_song_index();
 
                     Client::resolve_and_enqueue(
                         ctx,
@@ -619,7 +619,7 @@ where
                 max_rating: _,
             } => {
                 let items = self.enqueue(self.items(false).map(|(_, i)| i)).0;
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.set_sticker_multiple(RATING_STICKER, value.to_string(), items)?;
                     Ok(())
                 });
@@ -631,7 +631,7 @@ where
                 max_rating: _,
             } => {
                 let items = self.enqueue(self.items(false).map(|(_, i)| i)).0;
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.delete_sticker_multiple(RATING_STICKER, items)?;
                     Ok(())
                 });
@@ -658,21 +658,21 @@ where
             }
             CommonAction::Rate { kind: RateKind::Like(), current: false, .. } => {
                 let items = self.enqueue(self.items(false).map(|(_, i)| i)).0;
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.set_sticker_multiple(LIKE_STICKER, "2".to_string(), items)?;
                     Ok(())
                 });
             }
             CommonAction::Rate { kind: RateKind::Neutral(), current: false, .. } => {
                 let items = self.enqueue(self.items(false).map(|(_, i)| i)).0;
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.set_sticker_multiple(LIKE_STICKER, "1".to_string(), items)?;
                     Ok(())
                 });
             }
             CommonAction::Rate { kind: RateKind::Dislike(), current: false, .. } => {
                 let items = self.enqueue(self.items(false).map(|(_, i)| i)).0;
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.set_sticker_multiple(LIKE_STICKER, "0".to_string(), items)?;
                     Ok(())
                 });
@@ -789,7 +789,7 @@ where
                 if !current_items.is_empty() {
                     let cloned_items = current_items.clone();
                     section.add_item("Add to queue", move |ctx| {
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.enqueue_multiple(cloned_items, None, None, false)?;
                             Ok(())
                         });
@@ -797,7 +797,7 @@ where
                     });
                     let cloned_items = current_items.clone();
                     section.add_item("Replace queue", move |ctx| {
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.enqueue_multiple(cloned_items, None, None, true)?;
                             Ok(())
                         });
@@ -817,7 +817,7 @@ where
                             .initial_value(initial_playlist_name.unwrap_or_default())
                             .on_confirm(move |ctx, value| {
                                 let value = value.to_owned();
-                                ctx.command(move |client| {
+                                ctx.command(move |_, client| {
                                     let items: Vec<_> = songs_in_items_clone
                                         .into_iter()
                                         .map(|cb| -> Result<_> { cb(client) })
@@ -859,7 +859,7 @@ where
                             .confirm_label("Add")
                             .title("Select a playlist")
                             .on_confirm(move |ctx, selected, _idx| {
-                                ctx.command(move |client| {
+                                ctx.command(move |_, client| {
                                     client.add_to_playlist_multiple(
                                         &selected,
                                         items.into_iter().map(|s| s.file).collect_vec(),

--- a/rmpc/src/ui/mod.rs
+++ b/rmpc/src/ui/mod.rs
@@ -270,7 +270,7 @@ impl<'ui> Ui<'ui> {
                 GlobalAction::Partition { name: Some(name), autocreate } => {
                     let name = name.clone();
                     let autocreate = *autocreate;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         match client.switch_to_partition(&name) {
                             Ok(()) => {}
                             Err(MpdError::Mpd(MpdFailureResponse {
@@ -297,7 +297,7 @@ impl<'ui> Ui<'ui> {
                                 None
                             } else {
                                 let section = section.item("Switch to default partition", |ctx| {
-                                    ctx.command(move |client| {
+                                    ctx.command(move |_, client| {
                                         client.switch_to_partition("default")?;
                                         Ok(())
                                     });
@@ -310,13 +310,13 @@ impl<'ui> Ui<'ui> {
                         .multi_section(ctx, |section| {
                             let mut section = section
                                 .add_action("Switch", |ctx, label| {
-                                    ctx.command(move |client| {
+                                    ctx.command(move |_, client| {
                                         client.switch_to_partition(&label)?;
                                         Ok(())
                                     });
                                 })
                                 .add_action("Delete", |ctx, label| {
-                                    ctx.command(move |client| {
+                                    ctx.command(move |_, client| {
                                         client.delete_partition(&label)?;
                                         Ok(())
                                     });
@@ -335,7 +335,7 @@ impl<'ui> Ui<'ui> {
                         .input_section(ctx, "New partition:", |section| {
                             let section = section.action(|ctx, value| {
                                 if !value.is_empty() {
-                                    ctx.command(move |client| {
+                                    ctx.command(move |_, client| {
                                         client.send_start_cmd_list()?;
                                         client.send_new_partition(&value)?;
                                         client.send_switch_to_partition(&value)?;
@@ -442,7 +442,7 @@ impl<'ui> Ui<'ui> {
                 GlobalAction::NextTrack if ctx.status.state != State::Stop => {
                     let keep_state = ctx.config.keep_state_on_song_change;
                     let state = ctx.status.state;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.next_keep_state(keep_state, state)?;
                         Ok(())
                     });
@@ -452,7 +452,7 @@ impl<'ui> Ui<'ui> {
                     let elapsed_sec = ctx.status.elapsed.as_secs();
                     let keep_state = ctx.config.keep_state_on_song_change;
                     let state = ctx.status.state;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         match rewind_to_start {
                             Some(value) if elapsed_sec >= value => {
                                 client.seek_current(ValueChange::Set(0))?;
@@ -468,28 +468,28 @@ impl<'ui> Ui<'ui> {
                     });
                 }
                 GlobalAction::Stop if matches!(ctx.status.state, State::Play | State::Pause) => {
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.stop()?;
                         Ok(())
                     });
                 }
                 GlobalAction::ToggleRepeat => {
                     let repeat = !ctx.status.repeat;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.repeat(repeat)?;
                         Ok(())
                     });
                 }
                 GlobalAction::ToggleRandom => {
                     let random = !ctx.status.random;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.random(random)?;
                         Ok(())
                     });
                 }
                 GlobalAction::ToggleSingle => {
                     let single = ctx.status.single;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         if client.version() < Version::new(0, 21, 0) {
                             client.single(single.cycle_skip_oneshot())?;
                         } else {
@@ -500,7 +500,7 @@ impl<'ui> Ui<'ui> {
                 }
                 GlobalAction::ToggleConsume => {
                     let consume = ctx.status.consume;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         if client.version() < Version::new(0, 24, 0) {
                             client.consume(consume.cycle_skip_oneshot())?;
                         } else {
@@ -511,26 +511,26 @@ impl<'ui> Ui<'ui> {
                 }
                 GlobalAction::ToggleSingleOnOff => {
                     let single = ctx.status.single;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.single(single.cycle_skip_oneshot())?;
                         Ok(())
                     });
                 }
                 GlobalAction::ToggleConsumeOnOff => {
                     let consume = ctx.status.consume;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.consume(consume.cycle_skip_oneshot())?;
                         Ok(())
                     });
                 }
                 GlobalAction::TogglePause => {
                     if matches!(ctx.status.state, State::Play | State::Pause) {
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.pause_toggle()?;
                             Ok(())
                         });
                     } else {
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.play()?;
                             Ok(())
                         });
@@ -538,7 +538,7 @@ impl<'ui> Ui<'ui> {
                 }
                 GlobalAction::Pause => {
                     if matches!(ctx.status.state, State::Play) {
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.pause()?;
                             Ok(())
                         });
@@ -548,7 +548,7 @@ impl<'ui> Ui<'ui> {
                 }
                 GlobalAction::Unpause => {
                     if matches!(ctx.status.state, State::Pause) {
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.unpause()?;
                             Ok(())
                         });
@@ -558,14 +558,14 @@ impl<'ui> Ui<'ui> {
                 }
                 GlobalAction::VolumeUp => {
                     let step = ctx.config.volume_step;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.volume(ValueChange::Increase(step.into()))?;
                         Ok(())
                     });
                 }
                 GlobalAction::VolumeDown => {
                     let step = ctx.config.volume_step;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.volume(ValueChange::Decrease(step.into()))?;
                         Ok(())
                     });
@@ -573,7 +573,7 @@ impl<'ui> Ui<'ui> {
                 GlobalAction::CrossfadeUp => {
                     let current_xfade = ctx.status.xfade.unwrap_or(0);
                     let new_xfade = current_xfade.saturating_add(1);
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.crossfade(new_xfade)?;
                         Ok(())
                     });
@@ -581,7 +581,7 @@ impl<'ui> Ui<'ui> {
                 GlobalAction::CrossfadeDown => {
                     let current_xfade = ctx.status.xfade.unwrap_or(0);
                     let new_xfade = current_xfade.saturating_sub(1);
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.crossfade(new_xfade)?;
                         Ok(())
                     });
@@ -589,7 +589,7 @@ impl<'ui> Ui<'ui> {
                 GlobalAction::SeekForward
                     if matches!(ctx.status.state, State::Play | State::Pause) =>
                 {
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.seek_current(ValueChange::Increase(5))?;
                         Ok(())
                     });
@@ -597,7 +597,7 @@ impl<'ui> Ui<'ui> {
                 GlobalAction::SeekBack
                     if matches!(ctx.status.state, State::Play | State::Pause) =>
                 {
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.seek_current(ValueChange::Decrease(5))?;
                         Ok(())
                     });
@@ -605,19 +605,19 @@ impl<'ui> Ui<'ui> {
                 GlobalAction::SeekToStart
                     if matches!(ctx.status.state, State::Play | State::Pause) =>
                 {
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.seek_current(ValueChange::Set(0))?;
                         Ok(())
                     });
                 }
                 GlobalAction::Update => {
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.update(None)?;
                         Ok(())
                     });
                 }
                 GlobalAction::Rescan => {
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.rescan(None)?;
                         Ok(())
                     });
@@ -692,7 +692,7 @@ impl<'ui> Ui<'ui> {
                         .query(|client| Ok(MpdQueryResult::Decoders(client.decoders()?.0)));
                 }
                 GlobalAction::ShowCurrentSongInfo => {
-                    if let Some((_, current_song)) = ctx.find_current_song_in_queue() {
+                    if let Some(current_song) = &ctx.current_song() {
                         modal!(
                             ctx,
                             InfoListModal::builder()
@@ -719,7 +719,7 @@ impl<'ui> Ui<'ui> {
             )]
             match action {
                 CommonAction::Rate { kind, current: true, min_rating, max_rating } => {
-                    if let Some((_, song)) = ctx.find_current_song_in_queue() {
+                    if let Some(song) = ctx.current_song() {
                         match kind {
                             RateKind::Modal { values, custom, like } => {
                                 let items = vec![Enqueue::File { path: song.file.clone() }];
@@ -739,35 +739,35 @@ impl<'ui> Ui<'ui> {
                             RateKind::Value(value) => {
                                 let uri = song.file.clone();
                                 let value = value.to_string();
-                                ctx.command(move |client| {
+                                ctx.command(move |_, client| {
                                     client.set_sticker(&uri, RATING_STICKER, &value)?;
                                     Ok(())
                                 });
                             }
                             RateKind::ClearRating() => {
                                 let uri = song.file.clone();
-                                ctx.command(move |client| {
+                                ctx.command(move |_, client| {
                                     client.delete_sticker(&uri, RATING_STICKER)?;
                                     Ok(())
                                 });
                             }
                             RateKind::Like() => {
                                 let uri = song.file.clone();
-                                ctx.command(move |client| {
+                                ctx.command(move |_, client| {
                                     client.set_sticker(&uri, LIKE_STICKER, "2")?;
                                     Ok(())
                                 });
                             }
                             RateKind::Dislike() => {
                                 let uri = song.file.clone();
-                                ctx.command(move |client| {
+                                ctx.command(move |_, client| {
                                     client.set_sticker(&uri, LIKE_STICKER, "0")?;
                                     Ok(())
                                 });
                             }
                             RateKind::Neutral() => {
                                 let uri = song.file.clone();
-                                ctx.command(move |client| {
+                                ctx.command(move |_, client| {
                                     client.set_sticker(&uri, LIKE_STICKER, "1")?;
                                     Ok(())
                                 });

--- a/rmpc/src/ui/modals/downloads.rs
+++ b/rmpc/src/ui/modals/downloads.rs
@@ -251,7 +251,7 @@ impl DownloadsModal {
                                 let path = std::mem::take(path);
                                 section.add_item(action.to_string(), move |ctx| {
                                     let cache_dir = ctx.config.cache_dir.clone();
-                                    ctx.command(move |client| {
+                                    ctx.command(move |_, client| {
                                         client.add_downloaded_file_to_queue(
                                             path,
                                             cache_dir.as_deref(),

--- a/rmpc/src/ui/modals/menu/mod.rs
+++ b/rmpc/src/ui/modals/menu/mod.rs
@@ -265,7 +265,7 @@ pub fn create_rating_modal<'a>(
                 }
 
                 if !value.trim().is_empty() {
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.set_sticker_multiple(RATING_STICKER, value, clone2)?;
                         Ok(())
                     });
@@ -284,7 +284,7 @@ pub fn create_rating_modal<'a>(
             }
 
             section.action(move |ctx, value| {
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.set_sticker_multiple(RATING_STICKER, value, clone)?;
                     Ok(())
                 });
@@ -299,7 +299,7 @@ pub fn create_rating_modal<'a>(
             }
             let clone = items.clone();
             let section = section.item("Like", |ctx| {
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.set_sticker_multiple(LIKE_STICKER, "2".to_string(), clone)?;
                     Ok(())
                 });
@@ -307,7 +307,7 @@ pub fn create_rating_modal<'a>(
             });
             let clone = items.clone();
             let section = section.item("Neutral", |ctx| {
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.set_sticker_multiple(LIKE_STICKER, "1".to_string(), clone)?;
                     Ok(())
                 });
@@ -315,7 +315,7 @@ pub fn create_rating_modal<'a>(
             });
             let clone = items.clone();
             let section = section.item("Dislike", |ctx| {
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.set_sticker_multiple(LIKE_STICKER, "0".to_string(), clone)?;
                     Ok(())
                 });
@@ -326,7 +326,7 @@ pub fn create_rating_modal<'a>(
         .list_section(ctx, |mut section| {
             if custom || !values.is_empty() {
                 section.add_item("Clear rating", |ctx| {
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.delete_sticker_multiple(RATING_STICKER, clone3)?;
                         Ok(())
                     });
@@ -335,7 +335,7 @@ pub fn create_rating_modal<'a>(
             }
             if like {
                 section.add_item("Clear like state", |ctx| {
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.delete_sticker_multiple(LIKE_STICKER, items)?;
                         Ok(())
                     });
@@ -356,7 +356,7 @@ pub fn create_add_modal<'a>(
 ) -> MenuModal<'a> {
     MenuModal::new(ctx)
         .list_section(ctx, |section| {
-            let current_song_idx = ctx.find_current_song_in_queue().map(|(i, _)| i);
+            let current_song_idx = ctx.current_song_index();
             let mut section = section;
 
             for (label, options, (enqueue, hovered_idx)) in opts {
@@ -398,7 +398,7 @@ pub fn create_save_modal<'a>(
             let song_paths = song_paths.clone();
             sect.add_action(|ctx, value| {
                 if !value.is_empty() {
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.create_playlist(&value, song_paths)?;
                         Ok(())
                     });
@@ -451,7 +451,7 @@ pub fn add_to_playlist_or_show_modal(
         DuplicateStrategy::None if !duplicate_songs.is_empty() => {}
         DuplicateStrategy::NonDuplicate if !duplicate_songs.is_empty() => {
             // add only non duplicate songs
-            ctx.command(move |client| {
+            ctx.command(move |_, client| {
                 client.add_to_playlist_multiple(&playlist_name, non_duplicate_songs)?;
                 Ok(())
             });
@@ -472,7 +472,7 @@ pub fn add_to_playlist_or_show_modal(
         | DuplicateStrategy::NonDuplicate
         | DuplicateStrategy::Ask => {
             // add all songs
-            ctx.command(move |client| {
+            ctx.command(move |_, client| {
                 client.add_to_playlist_multiple(&playlist_name, all_songs)?;
                 Ok(())
             });
@@ -516,7 +516,7 @@ fn create_duplicate_songs_modal<'a>(
                 (
                     "Add anyway",
                     Box::new(|ctx| {
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.add_to_playlist_multiple(&playlist_name2, all_songs)?;
                             Ok(())
                         });
@@ -526,7 +526,7 @@ fn create_duplicate_songs_modal<'a>(
                 (
                     "Add non duplicates",
                     Box::new(|ctx| {
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.add_to_playlist_multiple(&playlist_name, non_duplicate_songs)?;
                             Ok(())
                         });
@@ -610,7 +610,7 @@ pub fn delete_from_playlist_or_show_confirmation(
         format!("Remove {songs_to_remove} song(s) from playlist \"{playlist_name}\"?");
 
     let delete_songs = move |ctx: &Ctx| {
-        ctx.command(move |client| {
+        ctx.command(move |_, client| {
             client.send_start_cmd_list()?;
             for (idx, _path) in songs_to_remove_in_playlist.iter().rev() {
                 client.send_delete_from_playlist(&playlist_name, &SingleOrRange::single(*idx))?;

--- a/rmpc/src/ui/panes/album_art.rs
+++ b/rmpc/src/ui/panes/album_art.rs
@@ -168,6 +168,7 @@ mod tests {
         config.album_art.method = method;
         ctx.config = std::sync::Arc::new(config);
         ctx.queue.push(Song { id: selected_song_id, ..Default::default() });
+        ctx.current_song = Some(Song { id: selected_song_id, ..Default::default() });
         ctx.status.songid = Some(selected_song_id);
         ctx.status.state = State::Play;
         let mut screen = AlbumArtPane::new(&ctx);
@@ -209,6 +210,7 @@ mod tests {
         config.album_art.method = method;
         ctx.config = std::sync::Arc::new(config);
         ctx.queue.push(Song { id: selected_song_id, ..Default::default() });
+        ctx.current_song = Some(Song { id: selected_song_id, ..Default::default() });
         ctx.status.songid = Some(selected_song_id);
         ctx.status.state = State::Play;
         let mut screen = AlbumArtPane::new(&ctx);

--- a/rmpc/src/ui/panes/header.rs
+++ b/rmpc/src/ui/panes/header.rs
@@ -45,21 +45,21 @@ impl Pane for HeaderPane {
 
         match event.kind {
             MouseEventKind::LeftClick => {
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.pause_toggle()?;
                     Ok(())
                 });
             }
             MouseEventKind::ScrollUp => {
                 let volume_step = ctx.config.volume_step.into();
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.volume(ValueChange::Increase(volume_step))?;
                     Ok(())
                 });
             }
             MouseEventKind::ScrollDown => {
                 let volume_step = ctx.config.volume_step.into();
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.volume(ValueChange::Decrease(volume_step))?;
                     Ok(())
                 });

--- a/rmpc/src/ui/panes/mod.rs
+++ b/rmpc/src/ui/panes/mod.rs
@@ -552,7 +552,7 @@ impl Property<PropertyKind> {
                     Some(Either::Left(Span::styled(formatted, style)))
                 }
                 StatusProperty::QueueTimeRemaining { separator } => {
-                    let remaining_time = ctx.find_current_song_in_queue().map_or(
+                    let remaining_time = ctx.current_song_index().zip(ctx.current_song()).map_or(
                         Duration::default(),
                         |(current_song_idx, current_song)| {
                             let total_remaining: Duration = ctx
@@ -746,7 +746,7 @@ impl SizedPaneOrSplit {
     ) -> Result<()> {
         let mut stack = vec![(self, area)];
 
-        let song = ctx.find_current_song_in_queue().map(|(_, song)| song);
+        let song = ctx.current_song();
         while let Some((configured_panes, area)) = stack.pop() {
             match configured_panes {
                 SizedPaneOrSplit::Pane(pane) => {
@@ -1460,6 +1460,7 @@ mod format_tests {
             });
 
             ctx.queue = queue;
+            ctx.current_song = Some(current_song.clone());
             ctx.status = Status {
                 elapsed,
                 duration: Duration::from_secs(123),

--- a/rmpc/src/ui/panes/playlists.rs
+++ b/rmpc/src/ui/panes/playlists.rs
@@ -404,7 +404,7 @@ impl BrowserPane<DirOrSong> for PlaylistsPane {
                             if current_name != new_value {
                                 let current_name = current_name.clone();
                                 let new_value = new_value.to_owned();
-                                ctx.command(move |client| {
+                                ctx.command(move |_, client| {
                                     client.rename_playlist(&current_name, &new_value)?;
                                     status_info!(
                                         "Playlist '{}' renamed to '{}'",

--- a/rmpc/src/ui/panes/progress_bar.rs
+++ b/rmpc/src/ui/panes/progress_bar.rs
@@ -86,7 +86,7 @@ impl Pane for ProgressBarPane {
                         f32::from(event.x.saturating_sub(self.area.x)) / f32::from(self.area.width),
                     )
                     .as_secs();
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.seek_current(ValueChange::Set(u32::try_from(second_to_seek_to)?))?;
                     Ok(())
                 });

--- a/rmpc/src/ui/panes/property.rs
+++ b/rmpc/src/ui/panes/property.rs
@@ -34,7 +34,7 @@ impl<'content> PropertyPane<'content> {
 
 impl Pane for PropertyPane<'_> {
     fn render(&mut self, frame: &mut Frame, area: Rect, ctx: &Ctx) -> Result<()> {
-        let song = ctx.find_current_song_in_queue().map(|(_, song)| song);
+        let song = ctx.current_song();
 
         let line = Line::from(self.content.iter().fold(Vec::new(), |mut acc, val| {
             match val.as_span(

--- a/rmpc/src/ui/panes/queue.rs
+++ b/rmpc/src/ui/panes/queue.rs
@@ -13,7 +13,7 @@ use ratatui::{
 };
 use rmpc_mpd::{
     client::Client,
-    commands::Song,
+    commands::{IdleEvent, Song},
     mpd_client::{MpdClient, MpdCommand},
     proto_client::ProtoClient,
     queue_position::QueuePosition,
@@ -110,7 +110,6 @@ const ADD_TO_PLAYLIST_MULTIPLE: &str = "add_to_playlist_multiple";
 impl QueuePane {
     pub fn new(ctx: &Ctx) -> Self {
         let (column_widths, column_formats) = Self::init(ctx);
-        let highlight_id = id::new();
 
         let mut s = Self {
             queue: Dir::new(ctx.queue.clone()),
@@ -120,7 +119,7 @@ impl QueuePane {
                 _ => Rect::default(),
             },
             should_center_cursor_on_current: ctx.config.center_current_song_on_change,
-            highlight_id,
+            highlight_id: id::new(),
             highlight_enabled: true,
         };
 
@@ -188,7 +187,7 @@ impl QueuePane {
             .list_section(ctx, |mut section| {
                 section.add_item("Play", move |ctx| {
                     if let Some(id) = selected_song_id {
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.play_id(id)?;
                             Ok(())
                         });
@@ -225,7 +224,7 @@ impl QueuePane {
                             .confirm_label("Add")
                             .title("Select a playlist")
                             .on_confirm(move |ctx, selected, _idx| {
-                                ctx.command(move |client| {
+                                ctx.command(move |_, client| {
                                     client.add_to_playlist_multiple(&selected, items)?;
                                     Ok(())
                                 });
@@ -244,7 +243,7 @@ impl QueuePane {
                             .input_label("Playlist name:")
                             .on_confirm(move |ctx, value| {
                                 let value = value.to_owned();
-                                ctx.command(move |client| {
+                                ctx.command(move |_, client| {
                                     client.save_queue_as_playlist(&value, None)?;
                                     Ok(())
                                 });
@@ -260,7 +259,7 @@ impl QueuePane {
                 let section = section
                     .item("Remove", move |ctx| {
                         if let Some(id) = selected_song_id {
-                            ctx.command(move |client| {
+                            ctx.command(move |_, client| {
                                 client.delete_id(id)?;
                                 Ok(())
                             });
@@ -268,7 +267,7 @@ impl QueuePane {
                         Ok(())
                     })
                     .item("Clear queue", |ctx| {
-                        ctx.command(|client| {
+                        ctx.command(|_, client| {
                             client.clear()?;
                             Ok(())
                         });
@@ -307,7 +306,7 @@ impl QueuePane {
 
         let swaps = QueueHeaderPane::calculate_swaps(evald.as_slice(), ctx)?;
 
-        ctx.command(move |client| {
+        ctx.command(move |_, client| {
             client.send_start_cmd_list()?;
             for swap in swaps {
                 client.send_swap_position(swap.0, swap.1)?;
@@ -360,7 +359,7 @@ impl Pane for QueuePane {
             .to_album_ranges()
             .map(|range| range.end.saturating_sub(1))
             .collect();
-        let current_song_id = ctx.find_current_song_in_queue().map(|(_, song)| song.id);
+        let current_song_id = ctx.current_song().map(|s| s.id);
         let marked = std::mem::take(self.queue.marked_mut());
         let filter = ctx.input.value(self.queue.filter_buffer_id);
         let selected_idx = self.queue.selected_idx();
@@ -506,20 +505,11 @@ impl Pane for QueuePane {
         );
 
         if self.should_center_cursor_on_current {
-            let to_select = ctx
-                .find_current_song_in_queue()
-                .or(self.queue.selected_with_idx())
-                .map(|(idx, _)| idx)
-                .or(Some(0));
+            let to_select = ctx.current_song_index().or(self.queue.selected_idx()).or(Some(0));
             self.queue.select_idx_opt(to_select, usize::MAX);
             self.should_center_cursor_on_current = false;
         } else {
-            let to_select = self
-                .queue
-                .selected_with_idx()
-                .or(ctx.find_current_song_in_queue())
-                .map(|v| v.0)
-                .or(Some(0));
+            let to_select = self.queue.selected_idx().or(ctx.current_song_index()).or(Some(0));
             self.queue.select_idx_opt(to_select, usize::MAX);
         }
 
@@ -533,12 +523,7 @@ impl Pane for QueuePane {
             self.queue.len(),
             self.areas[Areas::Table].height as usize,
         );
-        let to_select = self
-            .queue
-            .selected_with_idx()
-            .or(ctx.find_current_song_in_queue())
-            .map(|v| v.0)
-            .or(Some(0));
+        let to_select = self.queue.selected_idx().or(ctx.current_song_index()).or(Some(0));
         self.queue.select_idx_opt(to_select, ctx.config.scrolloff);
         ctx.render()?;
         Ok(())
@@ -555,7 +540,7 @@ impl Pane for QueuePane {
                 self.queue.items.clone_from(&ctx.queue);
             }
             UiEvent::SongChanged => {
-                if let Some((idx, _)) = ctx.find_current_song_in_queue()
+                if let Some(idx) = ctx.current_song_index()
                     && ctx.config.select_current_song_on_change
                 {
                     match (is_visible, ctx.config.center_current_song_on_change) {
@@ -629,7 +614,7 @@ impl Pane for QueuePane {
                     .and_then(|idx| self.queue.items.get(idx))
                 {
                     let id = song.id;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.play_id(id)?;
                         Ok(())
                     });
@@ -646,7 +631,7 @@ impl Pane for QueuePane {
                     .and_then(|idx| self.queue.items.get(idx))
                 {
                     let id = selected_song.id;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.delete_id(id)?;
                         Ok(())
                     });
@@ -699,7 +684,7 @@ impl Pane for QueuePane {
                         .title("Select a playlist")
                         .on_confirm(move |ctx, selected, _idx| {
                             let song_file = song_file.clone();
-                            ctx.command(move |client| {
+                            ctx.command(move |_, client| {
                                 if song_file.starts_with('/') {
                                     client.add_to_playlist(
                                         &selected,
@@ -729,7 +714,7 @@ impl Pane for QueuePane {
                         .confirm_label("Add")
                         .title("Select a playlist")
                         .on_confirm(move |ctx, selected, _idx| {
-                            ctx.command(move |client| {
+                            ctx.command(move |_, client| {
                                 let songs_len = song_files.len();
                                 for song_file in song_files {
                                     if song_file.starts_with('/') {
@@ -782,7 +767,7 @@ impl Pane for QueuePane {
             match action {
                 QueueActions::Delete if !self.queue.marked().is_empty() => {
                     for range in self.queue.marked().ranges().rev() {
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.delete_from_queue(range.into())?;
                             Ok(())
                         });
@@ -793,7 +778,7 @@ impl Pane for QueuePane {
                 }
                 QueueActions::Delete => {
                     if let Some((idx, _)) = self.queue.selected_with_idx() {
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.delete_from_queue(SingleOrRange::single(idx))?;
                             Ok(())
                         });
@@ -812,7 +797,7 @@ impl Pane for QueuePane {
                             ])
                             .action(Action::Single {
                                 on_confirm: Box::new(|ctx| {
-                                    ctx.command(|client| Ok(client.clear()?));
+                                    ctx.command(|_, client| Ok(client.clear()?));
                                     Ok(())
                                 }),
                                 confirm_label: Some("Clear"),
@@ -825,7 +810,7 @@ impl Pane for QueuePane {
                 QueueActions::Play => {
                     if let Some(selected_song) = self.queue.selected() {
                         let id = selected_song.id;
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.play_id(id)?;
                             Ok(())
                         });
@@ -863,7 +848,7 @@ impl Pane for QueuePane {
 
                 QueueActions::Shuffle if !self.queue.marked().is_empty() => {
                     for range in self.queue.marked().ranges().rev() {
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.shuffle(Some(range.into()))?;
                             Ok(())
                         });
@@ -871,7 +856,7 @@ impl Pane for QueuePane {
                     status_info!("Shuffled selected songs");
                 }
                 QueueActions::Shuffle => {
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.shuffle(None)?;
                         Ok(())
                     });
@@ -947,12 +932,15 @@ impl Pane for QueuePane {
                         }
 
                         let new_start_idx = range.start().saturating_sub(1);
-                        ctx.command(move |client| {
-                            client.move_in_queue(
+                        ctx.app_event_sender
+                            .send(AppEvent::IgnoreIdleEvent(IdleEvent::Playlist))?;
+                        ctx.command(move |tx, client| {
+                            let result = client.move_in_queue(
                                 range.into(),
                                 QueuePosition::Absolute(new_start_idx),
-                            )?;
-                            Ok(())
+                            );
+                            tx.send(AppEvent::UnIgnoreIdleEvent(IdleEvent::Playlist))?;
+                            Ok(result?)
                         });
                     }
 
@@ -987,12 +975,15 @@ impl Pane for QueuePane {
                         }
 
                         let new_start_idx = range.start().saturating_add(1);
-                        ctx.command(move |client| {
-                            client.move_in_queue(
+                        ctx.app_event_sender
+                            .send(AppEvent::IgnoreIdleEvent(IdleEvent::Playlist))?;
+                        ctx.command(move |tx, client| {
+                            let result = client.move_in_queue(
                                 range.into(),
                                 QueuePosition::Absolute(new_start_idx),
-                            )?;
-                            Ok(())
+                            );
+                            tx.send(AppEvent::UnIgnoreIdleEvent(IdleEvent::Playlist))?;
+                            Ok(result?)
                         });
                     }
 
@@ -1013,15 +1004,23 @@ impl Pane for QueuePane {
                         return Ok(());
                     }
 
-                    let Some((idx, selected)) = self.queue.selected_with_idx() else {
+                    let Some(idx) = self.queue.selected_idx() else {
                         return Ok(());
                     };
 
+                    if idx == 0 {
+                        return Ok(());
+                    }
+
                     let new_idx = idx.saturating_sub(1);
-                    let id = selected.id;
-                    ctx.command(move |client| {
-                        client.move_id(id, QueuePosition::Absolute(new_idx))?;
-                        Ok(())
+                    ctx.app_event_sender.send(AppEvent::IgnoreIdleEvent(IdleEvent::Playlist))?;
+                    ctx.command(move |tx, client| {
+                        let result = client.move_in_queue(
+                            SingleOrRange::single(idx),
+                            QueuePosition::Absolute(new_idx),
+                        );
+                        tx.send(AppEvent::UnIgnoreIdleEvent(IdleEvent::Playlist))?;
+                        Ok(result?)
                     });
                     self.queue.select_idx(new_idx, ctx.config.scrolloff);
                     self.queue.items.swap(idx, new_idx);
@@ -1032,15 +1031,19 @@ impl Pane for QueuePane {
                         return Ok(());
                     }
 
-                    let Some((idx, selected)) = self.queue.selected_with_idx() else {
+                    let Some(idx) = self.queue.selected_idx() else {
                         return Ok(());
                     };
 
                     let new_idx = (idx + 1).min(self.queue.len() - 1);
-                    let id = selected.id;
-                    ctx.command(move |client| {
-                        client.move_id(id, QueuePosition::Absolute(new_idx))?;
-                        Ok(())
+                    ctx.app_event_sender.send(AppEvent::IgnoreIdleEvent(IdleEvent::Playlist))?;
+                    ctx.command(move |tx, client| {
+                        let result = client.move_in_queue(
+                            SingleOrRange::single(idx),
+                            QueuePosition::Absolute(new_idx),
+                        );
+                        tx.send(AppEvent::UnIgnoreIdleEvent(IdleEvent::Playlist))?;
+                        Ok(result?)
                     });
                     self.queue.select_idx(new_idx, ctx.config.scrolloff);
                     self.queue.items.swap(idx, new_idx);
@@ -1221,7 +1224,7 @@ impl Pane for QueuePane {
                     max_rating: _,
                 } => {
                     let items = self.enqueue_items(false).0;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.set_sticker_multiple(RATING_STICKER, value.to_string(), items)?;
                         Ok(())
                     });
@@ -1233,7 +1236,7 @@ impl Pane for QueuePane {
                     max_rating: _,
                 } => {
                     let items = self.enqueue_items(false).0;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.delete_sticker_multiple(RATING_STICKER, items)?;
                         Ok(())
                     });
@@ -1260,21 +1263,21 @@ impl Pane for QueuePane {
                 }
                 CommonAction::Rate { kind: RateKind::Like(), current: false, .. } => {
                     let items = self.enqueue_items(false).0;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.set_sticker_multiple(LIKE_STICKER, "2".to_string(), items)?;
                         Ok(())
                     });
                 }
                 CommonAction::Rate { kind: RateKind::Neutral(), current: false, .. } => {
                     let items = self.enqueue_items(false).0;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.set_sticker_multiple(LIKE_STICKER, "1".to_string(), items)?;
                         Ok(())
                     });
                 }
                 CommonAction::Rate { kind: RateKind::Dislike(), current: false, .. } => {
                     let items = self.enqueue_items(false).0;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.set_sticker_multiple(LIKE_STICKER, "0".to_string(), items)?;
                         Ok(())
                     });

--- a/rmpc/src/ui/panes/queue_header.rs
+++ b/rmpc/src/ui/panes/queue_header.rs
@@ -86,7 +86,7 @@ impl QueueHeaderPane {
 
             let swaps = Self::calculate_swaps(evald.as_slice(), ctx)?;
 
-            ctx.command(move |client| {
+            ctx.command(move |_, client| {
                 client.send_start_cmd_list()?;
                 for swap in swaps {
                     client.send_swap_position(swap.0, swap.1)?;

--- a/rmpc/src/ui/panes/search/mod.rs
+++ b/rmpc/src/ui/panes/search/mod.rs
@@ -427,7 +427,7 @@ impl SearchPane {
                 CommonAction::AddOptions { kind: AddKind::Action(opts) } if opts.all => {
                     let (_, enqueue) = self.enqueue(opts.all);
                     if !enqueue.is_empty() {
-                        let current_song_idx = ctx.find_current_song_in_queue().map(|(i, _)| i);
+                        let current_song_idx = ctx.current_song_index();
                         Client::resolve_and_enqueue(
                             ctx,
                             enqueue,
@@ -585,7 +585,7 @@ impl SearchPane {
                         vec![Enqueue::File { path: item.file.clone() }]
                     });
                     if !items.is_empty() {
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.enqueue_multiple(items, None, None, false)?;
                             Ok(())
                         });
@@ -681,7 +681,7 @@ impl SearchPane {
                 CommonAction::Close => {}
                 CommonAction::Confirm if self.songs_dir.marked().is_empty() => {
                     let (hovered_song_idx, items) = self.enqueue(true);
-                    let current_song_idx = ctx.find_current_song_in_queue().map(|(i, _)| i);
+                    let current_song_idx = ctx.current_song_index();
 
                     if !items.is_empty() {
                         Client::resolve_and_enqueue(
@@ -702,7 +702,7 @@ impl SearchPane {
                     let (hovered_song_idx, enqueue) = self.enqueue(opts.all);
 
                     if !enqueue.is_empty() {
-                        let current_song_idx = ctx.find_current_song_in_queue().map(|(i, _)| i);
+                        let current_song_idx = ctx.current_song_index();
 
                         Client::resolve_and_enqueue(
                             ctx,
@@ -742,7 +742,7 @@ impl SearchPane {
                     max_rating: _,
                 } => {
                     let items = self.enqueue(false).1;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.set_sticker_multiple(RATING_STICKER, value.to_string(), items)?;
                         Ok(())
                     });
@@ -754,7 +754,7 @@ impl SearchPane {
                     max_rating: _,
                 } => {
                     let items = self.enqueue(false).1;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.delete_sticker_multiple(RATING_STICKER, items)?;
                         Ok(())
                     });
@@ -781,21 +781,21 @@ impl SearchPane {
                 }
                 CommonAction::Rate { kind: RateKind::Like(), current: false, .. } => {
                     let items = self.enqueue(false).1;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.set_sticker_multiple(LIKE_STICKER, "2".to_string(), items)?;
                         Ok(())
                     });
                 }
                 CommonAction::Rate { kind: RateKind::Neutral(), current: false, .. } => {
                     let items = self.enqueue(false).1;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.set_sticker_multiple(LIKE_STICKER, "1".to_string(), items)?;
                         Ok(())
                     });
                 }
                 CommonAction::Rate { kind: RateKind::Dislike(), current: false, .. } => {
                     let items = self.enqueue(false).1;
-                    ctx.command(move |client| {
+                    ctx.command(move |_, client| {
                         client.set_sticker_multiple(LIKE_STICKER, "0".to_string(), items)?;
                         Ok(())
                     });
@@ -870,14 +870,14 @@ impl SearchPane {
                     if !enqueue.is_empty() {
                         let enqueue_clone = enqueue.clone();
                         section.add_item("Add all to queue", move |ctx| {
-                            ctx.command(move |client| {
+                            ctx.command(move |_, client| {
                                 client.enqueue_multiple(enqueue_clone, None, None, false)?;
                                 Ok(())
                             });
                             Ok(())
                         });
                         section.add_item("Replace queue with all", move |ctx| {
-                            ctx.command(move |client| {
+                            ctx.command(move |_, client| {
                                 client.enqueue_multiple(enqueue, None, None, true)?;
                                 Ok(())
                             });
@@ -895,7 +895,7 @@ impl SearchPane {
                                     .input_label("Playlist name:")
                                     .on_confirm(move |ctx, value| {
                                         let value = value.to_owned();
-                                        ctx.command(move |client| {
+                                        ctx.command(move |_, client| {
                                             client.create_playlist(&value, song_files)?;
                                             Ok(())
                                         });
@@ -923,7 +923,7 @@ impl SearchPane {
                                     .confirm_label("Add")
                                     .title("Select a playlist")
                                     .on_confirm(move |ctx, selected, _idx| {
-                                        ctx.command(move |client| {
+                                        ctx.command(move |_, client| {
                                             client
                                                 .add_to_playlist_multiple(&selected, song_files)?;
                                             Ok(())
@@ -949,7 +949,7 @@ impl SearchPane {
                             .input_label("Playlist name:")
                             .on_confirm(move |ctx, value| {
                                 let value = value.to_owned();
-                                ctx.command(move |client| {
+                                ctx.command(move |_, client| {
                                     client.create_playlist(&value, song_files)?;
                                     Ok(())
                                 });
@@ -972,7 +972,7 @@ impl SearchPane {
                             .confirm_label("Add")
                             .title("Select a playlist")
                             .on_confirm(move |ctx, selected, _idx| {
-                                ctx.command(move |client| {
+                                ctx.command(move |_, client| {
                                     client.add_to_playlist_multiple(&selected, song_files)?;
                                     Ok(())
                                 });
@@ -1188,7 +1188,7 @@ impl Pane for SearchPane {
                     Phase::BrowseResults => {
                         let (_, items) = self.enqueue(false);
                         if !items.is_empty() {
-                            ctx.command(move |client| {
+                            ctx.command(move |_, client| {
                                 client.enqueue_multiple(items, None, None, false)?;
                                 Ok(())
                             });
@@ -1243,7 +1243,7 @@ impl Pane for SearchPane {
                 Phase::BrowseResults => {
                     let (_, items) = self.enqueue(false);
                     if !items.is_empty() {
-                        ctx.command(move |client| {
+                        ctx.command(move |_, client| {
                             client.enqueue_multiple(items, None, None, false)?;
                             Ok(())
                         });
@@ -1265,7 +1265,7 @@ impl Pane for SearchPane {
                             self.songs_dir.select_idx(idx, ctx.config.scrolloff);
                             if let Some(item) = self.songs_dir.selected() {
                                 let item = item.file.clone();
-                                ctx.command(move |client| {
+                                ctx.command(move |_, client| {
                                     client.add(&item, None)?;
                                     status_info!("Added '{item}' to queue");
                                     Ok(())

--- a/rmpc/src/ui/panes/volume.rs
+++ b/rmpc/src/ui/panes/volume.rs
@@ -93,7 +93,7 @@ impl Pane for VolumePane {
                 // Safe conversion: clamped to 0-100 range and rounded, so cast is always valid
                 let new_volume = (volume_ratio * 100.0).clamp(0.0, 100.0).round() as u32;
 
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.volume(ValueChange::Set(new_volume))?;
                     Ok(())
                 });
@@ -105,7 +105,7 @@ impl Pane for VolumePane {
                     return Ok(());
                 }
                 let volume_step = ctx.config.volume_step.into();
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.volume(ValueChange::Increase(volume_step))?;
                     Ok(())
                 });
@@ -115,7 +115,7 @@ impl Pane for VolumePane {
                     return Ok(());
                 }
                 let volume_step = ctx.config.volume_step.into();
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.volume(ValueChange::Decrease(volume_step))?;
                     Ok(())
                 });
@@ -131,7 +131,7 @@ impl Pane for VolumePane {
                 // Safe conversion: clamped to 0-100 range and rounded, so cast is always valid
                 let new_volume = (volume_ratio * 100.0).clamp(0.0, 100.0).round() as u32;
 
-                ctx.command(move |client| {
+                ctx.command(move |_, client| {
                     client.volume(ValueChange::Set(new_volume))?;
                     Ok(())
                 });

--- a/rmpc/src/ui/widgets/header.rs
+++ b/rmpc/src/ui/widgets/header.rs
@@ -30,7 +30,7 @@ impl Widget for Header<'_> {
         let row_count = config.theme.header.rows.len();
 
         let layouts = Layout::vertical((0..row_count).map(|_| Constraint::Length(1))).split(area);
-        let song = self.ctx.find_current_song_in_queue().map(|(_, song)| song);
+        let song = self.ctx.current_song();
         for row in 0..row_count {
             let [left, center, right] = *Layout::horizontal([
                 Constraint::Percentage(config.theme.header_column_widths[0]),


### PR DESCRIPTION
## Description

Should also improve performance with large queues

### Related issues

fixes: https://github.com/mierak/rmpc/issues/985

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
