### PR TITLE
fix: preserve sort order when adding a directory to the queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ keybinds
 - rmpc will now handle focused events and attempt to resize the TUI if needed
 - Loading a playlist when with missing songs will now load the existing songs instead of nothing
 - The borders of browser panes are nolonger affected by the scrollbar track being set
+- Adding a directory to the queue now orders its songs by `directories_sort` instead of relying on MPD's default order
 
 ## [0.11.0] - 2026-02-01
 

--- a/rmpc/src/shared/mpd_client_ext.rs
+++ b/rmpc/src/shared/mpd_client_ext.rs
@@ -109,6 +109,7 @@ pub enum MpdDelete {
 #[derive(Debug, Clone)]
 pub enum Enqueue {
     File { path: String },
+    Directory { path: String },
     Playlist { name: String },
     Find { filter: Vec<(Tag, FilterKind, String)> },
 }
@@ -162,7 +163,9 @@ impl<T: MpdClient + MpdCommand + ProtoClient> MpdClientExt for T {
             self.send_start_cmd_list()?;
             for item in &items[i..] {
                 match item {
-                    Enqueue::File { path } => self.send_add(path, position),
+                    Enqueue::File { path } | Enqueue::Directory { path } => {
+                        self.send_add(path, position)
+                    }
                     Enqueue::Playlist { name } => self.send_load_playlist(name, position),
                     Enqueue::Find { filter } => self.send_find_add(
                         &filter
@@ -451,7 +454,7 @@ impl<T: MpdClient + MpdCommand + ProtoClient> MpdClientExt for T {
         let mut uris = Vec::new();
         for item in items {
             match item {
-                Enqueue::File { path } => uris.push(path),
+                Enqueue::File { path } | Enqueue::Directory { path } => uris.push(path),
                 Enqueue::Playlist { name } => {
                     let playlist = self.list_playlist(&name)?.0;
                     uris.extend(playlist);
@@ -482,7 +485,7 @@ impl<T: MpdClient + MpdCommand + ProtoClient> MpdClientExt for T {
         let mut uris = Vec::new();
         for item in items {
             match item {
-                Enqueue::File { path } => uris.push(path),
+                Enqueue::File { path } | Enqueue::Directory { path } => uris.push(path),
                 Enqueue::Playlist { name } => {
                     let playlist = self.list_playlist(&name)?.0;
                     uris.extend(playlist);

--- a/rmpc/src/ui/browser.rs
+++ b/rmpc/src/ui/browser.rs
@@ -163,6 +163,11 @@ where
 
         (items, idx)
     }
+    // Panes that enqueue directories override this to expand them into their
+    // songs, ordered the way the pane displays them. Others pass through.
+    fn resolve_enqueue(&self, items: Vec<Enqueue>, _ctx: &Ctx) -> Result<Vec<Enqueue>> {
+        Ok(items)
+    }
     fn show_info(&self, item: &T, ctx: &Ctx) -> Result<()> {
         Ok(())
     }
@@ -599,6 +604,7 @@ where
             CommonAction::PaneLeft => {}
             CommonAction::AddOptions { kind: AddKind::Action(options) } => {
                 let (enqueue, hovered_idx) = self.enqueue_items(options.all);
+                let enqueue = self.resolve_enqueue(enqueue, ctx)?;
                 if !enqueue.is_empty() {
                     let queue_len = ctx.queue.len();
                     let current_song_idx = ctx.current_song_index();

--- a/rmpc/src/ui/browser.rs
+++ b/rmpc/src/ui/browser.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use enum_map::EnumMap;
@@ -332,6 +332,7 @@ where
                     self.stack_mut().current_mut().select_idx(idx_to_select, ctx.config.scrolloff);
                     if let Some(item) = self.stack().current().selected() {
                         let (items, _) = self.enqueue(std::iter::once(item));
+                        let items = self.resolve_enqueue(items, ctx)?;
                         if !items.is_empty() {
                             ctx.command(move |_, client| {
                                 client.enqueue_multiple(items, None, None, false)?;
@@ -620,13 +621,21 @@ where
                 }
             }
             CommonAction::AddOptions { kind: AddKind::Modal(items) } => {
-                let opts = items
-                    .iter()
-                    .map(|(label, opts)| {
-                        let enqueue = self.enqueue_items(opts.all);
-                        (label.to_owned(), *opts, enqueue)
-                    })
-                    .collect_vec();
+                // Options that share `all` resolve to the same items, so resolve
+                // once per value instead of once per option.
+                let mut resolved: HashMap<bool, (Vec<Enqueue>, Option<usize>)> = HashMap::new();
+                let mut opts = Vec::with_capacity(items.len());
+                for (label, options) in items {
+                    let enqueue = if let Some(enqueue) = resolved.get(&options.all) {
+                        enqueue.clone()
+                    } else {
+                        let (enqueue, hovered_idx) = self.enqueue_items(options.all);
+                        let enqueue = (self.resolve_enqueue(enqueue, ctx)?, hovered_idx);
+                        resolved.insert(options.all, enqueue.clone());
+                        enqueue
+                    };
+                    opts.push((label, options, enqueue));
+                }
 
                 modal!(ctx, create_add_modal(opts, ctx));
             }
@@ -803,10 +812,11 @@ where
             .items(false)
             .map(|(_, item)| self.list_songs_in_item(item.to_owned()))
             .collect_vec();
+        let (current_items, _) = self.enqueue_items(false);
+        let current_items = self.resolve_enqueue(current_items, ctx)?;
 
         let modal = MenuModal::new(ctx)
             .list_section(ctx, |mut section| {
-                let (current_items, _) = self.enqueue_items(false);
                 if !current_items.is_empty() {
                     let cloned_items = current_items.clone();
                     section.add_item("Add to queue", move |ctx| {

--- a/rmpc/src/ui/panes/directories.rs
+++ b/rmpc/src/ui/panes/directories.rs
@@ -239,7 +239,7 @@ impl BrowserPane<DirOrSong> for DirectoriesPane {
                 }
                 DirOrSong::Dir { full_path, playlist: false, .. } => {
                     dir_or_playlist_found = true;
-                    Enqueue::File { path: full_path.to_owned() }
+                    Enqueue::Directory { path: full_path.to_owned() }
                 }
                 DirOrSong::Song(song) => Enqueue::File { path: song.file.clone() },
             })
@@ -265,5 +265,34 @@ impl BrowserPane<DirOrSong> for DirectoriesPane {
         };
 
         (items, hovered_idx)
+    }
+
+    fn resolve_enqueue(&self, items: Vec<Enqueue>, ctx: &Ctx) -> Result<Vec<Enqueue>> {
+        if !items.iter().any(|item| matches!(item, Enqueue::Directory { .. })) {
+            return Ok(items);
+        }
+
+        let sort = ctx.config.directories_sort.clone();
+        ctx.query_sync(move |client| {
+            let mut resolved = Vec::with_capacity(items.len());
+            for item in items {
+                let Enqueue::Directory { path } = item else {
+                    resolved.push(item);
+                    continue;
+                };
+                // Fetch every song under the directory and add them in the same
+                // order the pane shows them, instead of letting MPD pick.
+                let songs = client
+                    .find(&[Filter::new_with_kind(Tag::File, &path, FilterKind::StartsWith)])?
+                    .into_iter()
+                    .map(DirOrSong::Song)
+                    .sorted_by(|a, b| a.with_custom_sort(&sort).cmp(&b.with_custom_sort(&sort)));
+                resolved.extend(songs.filter_map(|song| match song {
+                    DirOrSong::Song(song) => Some(Enqueue::File { path: song.file }),
+                    DirOrSong::Dir { .. } => None,
+                }));
+            }
+            Ok(resolved)
+        })
     }
 }

--- a/rmpc/src/ui/panes/directories.rs
+++ b/rmpc/src/ui/panes/directories.rs
@@ -12,7 +12,7 @@ use rmpc_mpd::{
 use super::Pane;
 use crate::{
     MpdQueryResult,
-    config::tabs::PaneType,
+    config::{sort_mode::SortOptions, tabs::PaneType},
     ctx::Ctx,
     shared::{keys::ActionEvent, mouse_event::MouseEvent, mpd_client_ext::Enqueue},
     ui::{
@@ -273,26 +273,183 @@ impl BrowserPane<DirOrSong> for DirectoriesPane {
         }
 
         let sort = ctx.config.directories_sort.clone();
+        let playlist_mode = ctx.config.show_playlists_in_browser;
         ctx.query_sync(move |client| {
+            let mut list_dir = |path: &str| -> Result<Vec<DirOrSong>> {
+                Ok(client
+                    .lsinfo(Some(path))?
+                    .0
+                    .into_iter()
+                    .filter_map(|entry| entry.into_dir_or_song(playlist_mode))
+                    .collect())
+            };
+
             let mut resolved = Vec::with_capacity(items.len());
             for item in items {
-                let Enqueue::Directory { path } = item else {
-                    resolved.push(item);
-                    continue;
-                };
-                // Fetch every song under the directory and add them in the same
-                // order the pane shows them, instead of letting MPD pick.
-                let songs = client
-                    .find(&[Filter::new_with_kind(Tag::File, &path, FilterKind::StartsWith)])?
-                    .into_iter()
-                    .map(DirOrSong::Song)
-                    .sorted_by(|a, b| a.with_custom_sort(&sort).cmp(&b.with_custom_sort(&sort)));
-                resolved.extend(songs.filter_map(|song| match song {
-                    DirOrSong::Song(song) => Some(Enqueue::File { path: song.file }),
-                    DirOrSong::Dir { .. } => None,
-                }));
+                match item {
+                    Enqueue::Directory { path } => {
+                        resolve_directory(&path, &sort, &mut list_dir, &mut resolved)?;
+                    }
+                    other => resolved.push(other),
+                }
             }
             Ok(resolved)
         })
+    }
+}
+
+// Expand a directory the way the pane shows it: sort each level on its own and
+// descend depth first, so songs stay grouped by their directory instead of
+// being flattened into a single sort. Songs, subdirectories and playlists at a
+// level are all handled.
+fn resolve_directory<F>(
+    path: &str,
+    sort: &SortOptions,
+    list_dir: &mut F,
+    out: &mut Vec<Enqueue>,
+) -> Result<()>
+where
+    F: FnMut(&str) -> Result<Vec<DirOrSong>>,
+{
+    let mut entries = list_dir(path)?;
+    entries.sort_by(|a, b| a.with_custom_sort(sort).cmp(&b.with_custom_sort(sort)));
+    for entry in entries {
+        match entry {
+            DirOrSong::Song(song) => out.push(Enqueue::File { path: song.file }),
+            DirOrSong::Dir { full_path, playlist: true, .. } => {
+                out.push(Enqueue::Playlist { name: full_path });
+            }
+            DirOrSong::Dir { full_path, playlist: false, .. } => {
+                resolve_directory(&full_path, sort, list_dir, out)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::collections::HashMap;
+
+    use rmpc_mpd::commands::{Song, metadata_tag::MetadataTag};
+
+    use super::resolve_directory;
+    use crate::{
+        config::{
+            sort_mode::{SortMode, SortOptions},
+            theme::properties::SongProperty,
+        },
+        shared::mpd_client_ext::Enqueue,
+        ui::dir_or_song::DirOrSong,
+    };
+
+    fn song(file: &str, track: &str) -> DirOrSong {
+        DirOrSong::Song(Song {
+            id: 0,
+            file: file.to_string(),
+            duration: None,
+            metadata: HashMap::from([(
+                "track".to_string(),
+                MetadataTag::Single(track.to_string()),
+            )]),
+            last_modified: chrono::Utc::now(),
+            added: None,
+        })
+    }
+
+    fn dir(full_path: &str) -> DirOrSong {
+        DirOrSong::Dir {
+            name: full_path.rsplit('/').next().unwrap_or(full_path).to_string(),
+            display_name: None,
+            full_path: full_path.to_string(),
+            last_modified: chrono::Utc::now(),
+            playlist: false,
+            metadata: HashMap::new(),
+        }
+    }
+
+    fn playlist(full_path: &str) -> DirOrSong {
+        DirOrSong::Dir {
+            name: full_path.to_string(),
+            display_name: None,
+            full_path: full_path.to_string(),
+            last_modified: chrono::Utc::now(),
+            playlist: true,
+            metadata: HashMap::new(),
+        }
+    }
+
+    fn sort_by_track() -> SortOptions {
+        SortOptions {
+            mode: SortMode::Format(vec![SongProperty::Track]),
+            group_by_type: true,
+            reverse: false,
+            ignore_leading_the: false,
+            fold_case: true,
+        }
+    }
+
+    fn resolve(root: &str, tree: &HashMap<&str, Vec<DirOrSong>>) -> Vec<String> {
+        let mut list_dir = |path: &str| -> anyhow::Result<Vec<DirOrSong>> {
+            Ok(tree.get(path).cloned().unwrap_or_default())
+        };
+        let mut out = Vec::new();
+        resolve_directory(root, &sort_by_track(), &mut list_dir, &mut out).unwrap();
+        out.into_iter()
+            .map(|item| match item {
+                Enqueue::File { path } => path,
+                Enqueue::Playlist { name } => name,
+                other => panic!("unexpected enqueue entry: {other:?}"),
+            })
+            .collect()
+    }
+
+    // Artist/ holds Album1 and Album2, each with tracks out of order. Adding
+    // Artist keeps every album's tracks together and sorted within the album
+    // instead of interleaving track 1 of both albums, then track 2, etc.
+    #[test]
+    fn groups_songs_by_directory() {
+        let tree = HashMap::from([
+            ("Artist", vec![dir("Artist/Album2"), dir("Artist/Album1")]),
+            ("Artist/Album1", vec![
+                song("Artist/Album1/2.flac", "2"),
+                song("Artist/Album1/1.flac", "1"),
+            ]),
+            ("Artist/Album2", vec![
+                song("Artist/Album2/2.flac", "2"),
+                song("Artist/Album2/1.flac", "1"),
+            ]),
+        ]);
+
+        assert_eq!(resolve("Artist", &tree), vec![
+            "Artist/Album1/1.flac",
+            "Artist/Album1/2.flac",
+            "Artist/Album2/1.flac",
+            "Artist/Album2/2.flac",
+        ]);
+    }
+
+    // A level mixing a subdirectory, loose songs and a playlist keeps the pane's
+    // order: with group_by_type the directory expands first, then the songs,
+    // then the playlist.
+    #[test]
+    fn handles_mixed_directory() {
+        let tree = HashMap::from([
+            ("Mixed", vec![
+                song("Mixed/2.flac", "2"),
+                playlist("Mixed/list"),
+                dir("Mixed/Sub"),
+                song("Mixed/1.flac", "1"),
+            ]),
+            ("Mixed/Sub", vec![song("Mixed/Sub/a.flac", "1")]),
+        ]);
+
+        assert_eq!(resolve("Mixed", &tree), vec![
+            "Mixed/Sub/a.flac",
+            "Mixed/1.flac",
+            "Mixed/2.flac",
+            "Mixed/list",
+        ]);
     }
 }


### PR DESCRIPTION
## Description

Adding a directory to the queue (`AddReplace`, `AddAllReplace`, `Add`, `Insert`, ...) sent a single `add <dir>` command, so MPD expanded the directory in its own database order and ignored `directories_sort`. Adding the same songs from *inside* the directory ordered them correctly, so the two paths disagreed.

The directories pane now resolves a directory to its songs and enqueues them one by one, ordered the same way the pane displays them.

### How it works

- `Enqueue` gets a `Directory` variant. The directories pane emits it for a directory instead of `File`.
- `BrowserPane::resolve_enqueue` (a no-op by default) is overridden by the directories pane. It fetches the songs under the directory (recursively, like MPD did) and orders them with the same `directories_sort` comparator the pane uses to display them, then returns plain `File` entries. It only runs a query when a directory is actually present, so ordinary song adds are untouched.
- If a `Directory` ever reaches the client unresolved it falls back to the old `add <dir>` behavior, so nothing regresses.

### Scope

This covers the add keybinds, which is what the issue reports. The context menu, the add modal, and middle-click still send `add <dir>` (they hit the fallback, so no change for them). Happy to route those through the same resolution if you'd like it everywhere.

### Related issues

Fixes #749

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [ ] Documentation has been updated (if needed)
- [x] Changelog has been updated
