### PR TITLE
fix: addyt failing when filename already exists with different ext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ keybinds
 - Loading a playlist when with missing songs will now load the existing songs instead of nothing
 - The borders of browser panes are nolonger affected by the scrollbar track being set
 - Adding a directory to the queue now orders its songs by `directories_sort` instead of relying on MPD's default order
+- `addyt` sometimes failing when files with identical file name already exists it the dir
 
 ## [0.11.0] - 2026-02-01
 

--- a/rmpc/src/shared/ytdlp/downloader.rs
+++ b/rmpc/src/shared/ytdlp/downloader.rs
@@ -100,6 +100,7 @@ impl YtDlp {
         cache.push(format!("{}.%(ext)s", id.filename));
 
         let mut command = Command::new("yt-dlp");
+        command.arg("--print").arg("after_move:RMPC_FILEPATH::%(filepath)s");
         command.arg("-x");
         command.arg("--embed-thumbnail");
         command.arg("--embed-metadata");
@@ -137,12 +138,13 @@ impl YtDlp {
             return Err(YtDlpDownloadError::YtDlpError { stdout, stderr, code: exit_code });
         }
 
-        // yt-dlp for some reason does not respect output file template when
-        // doing post processing with ffmpeg. This results in the file
-        // having different extensions than the one specified so we work
-        // around it by trying to find the file in the cache directory as that
-        // should still be reliable.
-        match id.get_cached(&self.cache_dir) {
+        let printed_path = stdout
+            .lines()
+            .find_map(|line| line.strip_prefix("RMPC_FILEPATH::"))
+            .map(|path| PathBuf::from(path.trim()));
+
+        match printed_path.filter(|path| path.is_file()).or_else(|| id.get_cached(&self.cache_dir))
+        {
             Some(file_path) => Ok(YtDlpDownloadResult {
                 file_path,
                 stderr,

--- a/rmpc/src/shared/ytdlp/ytdlp_item.rs
+++ b/rmpc/src/shared/ytdlp/ytdlp_item.rs
@@ -37,6 +37,8 @@ pub enum YtDlpHost {
     NicoVideo,
 }
 
+const EXCLUDED_EXTS: &[&str] = &["lrc", "jpg", "jpeg", "png", "webp", "part", "ytdl"];
+
 impl YtDlpItem {
     pub fn to_url(&self) -> String {
         self.kind.watch_url(&self.id)
@@ -46,12 +48,19 @@ impl YtDlpItem {
         root.join(self.kind.cache_dir_name())
     }
 
+    fn is_cached_candidate(&self, path: &Path) -> bool {
+        path.file_stem().is_some_and(|stem| stem == OsStr::new(&self.filename))
+            && path.extension().is_none_or(|ext| {
+                !EXCLUDED_EXTS.contains(&ext.to_string_lossy().to_lowercase().as_str())
+            })
+    }
+
     pub fn get_cached(&self, cache_dir: &Path) -> Option<PathBuf> {
         WalkDir::new(self.cache_subdir(cache_dir))
             .into_iter()
             .filter_map(Result::ok)
             .filter(|e| e.file_type().is_file())
-            .find(|e| e.path().file_stem().is_some_and(|stem| stem == OsStr::new(&self.filename)))
+            .find(|e| self.is_cached_candidate(e.path()))
             .map(|entry| entry.into_path())
     }
 
@@ -60,7 +69,7 @@ impl YtDlpItem {
             .into_iter()
             .filter_map(Result::ok)
             .filter(|e| e.file_type().is_file())
-            .filter(|e| e.path().file_stem().is_some_and(|stem| stem == OsStr::new(&self.filename)))
+            .filter(|e| self.is_cached_candidate(e.path()))
             .map(|entry| entry.into_path());
 
         for file in files {


### PR DESCRIPTION
## Description

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
