### PR TITLE
fix: kitty images with single-chunk payloads never displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Kitty image backend never displaying images whose encoded data fits into a single 4096 byte
+  chunk, because the first chunk always claimed more data would follow (`m=1`)
 - Benign error log when reading a sticker that does not exist
 - Theme hot reload not working when it was set using the `theme.ron` form
 - Issue with Iterm2 image protocol not rendering images sometimes

--- a/rmpc/src/ui/image/kitty.rs
+++ b/rmpc/src/ui/image/kitty.rs
@@ -226,9 +226,10 @@ fn transfer_image_data(
     let mut iter = content.chars().peekable();
 
     let first: String = iter.by_ref().take(4096).collect();
+    let m = i32::from(iter.peek().is_some());
     tmux_write!(
         w,
-        "\x1b_Gi=1,f=32,U=1,t=d,a=T,m=1,q=2,o=z,s={img_width},v={img_height};{first}\x1b\\"
+        "\x1b_Gi=1,f=32,U=1,t=d,a=T,m={m},q=2,o=z,s={img_width},v={img_height};{first}\x1b\\"
     )?;
 
     while iter.peek().is_some() {


### PR DESCRIPTION
Found this behaviour while working on an new Progressbar with FFmpeg showwavespic. Which would result in the whole image not rendering.

`transfer_image_data` always sends `m=1` in the first graphics protocol chunk. `m=1` tells the terminal that more chunks will follow, but when the base64 encoded image data fits into a single 4096 byte chunk, the `while` loop below never runs and no terminating `m=0` chunk is ever sent. The terminal then waits for continuation data indefinitely and the image is never displayed.

Album art images are usually large enough to span multiple chunks, which is why this rarely shows up in practice. It reproduces reliably with any sufficiently small image (roughly under 3 KB of compressed data), e.g. small embedded cover art or a tiny `default_album_art_path` image: the transfer is sent, kitty/ghostty accept it, but nothing ever renders.

Fix: derive `m` for the first chunk from whether more data actually remains, same as the continuation loop already does.
