### PR TITLE
Fix the behavor of draw_borders and the scrollbar in browser panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ keybinds
 - The queue should not leave empty space in the table anymore
 - rmpc will now handle focused events and attempt to resize the TUI if needed
 - Loading a playlist when with missing songs will now load the existing songs instead of nothing
+- The borders of browser panes are nolonger affected by the scrollbar track being set
 
 ## [0.11.0] - 2026-02-01
 

--- a/rmpc/src/config/theme/mod.rs
+++ b/rmpc/src/config/theme/mod.rs
@@ -133,7 +133,7 @@ impl Default for UiConfigFile {
         Self {
             layout: PaneOrSplitFile::default(),
             default_album_art_path: None,
-            draw_borders: true,
+            draw_borders: false,
             background_color: None,
             text_color: None,
             header_background_color: None,

--- a/rmpc/src/ui/widgets/browser.rs
+++ b/rmpc/src/ui/widgets/browser.rs
@@ -68,13 +68,7 @@ where
             .song_format
             .as_deref()
             .unwrap_or(ctx.config.theme.browser_song_format.0.as_slice());
-        let scrollbar_margin = match config.theme.scrollbar.as_ref() {
-            Some(scrollbar) if config.theme.draw_borders => {
-                let scrollbar_track = &scrollbar.symbols[0];
-                Margin { vertical: 0, horizontal: scrollbar_track.is_empty().into() }
-            }
-            Some(_) | None => Margin { vertical: 0, horizontal: 0 },
-        };
+        let scrollbar_margin = Margin { vertical: 0, horizontal: config.theme.draw_borders.into() };
         let column_right_padding: u16 = config.theme.scrollbar.is_some().into();
 
         let current = state.current().to_list_items(song_format, ctx);
@@ -144,7 +138,7 @@ where
                     .padding(Padding::new(0, column_right_padding, 0, 0))
                     .border_set(LEFT_COLUMN_SYMBOLS)
             } else {
-                Block::default().padding(Padding::new(1, column_right_padding, 0, 0))
+                Block::default().padding(Padding::new(0, column_right_padding, 0, 0))
             };
             if let Some(title) = title {
                 block = block.title(title);


### PR DESCRIPTION
## Description

The borders are no longer dependent on if a symbol is set for the scrollbar track.
`draw_borders` now defaults to false to avoid breaking configs where it wasn't explicitly set, including the default one.

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
