### PR TITLE
feat: rmpcd - implement mpris Seek, SetPosition and Seeked

### DIFF
--- a/rmpcd/src/mpris/mod.rs
+++ b/rmpcd/src/mpris/mod.rs
@@ -10,6 +10,7 @@ mod metadata;
 mod notify;
 mod player;
 mod root;
+mod seek;
 mod tracklist;
 pub use notify::{Change, notify_consumer};
 pub use player::Player;

--- a/rmpcd/src/mpris/player.rs
+++ b/rmpcd/src/mpris/player.rs
@@ -2,13 +2,25 @@
 use std::{collections::HashMap, sync::Arc};
 
 use rmpc_mpd::{
-    commands::{State, status::OnOffOneshot, volume::Bound},
+    commands::{Song, State, status::OnOffOneshot, volume::Bound},
     mpd_client::{MpdClient, ValueChange},
 };
 use tokio::sync::RwLock;
-use zbus::{fdo, interface, zvariant::Value};
+use zbus::{
+    fdo,
+    interface,
+    object_server::SignalEmitter,
+    zvariant::{ObjectPath, Value},
+};
 
-use crate::{async_client::AsyncClient, ctx::Ctx};
+use crate::{
+    async_client::AsyncClient,
+    ctx::Ctx,
+    mpris::{
+        metadata::SongExt,
+        seek::{self, SeekPlan},
+    },
+};
 
 pub struct Player {
     ctx: Arc<RwLock<Ctx>>,
@@ -71,15 +83,66 @@ impl Player {
         Ok(())
     }
 
-    async fn seek(&self, position: i64) -> fdo::Result<()> {
-        let position =
-            position.clamp(0, self.ctx.read().await.status.duration.as_micros() as i64) / 1_000_000;
-        self.client
-            .run(move |c| c.seek_current(ValueChange::Set(position as u32)))
-            .await
-            .map_err(|e| fdo::Error::Failed(format!("Failed to seek: {e}")))?;
+    async fn seek(
+        &self,
+        offset: i64,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+    ) -> fdo::Result<()> {
+        let (elapsed_us, duration_us) = {
+            let ctx = self.ctx.read().await;
+            (ctx.status.elapsed.as_micros() as i64, ctx.status.duration.as_micros() as i64)
+        };
+
+        match seek::plan_relative_seek(elapsed_us, duration_us, offset) {
+            SeekPlan::Relative { delta_secs, seeked_us } => {
+                let change = if delta_secs < 0 {
+                    ValueChange::Decrease(delta_secs.unsigned_abs() as u32)
+                } else {
+                    ValueChange::Increase(delta_secs as u32)
+                };
+                self.client
+                    .run(move |c| c.seek_current(change))
+                    .await
+                    .map_err(|e| fdo::Error::Failed(format!("Failed to seek: {e}")))?;
+                Player::seeked(&emitter, seeked_us).await?;
+            }
+            SeekPlan::Next => {
+                self.client.run(|c| c.next()).await.map_err(|e| {
+                    fdo::Error::Failed(format!("Failed to seek past track end: {e}"))
+                })?;
+            }
+            SeekPlan::Absolute { .. } | SeekPlan::Ignore => {}
+        }
         Ok(())
     }
+
+    async fn set_position(
+        &self,
+        track_id: ObjectPath<'_>,
+        position: i64,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+    ) -> fdo::Result<()> {
+        let requested_id = Song::id_from_object_path(track_id);
+        let (current_id, duration_us) = {
+            let ctx = self.ctx.read().await;
+            (ctx.current_song.as_ref().map(|song| song.id), ctx.status.duration.as_micros() as i64)
+        };
+
+        match seek::plan_set_position(current_id, requested_id, position, duration_us) {
+            SeekPlan::Absolute { secs, seeked_us } => {
+                self.client
+                    .run(move |c| c.seek_current(ValueChange::Set(secs)))
+                    .await
+                    .map_err(|e| fdo::Error::Failed(format!("Failed to set position: {e}")))?;
+                Player::seeked(&emitter, seeked_us).await?;
+            }
+            SeekPlan::Relative { .. } | SeekPlan::Next | SeekPlan::Ignore => {}
+        }
+        Ok(())
+    }
+
+    #[zbus(signal)]
+    pub async fn seeked(emitter: &SignalEmitter<'_>, position: i64) -> zbus::Result<()> {}
 
     #[zbus(property)]
     async fn volume(&self) -> f64 {

--- a/rmpcd/src/mpris/seek.rs
+++ b/rmpcd/src/mpris/seek.rs
@@ -1,0 +1,134 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeekPlan {
+    Absolute { secs: u32, seeked_us: i64 },
+    Relative { delta_secs: i64, seeked_us: i64 },
+    Next,
+    Ignore,
+}
+
+pub fn plan_set_position(
+    current_id: Option<u32>,
+    requested_id: Option<u32>,
+    position_us: i64,
+    duration_us: i64,
+) -> SeekPlan {
+    if duration_us <= 0 || position_us < 0 || position_us > duration_us {
+        return SeekPlan::Ignore;
+    }
+    match (current_id, requested_id) {
+        (Some(cur), Some(req)) if cur == req => {}
+        _ => return SeekPlan::Ignore,
+    }
+    SeekPlan::Absolute { secs: (position_us / 1_000_000) as u32, seeked_us: position_us }
+}
+
+pub fn plan_relative_seek(elapsed_us: i64, duration_us: i64, offset_us: i64) -> SeekPlan {
+    if duration_us <= 0 {
+        return SeekPlan::Ignore;
+    }
+    let target_us = elapsed_us.saturating_add(offset_us);
+    if target_us >= duration_us {
+        return SeekPlan::Next;
+    }
+    SeekPlan::Relative { delta_secs: offset_us / 1_000_000, seeked_us: target_us.max(0) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SEC: i64 = 1_000_000;
+
+    #[test]
+    fn set_position_valid_seeks_absolute() {
+        assert_eq!(plan_set_position(Some(7), Some(7), 90 * SEC, 200 * SEC), SeekPlan::Absolute {
+            secs: 90,
+            seeked_us: 90 * SEC
+        });
+    }
+
+    #[test]
+    fn set_position_at_exact_end_is_allowed() {
+        assert_eq!(plan_set_position(Some(7), Some(7), 200 * SEC, 200 * SEC), SeekPlan::Absolute {
+            secs: 200,
+            seeked_us: 200 * SEC
+        });
+    }
+
+    #[test]
+    fn set_position_negative_is_ignored() {
+        assert_eq!(plan_set_position(Some(7), Some(7), -1, 200 * SEC), SeekPlan::Ignore);
+    }
+
+    #[test]
+    fn set_position_beyond_duration_is_ignored() {
+        assert_eq!(plan_set_position(Some(7), Some(7), 200 * SEC + 1, 200 * SEC), SeekPlan::Ignore);
+    }
+
+    #[test]
+    fn set_position_mismatched_track_is_ignored() {
+        assert_eq!(plan_set_position(Some(7), Some(8), 10 * SEC, 200 * SEC), SeekPlan::Ignore);
+    }
+
+    #[test]
+    fn set_position_no_current_song_is_ignored() {
+        assert_eq!(plan_set_position(None, Some(7), 10 * SEC, 200 * SEC), SeekPlan::Ignore);
+    }
+
+    #[test]
+    fn set_position_unparsable_track_is_ignored() {
+        assert_eq!(plan_set_position(Some(7), None, 10 * SEC, 200 * SEC), SeekPlan::Ignore);
+    }
+
+    #[test]
+    fn set_position_no_duration_is_ignored() {
+        assert_eq!(plan_set_position(Some(7), Some(7), 0, 0), SeekPlan::Ignore);
+    }
+
+    #[test]
+    fn relative_forward_within_bounds() {
+        assert_eq!(plan_relative_seek(10 * SEC, 200 * SEC, 30 * SEC), SeekPlan::Relative {
+            delta_secs: 30,
+            seeked_us: 40 * SEC
+        });
+    }
+
+    #[test]
+    fn relative_backward_keeps_sign() {
+        assert_eq!(plan_relative_seek(60 * SEC, 200 * SEC, -30 * SEC), SeekPlan::Relative {
+            delta_secs: -30,
+            seeked_us: 30 * SEC
+        });
+    }
+
+    #[test]
+    fn relative_backward_past_start_clamps_seeked_to_zero() {
+        assert_eq!(plan_relative_seek(10 * SEC, 200 * SEC, -30 * SEC), SeekPlan::Relative {
+            delta_secs: -30,
+            seeked_us: 0
+        });
+    }
+
+    #[test]
+    fn relative_forward_past_end_is_next() {
+        assert_eq!(plan_relative_seek(190 * SEC, 200 * SEC, 30 * SEC), SeekPlan::Next);
+    }
+
+    #[test]
+    fn relative_reaching_exact_end_is_next() {
+        assert_eq!(plan_relative_seek(170 * SEC, 200 * SEC, 30 * SEC), SeekPlan::Next);
+    }
+
+    #[test]
+    fn relative_no_duration_is_ignored() {
+        assert_eq!(plan_relative_seek(0, 0, 5 * SEC), SeekPlan::Ignore);
+    }
+
+    #[test]
+    fn relative_sub_second_offset_truncates_delta() {
+        assert_eq!(plan_relative_seek(10 * SEC, 200 * SEC, 2_500_000), SeekPlan::Relative {
+            delta_secs: 2,
+            seeked_us: 12_500_000
+        });
+    }
+}

--- a/rmpcd/src/mpris/tracklist.rs
+++ b/rmpcd/src/mpris/tracklist.rs
@@ -21,7 +21,7 @@ impl Tracklist {
     }
 }
 
-#[interface(name = "org.mpris.MedPlayer2.TrackList")]
+#[interface(name = "org.mpris.MediaPlayer2.TrackList")]
 impl Tracklist {
     #[zbus()]
     async fn get_tracks_metadata(


### PR DESCRIPTION
## Description
- `Seek` was treating its offset as an absolute position; it now seeks relative to the current position.
- `SetPosition` does an absolute seek, ignoring out-of-range positions or a track ID that isn't the current song.
- `Seeked` fires after a successful seek.

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [ ] Changelog has been updated
