### PR TITLE
add a vertical slider for volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added a new vertical volume slider pane.
 - **Breaking** `ExternalCommand` can now have arguments supplied at runtime. This will break your
   existing keybinds if they contained either `{` or `}`. You will now need to escape these by
   doubling them up: `{{` and `}}`.

--- a/rmpc/src/config/tabs.rs
+++ b/rmpc/src/config/tabs.rs
@@ -288,6 +288,9 @@ impl TryFrom<PaneTypeFile> for PaneType {
             PaneTypeFile::Volume { kind } => PaneType::Volume {
                 kind: match kind {
                     VolumeTypeFile::Slider(cfg) => VolumeType::Slider(cfg.into_config()?),
+                    VolumeTypeFile::VerticalSlider(cfg) => {
+                        VolumeType::VerticalSlider(cfg.into_config()?)
+                    }
                 },
             },
             PaneTypeFile::Header => PaneType::Header,
@@ -1273,6 +1276,7 @@ impl Default for TabsFile {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum VolumeTypeFile {
     Slider(VolumeSliderConfigFile),
+    VerticalSlider(VolumeSliderConfigFile),
 }
 
 impl Default for VolumeTypeFile {
@@ -1284,6 +1288,7 @@ impl Default for VolumeTypeFile {
 #[derive(Debug, Clone, Hash, Eq, PartialEq, strum::Display, strum::EnumDiscriminants)]
 pub enum VolumeType {
     Slider(VolumeSliderConfig),
+    VerticalSlider(VolumeSliderConfig),
 }
 
 pub(crate) fn validate_tabs(layout: &SizedPaneOrSplit, tabs: &Tabs) -> Result<()> {

--- a/rmpc/src/ui/panes/volume.rs
+++ b/rmpc/src/ui/panes/volume.rs
@@ -67,6 +67,44 @@ impl Pane for VolumePane {
                     frame.buffer_mut().set_string(area.x + i, area.y, c, style);
                 }
             }
+            VolumeType::VerticalSlider(config) => {
+                if area.height < 1 || area.width < 1 {
+                    return Ok(());
+                }
+
+                let symbols = &config.symbols;
+                let filled_len = (f64::from(area.height - 1)
+                    * f64::from(*ctx.status.volume.value())
+                    / 100.0) as u16;
+
+                for i in 0..area.height {
+                    let inv_i = area.height - 1 - i;
+
+                    let style = if inv_i <= filled_len && filled_len > 0 {
+                        config.filled_style
+                    } else {
+                        config.track_style
+                    };
+
+                    let (c, style) = if let Some(sym) = &config.symbols.start
+                        && i == 0
+                    {
+                        (sym, style)
+                    } else if inv_i < filled_len {
+                        (&symbols.filled, style)
+                    } else if let Some(sym) = &config.symbols.end
+                        && i == area.height - 1
+                    {
+                        (sym, style)
+                    } else if inv_i == filled_len {
+                        (&symbols.thumb, config.thumb_style)
+                    } else {
+                        (&symbols.track, style)
+                    };
+
+                    frame.buffer_mut().set_string(area.x, area.y + i, c, style);
+                }
+            }
         }
 
         Ok(())
@@ -87,9 +125,22 @@ impl Pane for VolumePane {
                     return Ok(());
                 }
 
-                let volume_ratio =
-                    f32::from(event.x.saturating_sub(self.area.x)) / f32::from(self.area.width - 1);
-
+                let volume_ratio = match &self.config {
+                    VolumeType::Slider(_) => {
+                        if self.area.width == 0 {
+                            return Ok(());
+                        }
+                        f32::from(event.x.saturating_sub(self.area.x))
+                            / f32::from(self.area.width - 1)
+                    }
+                    VolumeType::VerticalSlider(_) => {
+                        if self.area.height == 0 {
+                            return Ok(());
+                        }
+                        1.0 - f32::from(event.y.saturating_sub(self.area.y))
+                            / f32::from(self.area.height - 1)
+                    }
+                };
                 // Safe conversion: clamped to 0-100 range and rounded, so cast is always valid
                 let new_volume = (volume_ratio * 100.0).clamp(0.0, 100.0).round() as u32;
 
@@ -125,10 +176,22 @@ impl Pane for VolumePane {
                     return Ok(());
                 }
 
-                let volume_ratio =
-                    f32::from(event.x.saturating_sub(self.area.x)) / f32::from(self.area.width - 1);
-
-                // Safe conversion: clamped to 0-100 range and rounded, so cast is always valid
+                let volume_ratio = match &self.config {
+                    VolumeType::Slider(_) => {
+                        if self.area.width == 0 {
+                            return Ok(());
+                        }
+                        f32::from(event.x.saturating_sub(self.area.x))
+                            / f32::from(self.area.width - 1)
+                    }
+                    VolumeType::VerticalSlider(_) => {
+                        if self.area.height == 0 {
+                            return Ok(());
+                        }
+                        1.0 - f32::from(event.y.saturating_sub(self.area.y))
+                            / f32::from(self.area.height - 1)
+                    }
+                };
                 let new_volume = (volume_ratio * 100.0).clamp(0.0, 100.0).round() as u32;
 
                 ctx.command(move |_, client| {

--- a/rmpc/src/ui/panes/volume.rs
+++ b/rmpc/src/ui/panes/volume.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Ok, Result};
 use ratatui::{Frame, prelude::Rect};
 use rmpc_mpd::{
     commands::volume::Bound,
@@ -120,23 +120,19 @@ impl Pane for VolumePane {
                 if !self.area.contains(event.into()) {
                     return Ok(());
                 }
-                // Avoid division by zero (if width is set to 0)
-                if self.area.width == 0 {
-                    return Ok(());
+                // Avoid division by zero (if width or height is set to 0)
+                match &self.config {
+                    VolumeType::Slider(_) if self.area.width == 0 => return Ok(()),
+                    VolumeType::VerticalSlider(_) if self.area.height == 0 => return Ok(()),
+                    _ => {}
                 }
 
                 let volume_ratio = match &self.config {
                     VolumeType::Slider(_) => {
-                        if self.area.width == 0 {
-                            return Ok(());
-                        }
                         f32::from(event.x.saturating_sub(self.area.x))
                             / f32::from(self.area.width - 1)
                     }
                     VolumeType::VerticalSlider(_) => {
-                        if self.area.height == 0 {
-                            return Ok(());
-                        }
                         1.0 - f32::from(event.y.saturating_sub(self.area.y))
                             / f32::from(self.area.height - 1)
                     }
@@ -176,22 +172,23 @@ impl Pane for VolumePane {
                     return Ok(());
                 }
 
+                match &self.config {
+                    VolumeType::Slider(_) if self.area.width == 0 => return Ok(()),
+                    VolumeType::VerticalSlider(_) if self.area.height == 0 => return Ok(()),
+                    _ => {}
+                }
+
                 let volume_ratio = match &self.config {
                     VolumeType::Slider(_) => {
-                        if self.area.width == 0 {
-                            return Ok(());
-                        }
                         f32::from(event.x.saturating_sub(self.area.x))
                             / f32::from(self.area.width - 1)
                     }
                     VolumeType::VerticalSlider(_) => {
-                        if self.area.height == 0 {
-                            return Ok(());
-                        }
                         1.0 - f32::from(event.y.saturating_sub(self.area.y))
                             / f32::from(self.area.height - 1)
                     }
                 };
+                // Safe conversion: clamped to 0-100 range and rounded, so cast is always valid
                 let new_volume = (volume_ratio * 100.0).clamp(0.0, 100.0).round() as u32;
 
                 ctx.command(move |_, client| {


### PR DESCRIPTION
## Description

adds a new vertical slider pane to control the volume, [link](https://github.com/rmpc-org/rmpc-org.github.io/pull/65) for doc pr.

### Related issues

closes #1008 

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
