### PR TITLE
feat: allow grouping in first level of browser

### DIFF
--- a/rmpc-mpd/src/client.rs
+++ b/rmpc-mpd/src/client.rs
@@ -28,7 +28,7 @@ use crate::{
         Update,
         Volume,
         decoders::Decoders,
-        list::MpdList,
+        list::{MpdGroupedList, MpdList, RawGroupedPairs},
         list_all::ListAll,
         list_playlist::FileList,
         messages::Messages,
@@ -576,6 +576,16 @@ impl MpdClient for Client<'_> {
 
     fn list_tag(&mut self, tag: Tag, filter: Option<&[Filter<'_>]>) -> MpdResult<MpdList> {
         self.send_list_tag(tag, filter).and_then(|()| self.read_response())
+    }
+
+    fn list_tag_grouped(
+        &mut self,
+        tag: Tag,
+        group_tags: &[Tag],
+        filter: Option<&[Filter<'_>]>,
+    ) -> MpdResult<MpdGroupedList> {
+        self.send_list_tag_grouped(&tag, group_tags, filter)?;
+        self.read_response::<RawGroupedPairs>().map(|raw| raw.into_grouped_list(tag.as_str()))
     }
 
     fn shuffle(&mut self, range: Option<SingleOrRange>) -> MpdResult<()> {

--- a/rmpc-mpd/src/commands/list.rs
+++ b/rmpc-mpd/src/commands/list.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use derive_more::{AsMut, AsRef, Into, IntoIterator};
 
 use crate::{
@@ -18,5 +20,36 @@ impl FromMpd for MpdList {
     fn next_internal(&mut self, _key: &str, value: String) -> Result<LineHandled, MpdError> {
         self.0.push(value);
         Ok(LineHandled::Yes)
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct MpdGroupedList(pub Vec<HashMap<String, String>>);
+
+#[derive(Default)]
+pub(crate) struct RawGroupedPairs(pub Vec<(String, String)>);
+
+impl FromMpd for RawGroupedPairs {
+    fn next_internal(&mut self, key: &str, value: String) -> Result<LineHandled, MpdError> {
+        self.0.push((key.to_string(), value));
+        Ok(LineHandled::Yes)
+    }
+}
+
+impl RawGroupedPairs {
+    pub(crate) fn into_grouped_list(self, primary: &str) -> MpdGroupedList {
+        let primary = primary.to_lowercase();
+        let mut context = HashMap::new();
+        let mut records = Vec::new();
+        for (key, value) in self.0 {
+            if key == primary {
+                let mut record = context.clone();
+                record.insert(key, value);
+                records.push(record);
+            } else {
+                context.insert(key, value);
+            }
+        }
+        MpdGroupedList(records)
     }
 }

--- a/rmpc-mpd/src/mpd_client.rs
+++ b/rmpc-mpd/src/mpd_client.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{fmt::Write, str::FromStr};
 
 use anyhow::Result;
 use rmpc_shared::version::Version;
@@ -16,7 +16,7 @@ use super::{
         Update,
         Volume,
         decoders::Decoders,
-        list::MpdList,
+        list::{MpdGroupedList, MpdList},
         list_playlist::FileList,
         mpd_config::MpdConfig,
         outputs::Outputs,
@@ -147,6 +147,12 @@ pub trait MpdCommand {
         position: Option<QueuePosition>,
     ) -> MpdResult<()>;
     fn send_list_tag(&mut self, tag: Tag, filter: Option<&[Filter<'_>]>) -> MpdResult<()>;
+    fn send_list_tag_grouped(
+        &mut self,
+        tag: &Tag,
+        group_tags: &[Tag],
+        filter: Option<&[Filter<'_>]>,
+    ) -> MpdResult<()>;
     fn send_shuffle(&mut self, range: Option<SingleOrRange>) -> MpdResult<()>;
     fn send_list_all(&mut self, path: Option<&str>) -> MpdResult<()>;
     fn send_lsinfo(&mut self, path: Option<&str>) -> MpdResult<()>;
@@ -288,6 +294,12 @@ pub trait MpdClient: Sized {
         position: Option<QueuePosition>,
     ) -> MpdResult<()>;
     fn list_tag(&mut self, tag: Tag, filter: Option<&[Filter<'_>]>) -> MpdResult<MpdList>;
+    fn list_tag_grouped(
+        &mut self,
+        tag: Tag,
+        group_tags: &[Tag],
+        filter: Option<&[Filter<'_>]>,
+    ) -> MpdResult<MpdGroupedList>;
     /// Shuffles the current queue.
     fn shuffle(&mut self, range: Option<SingleOrRange>) -> MpdResult<()>;
     // Database
@@ -625,6 +637,28 @@ impl<T: SocketClient> MpdCommand for T {
             self.execute(&format!("list {} \"({})\"", tag.as_str(), filter.to_query_str()))
         } else {
             self.execute(&format!("list {}", tag.as_str()))
+        }
+    }
+
+    fn send_list_tag_grouped(
+        &mut self,
+        tag: &Tag,
+        group_tags: &[Tag],
+        filter: Option<&[Filter<'_>]>,
+    ) -> MpdResult<()> {
+        let groups = group_tags.iter().fold(String::new(), |mut output, value| {
+            let _ = write!(output, " group {}", value.as_str());
+            output
+        });
+        if let Some(filter) = filter {
+            self.execute(&format!(
+                "list {} \"({})\"{}",
+                tag.as_str(),
+                filter.to_query_str(),
+                groups
+            ))
+        } else {
+            self.execute(&format!("list {}{}", tag.as_str(), groups))
         }
     }
 

--- a/rmpc-mpd/src/tests/fixtures/mpd_client.rs
+++ b/rmpc-mpd/src/tests/fixtures/mpd_client.rs
@@ -17,7 +17,7 @@ use crate::{
         Status,
         Update,
         Volume,
-        list::MpdList,
+        list::{MpdGroupedList, MpdList},
         list_all::ListAll,
         list_playlist::FileList,
         metadata_tag::MetadataTagExt,
@@ -457,6 +457,15 @@ impl MpdClient for TestMpdClient {
     }
 
     fn list_tag(&mut self, _tag: Tag, _filter: Option<&[Filter<'_>]>) -> MpdResult<MpdList> {
+        todo!("Not yet implemented")
+    }
+
+    fn list_tag_grouped(
+        &mut self,
+        _tag: Tag,
+        _group_tags: &[Tag],
+        _filter: Option<&[Filter<'_>]>,
+    ) -> MpdResult<MpdGroupedList> {
         todo!("Not yet implemented")
     }
 

--- a/rmpc/src/config/tabs.rs
+++ b/rmpc/src/config/tabs.rs
@@ -334,16 +334,8 @@ impl TryFrom<PaneTypeFile> for PaneType {
                         bail!("At least one level is required for browser panes");
                     }
 
-                    if levels[0].group_by.len() != 1 {
-                        bail!("group_by on the first level must have exactly one tag");
-                    }
-
-                    if levels[0].sort_by.is_some() {
-                        bail!("sort_by is not allowed on the first level");
-                    }
-
-                    if levels[0].format.is_some() {
-                        bail!("format is not allowed on the first level");
+                    if levels[0].group_by.is_empty() {
+                        bail!("group_by on the first level must have at least one entry");
                     }
 
                     PaneType::Browser {

--- a/rmpc/src/shared/mpd_query.rs
+++ b/rmpc/src/shared/mpd_query.rs
@@ -6,7 +6,7 @@ use crossbeam::channel::Sender;
 use ratatui::{style::Style, widgets::ListItem};
 use rmpc_mpd::{
     client::Client,
-    commands::{Decoder, IdleEvent, Song, Status, Volume},
+    commands::{Decoder, IdleEvent, Song, Status, Volume, list::MpdGroupedList},
 };
 
 use super::{events::AppEvent, mpd_client_ext::PartitionedOutput};
@@ -93,6 +93,7 @@ pub(crate) enum MpdQueryResult {
     Decoders(Vec<Decoder>),
     ExternalCommand(Arc<Vec<String>>, Vec<String>, Vec<Song>),
     SongStickers(HashMap<String, HashMap<String, String>>),
+    TagGroupedList { data: MpdGroupedList },
     Any(Box<dyn Any + Send + Sync>),
 }
 

--- a/rmpc/src/ui/dir_or_song.rs
+++ b/rmpc/src/ui/dir_or_song.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, cmp::Ordering, str::FromStr};
+use std::{borrow::Cow, cmp::Ordering, collections::HashMap, str::FromStr};
 
 use rmpc_mpd::commands::{
     Song,
@@ -23,6 +23,7 @@ pub(crate) enum DirOrSong {
         full_path: String,
         last_modified: chrono::DateTime<chrono::Utc>,
         playlist: bool,
+        metadata: HashMap<String, String>,
     },
     Song(Song),
 }
@@ -35,6 +36,7 @@ impl DirOrSong {
             full_path: String::new(),
             last_modified: chrono::Utc::now(),
             playlist: false,
+            metadata: HashMap::new(),
         }
     }
 
@@ -45,6 +47,22 @@ impl DirOrSong {
             full_path: String::new(),
             last_modified: chrono::Utc::now(),
             playlist: false,
+            metadata: HashMap::new(),
+        }
+    }
+
+    pub fn name_display_name_with_metadata(
+        name: String,
+        display_name: String,
+        metadata: HashMap<String, String>,
+    ) -> Self {
+        DirOrSong::Dir {
+            name,
+            display_name: Some(display_name),
+            full_path: String::new(),
+            last_modified: chrono::Utc::now(),
+            playlist: false,
+            metadata,
         }
     }
 
@@ -55,6 +73,7 @@ impl DirOrSong {
             full_path: String::new(),
             last_modified: chrono::Utc::now(),
             playlist: true,
+            metadata: HashMap::new(),
         }
     }
 
@@ -190,6 +209,7 @@ impl LsInfoEntryExt for LsInfoEntry {
                 full_path,
                 last_modified,
                 playlist: false,
+                metadata: HashMap::new(),
             }),
             LsInfoEntry::Playlist(playlist) => match show_playlists_mode {
                 ShowPlaylistsMode::All => Some(DirOrSong::Dir {
@@ -198,6 +218,7 @@ impl LsInfoEntryExt for LsInfoEntry {
                     full_path: playlist.full_path,
                     last_modified: playlist.last_modified,
                     playlist: true,
+                    metadata: HashMap::new(),
                 }),
                 ShowPlaylistsMode::None => None,
                 ShowPlaylistsMode::NonRoot if playlist.name == playlist.full_path => None,
@@ -207,6 +228,7 @@ impl LsInfoEntryExt for LsInfoEntry {
                     full_path: playlist.full_path,
                     last_modified: playlist.last_modified,
                     playlist: true,
+                    metadata: HashMap::new(),
                 }),
             },
         }
@@ -485,6 +507,7 @@ mod ordtest {
             full_path: name.to_string(),
             last_modified: mtime.parse().unwrap(),
             playlist: false,
+            metadata: HashMap::new(),
         }
     }
 

--- a/rmpc/src/ui/panes/playlists/tests.rs
+++ b/rmpc/src/ui/panes/playlists/tests.rs
@@ -542,6 +542,7 @@ fn dir(name: &str) -> DirOrSong {
         full_path: name.to_string(),
         last_modified: *NOW,
         playlist: false,
+        metadata: HashMap::new(),
     }
 }
 

--- a/rmpc/src/ui/panes/tag_browser.rs
+++ b/rmpc/src/ui/panes/tag_browser.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use ratatui::{Frame, prelude::Rect, widgets::ListState};
 use rmpc_mpd::{
     client::Client,
-    commands::Song,
+    commands::{Song, list::MpdGroupedList, metadata_tag::MetadataTag},
     filter::{Filter, Tag},
     mpd_client::MpdClient,
 };
@@ -40,6 +40,7 @@ pub struct TagBrowserPane {
 }
 
 const INIT: &str = "init";
+const INIT_GROUPED: &str = "init_grouped";
 const FETCH_SONGS: &str = "fetch_songs";
 
 struct SongGroup {
@@ -207,6 +208,72 @@ impl TagBrowserPane {
         Self::insert_level(&mut self.stack, root_value.into(), data, &self.tags[1..], ctx);
     }
 
+    fn process_grouped_list(&mut self, data: MpdGroupedList, ctx: &Ctx) {
+        let stub_songs: Vec<Song> = data
+            .0
+            .into_iter()
+            .map(|record| Song {
+                id: 0,
+                file: String::new(),
+                duration: None,
+                last_modified: chrono::Utc::now(),
+                added: None,
+                metadata: record
+                    .into_iter()
+                    .filter(|(_, v)| !v.is_empty())
+                    .map(|(k, v)| (k, MetadataTag::Single(v)))
+                    .collect(),
+            })
+            .collect();
+
+        let groups = Self::group_songs_by_tag(stub_songs, &self.tags[0], ctx);
+
+        self.stack = DirStack::new(
+            groups
+                .into_iter()
+                .map(|mut group| {
+                    let metadata = group.songs[0]
+                        .metadata
+                        .iter_mut()
+                        .map(|(k, v)| (k.clone(), v.first().to_string()))
+                        .collect();
+                    DirOrSong::name_display_name_with_metadata(
+                        group.id,
+                        group.display_name,
+                        metadata,
+                    )
+                })
+                .collect(),
+        );
+    }
+
+    fn queue_root_fetch(&mut self, ctx: &Ctx) -> Result<()> {
+        let target = self.target_pane.clone();
+        if self.tags[0].group_by.len() > 1 {
+            let primary_tag: Tag = self.tags[0].group_by[0][0].clone().try_into()?;
+            let group_tags: Vec<Tag> = self.tags[0].group_by[1..]
+                .iter()
+                .filter_map(|props| props.first().and_then(|p| p.clone().try_into().ok()))
+                .collect();
+            ctx.query().id(INIT_GROUPED).replace_id(INIT_GROUPED).target(target).query(
+                move |client| {
+                    let result = client
+                        .list_tag_grouped(primary_tag, &group_tags, None)
+                        .context("Cannot list grouped tags")?;
+                    Ok(MpdQueryResult::TagGroupedList { data: result })
+                },
+            );
+        } else {
+            let root_tag = self.tags[0].group_by[0][0].clone().try_into()?;
+            ctx.query().id(INIT).replace_id(INIT).target(target).query(move |client| {
+                let result = client.list_tag(root_tag, None).context("Cannot list artists")?;
+                log::debug!("Fetched root tag values: {:?}", result.0);
+                Ok(MpdQueryResult::LsInfo { data: result.0, path: None })
+            });
+        }
+        Ok(())
+    }
+
     fn songs_for_item(&self, item: &DirOrSong) -> Vec<Song> {
         let path = self.stack().path().to_owned();
         item.walk(&self.stack, path)
@@ -227,14 +294,7 @@ impl Pane for TagBrowserPane {
 
     fn before_show(&mut self, ctx: &Ctx) -> Result<()> {
         if !self.initialized {
-            let root_tag = self.tags[0].group_by[0][0].clone().try_into()?;
-            let target = self.target_pane.clone();
-            ctx.query().id(INIT).replace_id(INIT).target(target).query(move |client| {
-                let result = client.list_tag(root_tag, None).context("Cannot list artists")?;
-                log::debug!("Fetched root tag values: {:?}", result.0);
-                Ok(MpdQueryResult::LsInfo { data: result.0, path: None })
-            });
-
+            self.queue_root_fetch(ctx)?;
             self.initialized = true;
         }
 
@@ -244,13 +304,8 @@ impl Pane for TagBrowserPane {
     fn on_event(&mut self, event: &mut UiEvent, _is_visible: bool, ctx: &Ctx) -> Result<()> {
         match event {
             UiEvent::Database => {
-                let root_tag = self.tags[0].group_by[0][0].clone().try_into()?;
-                let target = self.target_pane.clone();
                 self.stack = DirStack::default();
-                ctx.query().id(INIT).replace_id(INIT).target(target).query(move |client| {
-                    let result = client.list_tag(root_tag, None).context("Cannot list artists")?;
-                    Ok(MpdQueryResult::LsInfo { data: result.0, path: None })
-                });
+                self.queue_root_fetch(ctx)?;
             }
             UiEvent::Reconnected => {
                 self.initialized = false;
@@ -291,6 +346,13 @@ impl Pane for TagBrowserPane {
 
                 self.process_songs(root_path, data, ctx);
                 self.fetch_data_internal(ctx)?;
+                ctx.render()?;
+            }
+            (INIT_GROUPED, MpdQueryResult::TagGroupedList { data }) => {
+                self.process_grouped_list(data, ctx);
+                if let Some(sel) = self.stack.current().selected() {
+                    self.fetch_data(sel, ctx)?;
+                }
                 ctx.render()?;
             }
             (INIT, MpdQueryResult::LsInfo { data, path: _ }) => {
@@ -338,11 +400,31 @@ impl BrowserPane<DirOrSong> for TagBrowserPane {
     fn fetch_data(&self, selected: &DirOrSong, ctx: &Ctx) -> Result<()> {
         match self.stack.path().as_slice() {
             [] => {
-                let current = selected.as_path();
-                let root_tag: Tag = self.tags[0].group_by[0][0].clone().try_into()?;
+                let current = selected.as_path().to_owned();
                 let target = self.target_pane.clone();
-                let current = current.to_owned();
 
+                if let DirOrSong::Dir { metadata, .. } = selected
+                    && !metadata.is_empty()
+                {
+                    let filters: Vec<(Tag, String)> =
+                        metadata.iter().map(|(k, v)| (Tag::from(k.clone()), v.clone())).collect();
+                    ctx.query().id(FETCH_SONGS).replace_id(FETCH_SONGS).target(target).query(
+                        move |client| {
+                            let filter_refs: Vec<Filter<'_>> = filters
+                                .iter()
+                                .map(|(tag, val)| Filter::new(tag.clone(), val.as_str()))
+                                .collect();
+                            let all_songs: Vec<Song> = client.find(&filter_refs)?;
+                            Ok(MpdQueryResult::SongsList {
+                                data: all_songs,
+                                path: Some(current.into()),
+                            })
+                        },
+                    );
+                    return Ok(());
+                }
+
+                let root_tag: Tag = self.tags[0].group_by[0][0].clone().try_into()?;
                 ctx.query().id(FETCH_SONGS).replace_id(FETCH_SONGS).target(target).query(
                     move |client| {
                         let all_songs: Vec<Song> =
@@ -724,6 +806,253 @@ mod tests {
         pane.process_songs(artist.clone(), songs, &ctx);
 
         assert_eq!(pane_albums(&pane), vec!["(<no originaldate>) album_a"]);
+    }
+
+    mod process_grouped_list {
+        use super::*;
+
+        fn grouped_record(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
+            pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+        }
+
+        fn grouped_album_by_artist_tag() -> BrowserTagConfig {
+            BrowserTagConfig {
+                group_by: vec![vec![SongProperty::Album], vec![SongProperty::Artist]],
+                sort_by: None,
+                format: vec![
+                    Property {
+                        kind: PropertyKindOrText::Property(SongProperty::Artist),
+                        style: None,
+                        default: None,
+                    },
+                    Property {
+                        kind: PropertyKindOrText::Text(" - ".to_string()),
+                        style: None,
+                        default: None,
+                    },
+                    Property {
+                        kind: PropertyKindOrText::Property(SongProperty::Album),
+                        style: None,
+                        default: None,
+                    },
+                ],
+                skip: CollapseLevel::default(),
+            }
+        }
+
+        fn grouped_album_sorted_by_date_tag() -> BrowserTagConfig {
+            BrowserTagConfig {
+                group_by: vec![vec![SongProperty::Album], vec![SongProperty::Artist], vec![
+                    SongProperty::Other("date".to_string()),
+                ]],
+                sort_by: Some(vec![vec![SongProperty::Other("date".to_string())]]),
+                format: vec![
+                    Property {
+                        kind: PropertyKindOrText::Text("(".to_string()),
+                        style: None,
+                        default: None,
+                    },
+                    Property {
+                        kind: PropertyKindOrText::Property(SongProperty::Other("date".to_string())),
+                        style: None,
+                        default: None,
+                    },
+                    Property {
+                        kind: PropertyKindOrText::Text(") ".to_string()),
+                        style: None,
+                        default: None,
+                    },
+                    Property {
+                        kind: PropertyKindOrText::Property(SongProperty::Album),
+                        style: None,
+                        default: None,
+                    },
+                ],
+                skip: CollapseLevel::default(),
+            }
+        }
+
+        fn pane_root_display_names(pane: &TagBrowserPane) -> Vec<String> {
+            pane.stack
+                .current()
+                .items
+                .iter()
+                .map(|item| match item {
+                    DirOrSong::Dir { display_name, name, .. } => {
+                        display_name.as_ref().unwrap_or(name).clone()
+                    }
+                    DirOrSong::Song(s) => s.file.clone(),
+                })
+                .collect_vec()
+        }
+
+        #[rstest]
+        fn sorts_by_display_name_when_no_sort_by(mut ctx: Ctx, config: Config) {
+            ctx.config = std::sync::Arc::new(config);
+            let mut pane =
+                TagBrowserPane::new(vec![grouped_album_by_artist_tag()], PaneType::Albums, &ctx);
+
+            pane.process_grouped_list(
+                MpdGroupedList(vec![
+                    grouped_record(&[("album", "B Album"), ("artist", "Artist Y")]),
+                    grouped_record(&[("album", "A Album"), ("artist", "Artist X")]),
+                    grouped_record(&[("album", "C Album"), ("artist", "Artist Z")]),
+                ]),
+                &ctx,
+            );
+
+            assert_eq!(pane_root_display_names(&pane), vec![
+                "Artist X - A Album",
+                "Artist Y - B Album",
+                "Artist Z - C Album"
+            ]);
+        }
+
+        #[rstest]
+        fn sorts_by_configured_tag(mut ctx: Ctx, config: Config) {
+            ctx.config = std::sync::Arc::new(config);
+            let mut pane = TagBrowserPane::new(
+                vec![grouped_album_sorted_by_date_tag()],
+                PaneType::Albums,
+                &ctx,
+            );
+
+            pane.process_grouped_list(
+                MpdGroupedList(vec![
+                    grouped_record(&[
+                        ("album", "B Album"),
+                        ("artist", "Artist Y"),
+                        ("date", "2005"),
+                    ]),
+                    grouped_record(&[
+                        ("album", "A Album"),
+                        ("artist", "Artist X"),
+                        ("date", "2003"),
+                    ]),
+                    grouped_record(&[
+                        ("album", "C Album"),
+                        ("artist", "Artist Z"),
+                        ("date", "2001"),
+                    ]),
+                ]),
+                &ctx,
+            );
+
+            assert_eq!(pane_root_display_names(&pane), vec![
+                "(2001) C Album",
+                "(2003) A Album",
+                "(2005) B Album"
+            ]);
+        }
+
+        #[rstest]
+        fn root_item_filters_contain_all_tags(mut ctx: Ctx, config: Config) {
+            ctx.config = std::sync::Arc::new(config);
+            let mut pane = TagBrowserPane::new(
+                vec![grouped_album_sorted_by_date_tag()],
+                PaneType::Albums,
+                &ctx,
+            );
+
+            pane.process_grouped_list(
+                MpdGroupedList(vec![grouped_record(&[
+                    ("album", "The Phantom Agony"),
+                    ("artist", "Epica"),
+                    ("date", "2003-08-21"),
+                ])]),
+                &ctx,
+            );
+
+            assert_eq!(pane.stack.current().items.len(), 1);
+            let item = &pane.stack.current().items[0];
+            let DirOrSong::Dir { metadata, .. } = item else {
+                panic!("expected Dir, got Song");
+            };
+            assert_eq!(metadata.get("album").map(String::as_str), Some("The Phantom Agony"));
+            assert_eq!(metadata.get("artist").map(String::as_str), Some("Epica"));
+            assert_eq!(metadata.get("date").map(String::as_str), Some("2003-08-21"));
+        }
+
+        #[rstest]
+        fn same_album_different_artists_are_separate_items(mut ctx: Ctx, config: Config) {
+            ctx.config = std::sync::Arc::new(config);
+            let mut pane = TagBrowserPane::new(
+                vec![grouped_album_sorted_by_date_tag()],
+                PaneType::Albums,
+                &ctx,
+            );
+
+            pane.process_grouped_list(
+                MpdGroupedList(vec![
+                    grouped_record(&[
+                        ("album", "Grimoire"),
+                        ("artist", "Artist A"),
+                        ("date", "2016"),
+                    ]),
+                    grouped_record(&[
+                        ("album", "Grimoire"),
+                        ("artist", "Artist B"),
+                        ("date", "2016"),
+                    ]),
+                ]),
+                &ctx,
+            );
+
+            assert_eq!(pane_root_display_names(&pane).len(), 2);
+            let artists: Vec<&str> = pane
+                .stack
+                .current()
+                .items
+                .iter()
+                .filter_map(|item| {
+                    if let DirOrSong::Dir { metadata, .. } = item {
+                        metadata.get("artist").map(String::as_str)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            assert!(artists.contains(&"Artist A"));
+            assert!(artists.contains(&"Artist B"));
+        }
+
+        #[rstest]
+        fn empty_records_produces_empty_stack(mut ctx: Ctx, config: Config) {
+            ctx.config = std::sync::Arc::new(config);
+            let mut pane =
+                TagBrowserPane::new(vec![grouped_album_by_artist_tag()], PaneType::Albums, &ctx);
+
+            pane.process_grouped_list(MpdGroupedList(vec![]), &ctx);
+
+            assert!(pane.stack.current().items.is_empty());
+        }
+
+        #[rstest]
+        fn second_call_replaces_previous_state(mut ctx: Ctx, config: Config) {
+            ctx.config = std::sync::Arc::new(config);
+            let mut pane =
+                TagBrowserPane::new(vec![grouped_album_by_artist_tag()], PaneType::Albums, &ctx);
+
+            pane.process_grouped_list(
+                MpdGroupedList(vec![grouped_record(&[
+                    ("album", "Old Album"),
+                    ("artist", "Old Artist"),
+                ])]),
+                &ctx,
+            );
+            assert_eq!(pane.stack.current().items.len(), 1);
+
+            pane.process_grouped_list(
+                MpdGroupedList(vec![
+                    grouped_record(&[("album", "New Album A"), ("artist", "New Artist")]),
+                    grouped_record(&[("album", "New Album B"), ("artist", "New Artist")]),
+                ]),
+                &ctx,
+            );
+
+            assert_eq!(pane_root_display_names(&pane).len(), 2);
+            assert!(pane_root_display_names(&pane).iter().all(|n| n.contains("New")));
+        }
     }
 
     mod list_songs_in_item {


### PR DESCRIPTION
## Description

Lift the limitation of disallowing group_by at the first level of browser panes

### Related issues

Continuation of https://github.com/mierak/rmpc/issues/909
docs pr: https://github.com/rmpc-org/rmpc-org.github.io/pull/66

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
