### PR TITLE
feat: add home manager module with nix-native ron config generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Home Manager module (`homeManagerModules.rmpc` flake output) with structured
+  `programs.rmpc.settings` and `programs.rmpc.themes` options written in plain
+  Nix and rendered to RON at build time.
 - Added a new vertical volume slider pane.
 - **Breaking** `ExternalCommand` can now have arguments supplied at runtime. This will break your
   existing keybinds if they contained either `{` or `}`. You will now need to escape these by

--- a/flake.nix
+++ b/flake.nix
@@ -82,5 +82,16 @@
 
         devShells.default = (mkScope pkgs).shell;
       }
-    );
+    )
+    // {
+      # Structured `programs.rmpc.settings`/`themes` options rendered to RON,
+      # extending the module that ships with Home Manager.
+      homeManagerModules = {
+        rmpc = import ./nix/home-manager.nix;
+        default = inputs.self.homeManagerModules.rmpc;
+      };
+
+      # The Nix -> RON serializer on its own, for use outside Home Manager.
+      lib.ron = import ./nix/ron.nix {inherit (inputs.nixpkgs) lib;};
+    };
 }

--- a/nix/home-manager.nix
+++ b/nix/home-manager.nix
@@ -1,0 +1,130 @@
+# Extends the `programs.rmpc` module that ships with Home Manager
+# (enable/package/config) with structured `settings` and `themes` options
+# rendered to RON. The rendered settings flow through the upstream `config`
+# option, which is `types.lines` and concatenates all definitions — so set
+# either `settings` or `config`, never both.
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.programs.rmpc;
+  ron = import ./ron.nix {inherit lib;};
+
+  # Shorthands for shapes that appear in almost every rmpc config, exposed
+  # together with the ron.nix constructors as the `rmpcLib` module argument.
+  rmpcLib =
+    ron
+    // {
+      # pane "Queue" -> Pane(Queue)
+      pane = name: ron.enum "Pane" [(ron.variant name)];
+
+      # tab "Albums" "Albums" -> (name: "Albums", pane: Pane(Albums))
+      tab = name: pane: {
+        inherit name;
+        pane = rmpcLib.pane pane;
+      };
+
+      # prop (variant "Artist") -> Property(Artist)
+      prop = kind: ron.enum "Property" [kind];
+
+      # text " - " -> Text(" - ")
+      text = s: ron.enum "Text" [s];
+    };
+
+  # Tagged values (variant/enum/struct/raw) are attrsets, admitted by the
+  # attrsOf branch.
+  ronValue = let
+    t = lib.types;
+    valueType =
+      t.nullOr (t.oneOf [
+        t.bool
+        t.int
+        t.float
+        t.str
+        (t.attrsOf valueType)
+        (t.listOf valueType)
+      ])
+      // {
+        description = "RON value";
+      };
+  in
+    valueType;
+
+  renderDocument = value:
+    lib.concatMapStrings (extension: "#![enable(${extension})]\n") cfg.ronExtensions
+    + ron.toRON value
+    + "\n";
+in {
+  options.programs.rmpc = {
+    settings = lib.mkOption {
+      type = lib.types.attrsOf ronValue;
+      default = {};
+      example = lib.literalExpression ''
+        {
+          address = "127.0.0.1:6600";
+          theme = "mytheme";
+          album_art.method = rmpcLib.variant "Kitty";
+          tabs = [
+            (rmpcLib.tab "Queue" "Queue")
+            (rmpcLib.tab "Search" "Search")
+          ];
+        }
+      '';
+      description = ''
+        rmpc configuration, rendered to RON and written to
+        {file}`$XDG_CONFIG_HOME/rmpc/config.ron`. RON constructs with no
+        native Nix representation are built with the helpers provided
+        through the `rmpcLib` module argument. Mutually exclusive with the
+        plain `config` option.
+      '';
+    };
+
+    themes = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.attrsOf ronValue);
+      default = {};
+      example = lib.literalExpression ''
+        {
+          mytheme = {
+            background_color = "#1e1e2e";
+            tab_bar.active_style = { fg = "black"; bg = "#cba6f7"; modifiers = "Bold"; };
+          };
+        }
+      '';
+      description = ''
+        Themes in the same representation as {option}`programs.rmpc.settings`,
+        each rendered to {file}`$XDG_CONFIG_HOME/rmpc/themes/<name>.ron`.
+        Select one by setting `settings.theme` to its attribute name.
+      '';
+    };
+
+    ronExtensions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "implicit_some"
+        "unwrap_newtypes"
+        "unwrap_variant_newtypes"
+      ];
+      description = ''
+        RON extensions emitted as `#![enable(...)]` header lines in the
+        generated files. The default matches rmpc's default config.
+      '';
+    };
+  };
+
+  config = lib.mkMerge [
+    # Outside the mkIf so config modules can use rmpcLib unconditionally.
+    {_module.args.rmpcLib = rmpcLib;}
+
+    (lib.mkIf cfg.enable {
+      programs.rmpc.config = lib.mkIf (cfg.settings != {}) (renderDocument cfg.settings);
+
+      xdg.configFile =
+        lib.mapAttrs' (
+          name: theme:
+            lib.nameValuePair "rmpc/themes/${name}.ron" {text = renderDocument theme;}
+        )
+        cfg.themes;
+    })
+  ];
+}

