### PR TITLE
fix: rmpcd last fm plugin - convert song duration to seconds for now playing

### DIFF
--- a/rmpcd/src/lua/builtin/lastfm.lua
+++ b/rmpcd/src/lua/builtin/lastfm.lua
@@ -311,7 +311,7 @@ end
 
 M.song_change = function(self, old, new)
     if new ~= nil and (self.update_now_playing or false) then
-        lastfm_update_now_playing(self.api_key, self.shared_secret, self.session_key, new, new.duration)
+        lastfm_update_now_playing(self.api_key, self.shared_secret, self.session_key, new, new.duration / 1000)
     end
 
     local current_time = os.time()


### PR DESCRIPTION
The song duration is in milliseconds but lastfm's now playing endpoint expects seconds. It sets your now playing status for the duration given in the request, so it was being set for 1000x longer than it should've been

I made sure it doesn't need to be an integer, for example sending the duration "30.123" sets it for 30 seconds