--- a/nix/ron.nix
+++ b/nix/ron.nix
@@ -1,0 +1,94 @@
+# Serializes Nix values to RON. Nix has no syntax for RON enum variants
+# (Auto, as opposed to the string "Auto") or named structs (Split(...));
+# those are written as `__type`-tagged attrsets built with the constructors
+# below, the same convention used by Home Manager's Cosmic modules. `null`
+# renders as None: rmpc enables the implicit_some extension, so Some() is
+# never needed and optionals only ever appear as a literal None.
+{lib}: let
+  inherit (builtins) head match stringLength toJSON typeOf;
+  inherit (lib) all boolToString concatMapStringsSep concatStringsSep hasInfix mapAttrsToList;
+  inherit (lib.strings) floatToString replicate;
+
+  indent = level: replicate level "    ";
+
+  # floatToString pads to six decimals (1.5 -> "1.500000"); trim the excess,
+  # but keep one decimal so the value stays a float in RON.
+  renderFloat = f: let
+    s = floatToString f;
+  in
+    if hasInfix "." s
+    then head (match "(-?[0-9]+[.][0-9]*[1-9]|-?[0-9]+[.]0)0*" s)
+    else s;
+
+  # One line when everything is short and flat, otherwise one element per line.
+  layout = level: open: close: elements: let
+    oneLine = "${open}${concatStringsSep ", " elements}${close}";
+    fitsOneLine = all (e: !hasInfix "\n" e) elements && stringLength oneLine <= 60;
+  in
+    if elements == []
+    then "${open}${close}"
+    else if fitsOneLine
+    then oneLine
+    else "${open}\n${concatMapStringsSep "\n" (e: "${indent (level + 1)}${e},") elements}\n${indent level}${close}";
+
+  renderFields = level: open: close: fields:
+    layout level open close (mapAttrsToList (name: value: "${name}: ${render (level + 1) value}") fields);
+
+  renderTagged = level: value:
+    if value.__type == "raw"
+    then value.value
+    else if value.__type == "enum"
+    then
+      if value ? value
+      then layout level "${value.variant}(" ")" (map (render (level + 1)) value.value)
+      else value.variant
+    else if value.__type == "namedStruct"
+    then renderFields level "${value.name}(" ")" value.value
+    else throw "ron.nix: unknown tagged value type `${toString value.__type}`";
+
+  render = level: value:
+    {
+      bool = boolToString value;
+      int = toString value;
+      float = renderFloat value;
+      string = toJSON value; # JSON string escaping is valid RON
+      path = toJSON (toString value);
+      null = "None";
+      list = layout level "[" "]" (map (render (level + 1)) value);
+      set =
+        if value ? __type
+        then renderTagged level value
+        else renderFields level "(" ")" value;
+    }
+    .${
+      typeOf value
+    } or (throw "ron.nix: cannot serialize a ${typeOf value} to RON");
+in {
+  # variant "Auto" -> Auto
+  variant = name: {
+    __type = "enum";
+    variant = name;
+  };
+
+  # enum "Text" ["-"] -> Text("-"); arguments are serialized, so variants nest
+  enum = name: args: {
+    __type = "enum";
+    variant = name;
+    value = args;
+  };
+
+  # struct "Split" {size = "50%";} -> Split(size: "50%")
+  struct = name: fields: {
+    __type = "namedStruct";
+    name = name;
+    value = fields;
+  };
+
+  # emitted into the output verbatim
+  raw = value: {
+    __type = "raw";
+    inherit value;
+  };
+
+  toRON = render 0;
+}


### PR DESCRIPTION
## Description
This PR adds a `homeManagerModules.rmpc` flake output that extends the existing Home Manager `programs.rmpc` module by introducing a native Nix-to-RON serializer (`nix/ron.nix`), it removes the need to write raw configuration string blobs. The module introduces new options for `settings`, `themes`, and `ronExtensions`. Because the module isn't bound by a strict upstream schema, any configuration options added to rmpc in the future will work out of the box without requiring updates here.

Standard Nix primitive types (attrsets, lists, strings, booleans, and nulls) map directly to their RON equivalents. However, because plain Nix cannot natively express RON enums or named structs, the module automatically injects an `rmpcLib` argument containing the following helper functions:

| Helper | RON |
| :--- | :--- |
| `variant "Auto"` | `Auto` |
| `enum "Text" [" - "]` | `Text(" - ")` |
| `struct "Split" { size = "50%"; }` | `Split(size: "50%")` |
| `pane "Queue"` | `Pane(Queue)` |
| `tab "Search" "Search"` | `(name: "Search", pane: Pane(Search))` |
| `prop (variant "Artist")` | `Property(Artist)` |
| `text " - "` | `Text(" - ")` |

Helpers can also be nested, e.g., `prop (enum "Status" [(variant "State")])` renders as `Property(Status(State))`

For reference as well, here's my current config that uses this module:
```nix
{ config, rmpcLib, ... }:

let
  inherit (rmpcLib) variant enum struct pane prop text tab;
  bold = fg: { inherit fg; modifiers = "Bold"; };

  # catppuccin macchiato
  mauve = "#c6a0f6";
  lavender = "#b7bdf8";
  sapphire = "#7dc4e4";
  yellow = "#eed49f";
  fgText = "#cad3f5";
  base = "#24273a";
  mantle = "#1e2030";
  overlay0 = "#6e738d";
in
{
  programs.rmpc = {
    enable = true;

    settings = {
      address = "127.0.0.1:6600";
      theme = "catppuccin-macchiato";
      lyrics_dir = "${config.home.homeDirectory}/.lyrics";

      album_art = {
        method = variant "Auto";
        max_size_px = { width = 0; height = 0; };
        vertical_align = variant "Top";
      };

      tabs = [
        {
          name = "Queue";
          pane = struct "Split" {
            direction = variant "Horizontal";
            panes = [
              { size = "100%"; pane = pane "Queue"; }
              {
                size = "42";
                pane = struct "Split" {
                  direction = variant "Vertical";
                  panes = [
                    { size = "20"; borders = "TOP | BOTTOM"; pane = pane "AlbumArt"; }
                    { size = "100%"; borders = "NONE"; pane = pane "Lyrics"; }
                  ];
                };
              }
            ];
          };
        }
        (tab "Directories" "Directories")
        (tab "Artists" "Artists")
        (tab "Album Artists" "AlbumArtists")
        (tab "Albums" "Albums")
        (tab "Playlists" "Playlists")
        (tab "Search" "Search")
      ];
    };

    themes.catppuccin-macchiato = {
      default_album_art_path = null;
      symbols = {
        song = "🎵";
        dir = "📁";
        playlist = "🎼";
        marker = "";
      };

      layout = struct "Split" {
        direction = variant "Vertical";
        panes = [
          { pane = pane "Header"; size = "1"; }
          { pane = pane "TabContent"; size = "100%"; }
          { pane = pane "ProgressBar"; size = "1"; }
        ];
      };

      progress_bar = {
        symbols = [ "" "" "⭘" " " " " ];
        track_style = { bg = mantle; };
        elapsed_style = { fg = mauve; bg = mantle; };
        thumb_style = { fg = mauve; bg = mantle; };
      };

      scrollbar = {
        symbols = [ "│" "█" "▲" "▼" ];
        track_style = { };
        ends_style = { };
        thumb_style = { fg = lavender; };
      };

      browser_column_widths = [ 20 38 42 ];
      text_color = fgText;
      background_color = base;
      header_background_color = mantle;
      modal_background_color = null;
      modal_backdrop = false;

      tab_bar = {
        active_style = { fg = "black"; bg = mauve; modifiers = "Bold"; };
        inactive_style = { };
      };
      borders_style = { fg = overlay0; };
      highlighted_item_style = { fg = mauve; bg = null; modifiers = "Bold"; };
      current_item_style = { fg = "black"; bg = lavender; modifiers = "Bold"; };
      highlight_border_style = { fg = lavender; };

      song_table_format = [
        {
          prop = {
            kind = prop (variant "Artist");
            style = { fg = lavender; };
            default = { kind = text "Unknown"; };
          };
          width = "50%";
          alignment = variant "Right";
        }
        {
          prop = {
            kind = text "-";
            style = { fg = lavender; };
            default = { kind = text "Unknown"; };
          };
          width = "1";
          alignment = variant "Center";
        }
        {
          prop = {
            kind = prop (variant "Title");
            style = { fg = sapphire; };
            default = { kind = text "Unknown"; };
          };
          width = "50%";
        }
      ];

      lyrics = {
        timestamp = false;
        alignment = variant "Center";
      };

      header.rows = [
        {
          left = [
            { kind = text "["; style = bold lavender; }
            { kind = prop (enum "Status" [ (variant "State") ]); style = bold lavender; }
            { kind = text "]"; style = bold lavender; }
          ];
          center = [
            {
              kind = prop (enum "Song" [ (variant "Artist") ]);
              style = bold yellow;
              default = { kind = text "Unknown"; style = bold yellow; };
            }
            { kind = text " - "; }
            {
              kind = prop (enum "Song" [ (variant "Title") ]);
              style = bold sapphire;
              default = { kind = text "No Song"; style = bold sapphire; };
            }
          ];
          right = [
            { kind = text "Vol: "; style = bold lavender; }
            { kind = prop (enum "Status" [ (variant "Volume") ]); style = bold lavender; }
            { kind = text "% "; style = bold lavender; }
          ];
        }
      ];
    };
  };
}
```

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [ ] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
