### PR TITLE
Add a `Hash` property transform to color content from a palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added `current` option to `Save()` keybind to save the currently playing song
+- `Hash` property transform that colors its content by hashing it against a configured palette, so
+  the same value (artist, year, album, ...) always gets the same color.
 - Added a new vertical volume slider pane.
 - **Breaking** `ExternalCommand` can now have arguments supplied at runtime. This will break your
   existing keybinds if they contained either `{` or `}`. You will now need to escape these by

--- a/rmpc/src/config/theme/properties.rs
+++ b/rmpc/src/config/theme/properties.rs
@@ -3,14 +3,39 @@ use std::collections::BTreeMap;
 use anyhow::{Result, bail};
 use bon::Builder;
 use itertools::Itertools;
-use ratatui::style::Style;
+use ratatui::style::{Color, Style};
 use rmpc_mpd::filter::Tag;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use strum::Display;
 
-use super::style::ToConfigOr;
+use super::style::{StringColor, ToConfigOr};
 use crate::config::{defaults, theme::StyleFile};
+
+/// Picks a color from `colors` deterministically based on the content string.
+///
+/// The same content always maps to the same color, while different content is
+/// spread across the palette. Returns `None` when `colors` is empty so callers
+/// can leave the content unstyled.
+pub(crate) fn hashed_color(content: &str, colors: &[Color]) -> Option<Color> {
+    if colors.is_empty() {
+        return None;
+    }
+
+    // FNV-1a, a small deterministic hash so the mapping is stable across runs.
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in content.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+
+    let idx = (hash % colors.len() as u64) as usize;
+    Some(colors[idx])
+}
+
+pub(super) fn parse_colors(colors: Vec<String>) -> Result<Vec<Color>> {
+    colors.into_iter().filter_map(|color| StringColor(Some(color)).to_color().transpose()).collect()
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum SongPropertyFile {
@@ -294,12 +319,17 @@ pub enum TransformFile<T: Clone> {
         content: Box<PropertyFile<T>>,
         replacements: Vec<ReplacementFile<T>>,
     },
+    Hash {
+        content: Box<PropertyFile<T>>,
+        colors: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Transform<T> {
     Truncate { content: Box<Property<T>>, length: usize, from_start: bool },
     Replace { content: Box<Property<T>>, replacements: BTreeMap<String, Property<T>> },
+    Hash { content: Box<Property<T>>, colors: Vec<Color> },
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -551,6 +581,12 @@ impl TryFrom<PropertyFile<PropertyKindFile>> for Property<PropertyKind> {
                         .map(|r| -> Result<_> { Ok((r.r#match, r.replace.try_into()?)) })
                         .try_collect()?,
                 }),
+                PropertyKindFileOrText::Transform(TransformFile::Hash { content, colors }) => {
+                    PropertyKindOrText::Transform(Transform::Hash {
+                        content: Box::new((*content).try_into()?),
+                        colors: parse_colors(colors)?,
+                    })
+                }
                 PropertyKindFileOrText::Sticker(value) => PropertyKindOrText::Sticker(value),
                 PropertyKindFileOrText::Property(prop) => {
                     PropertyKindOrText::Property(match prop {
@@ -676,5 +712,49 @@ impl TryFrom<SongProperty> for Tag {
             SongProperty::LastModified() => bail!("Cannot convert LastModified to Tag"),
             SongProperty::Other(val) => Ok(Tag::Custom(val)),
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::collections::HashSet;
+
+    use ratatui::style::Color;
+
+    use super::hashed_color;
+
+    #[test]
+    fn empty_palette_yields_none() {
+        assert_eq!(hashed_color("anything", &[]), None);
+    }
+
+    #[test]
+    fn is_deterministic() {
+        let colors = [Color::Red, Color::Green, Color::Blue];
+        assert_eq!(hashed_color("2024", &colors), hashed_color("2024", &colors));
+    }
+
+    #[test]
+    fn always_within_palette() {
+        let colors = [Color::Red, Color::Green, Color::Blue];
+        for content in ["", "a", "2024", "The Beatles", "α β γ"] {
+            let picked = hashed_color(content, &colors).unwrap();
+            assert!(colors.contains(&picked), "{content:?} picked {picked:?} outside palette");
+        }
+    }
+
+    #[test]
+    fn single_color_palette_is_always_selected() {
+        let colors = [Color::Magenta];
+        assert_eq!(hashed_color("whatever", &colors), Some(Color::Magenta));
+    }
+
+    #[test]
+    fn spreads_across_the_palette() {
+        let colors = [Color::Red, Color::Green, Color::Blue, Color::Yellow];
+        let used: HashSet<_> =
+            (0..64).map(|i| hashed_color(&format!("item-{i}"), &colors).unwrap()).collect();
+        assert!(used.len() > 1, "hash should distribute across multiple colors, got {used:?}");
     }
 }

--- a/rmpc/src/config/theme/queue_table.rs
+++ b/rmpc/src/config/theme/queue_table.rs
@@ -19,6 +19,7 @@ use super::{
         SongPropertyFile,
         Transform,
         TransformFile,
+        parse_colors,
     },
     style::ToConfigOr,
 };
@@ -287,6 +288,12 @@ impl PropertyFile<SongPropertyFile> {
                         .map(|r| -> Result<_> { Ok((r.r#match, r.replace.convert()?)) })
                         .try_collect()?,
                 }),
+                PropertyKindFileOrText::Transform(TransformFile::Hash { content, colors }) => {
+                    PropertyKindOrText::Transform(Transform::Hash {
+                        content: Box::new((*content).convert()?),
+                        colors: parse_colors(colors)?,
+                    })
+                }
                 PropertyKindFileOrText::Sticker(value) => PropertyKindOrText::Sticker(value),
                 PropertyKindFileOrText::Property(prop) => PropertyKindOrText::Property(prop.into()),
                 PropertyKindFileOrText::Group(group) => {

--- a/rmpc/src/ui/panes/mod.rs
+++ b/rmpc/src/ui/panes/mod.rs
@@ -53,6 +53,7 @@ use crate::{
                 StatusProperty,
                 Transform,
                 WidgetProperty,
+                hashed_color,
             },
         },
     },
@@ -525,6 +526,13 @@ impl Property<SongProperty> {
                             .and_then(|d| d.as_string(song, tag_separator, strategy, ctx))
                     })
             }
+            PropertyKindOrText::Transform(Transform::Hash { content, .. }) => {
+                content.as_string(song, tag_separator, strategy, ctx).or_else(|| {
+                    self.default
+                        .as_ref()
+                        .and_then(|d| d.as_string(song, tag_separator, strategy, ctx))
+                })
+            }
         }
     }
 }
@@ -827,6 +835,31 @@ impl Property<PropertyKind> {
                             remaining_len = remaining_len.saturating_sub(remaining);
                         }
                         Some(Either::Right(buf.into()))
+                    }
+                    None => self.default_as_span(song, ctx, tag_separator, strategy),
+                }
+            }
+            PropertyKindOrText::Transform(Transform::Hash { content, colors }) => {
+                match content.as_span(song, ctx, tag_separator, strategy) {
+                    Some(Either::Left(mut span)) => {
+                        if let Some(color) = hashed_color(span.content.as_ref(), colors) {
+                            span.style = span.style.fg(color);
+                        }
+                        Some(Either::Left(span))
+                    }
+                    Some(Either::Right(mut spans)) => {
+                        let mut content = String::new();
+                        for span in &spans {
+                            content.push_str(span.content.as_ref());
+                        }
+
+                        if let Some(color) = hashed_color(&content, colors) {
+                            for span in &mut spans {
+                                span.style = span.style.fg(color);
+                            }
+                        }
+
+                        Some(Either::Right(spans))
                     }
                     None => self.default_as_span(song, ctx, tag_separator, strategy),
                 }
@@ -1199,6 +1232,73 @@ mod format_tests {
                 result.map(|line| line.spans.iter().map(|s| s.content.clone()).collect::<String>()),
                 Some(expected)
             );
+        }
+    }
+
+    mod hash {
+        use ratatui::style::Color;
+
+        use super::*;
+        use crate::config::theme::properties::Transform;
+
+        fn hash_of(text: &str, colors: Vec<Color>) -> Property<PropertyKind> {
+            Property::<PropertyKind> {
+                kind: PropertyKindOrText::Transform(Transform::Hash {
+                    content: Box::new(Property {
+                        kind: PropertyKindOrText::Text(text.into()),
+                        style: None,
+                        default: None,
+                    }),
+                    colors,
+                }),
+                style: None,
+                default: None,
+            }
+        }
+
+        fn single_span<'a>(result: Option<Either<Span<'a>, Vec<Span<'a>>>>) -> Span<'a> {
+            match result {
+                Some(Either::Left(span)) => span,
+                other => panic!("expected a single span, got {other:?}"),
+            }
+        }
+
+        #[rstest]
+        fn keeps_the_content(ctx: Ctx) {
+            let format = hash_of("hello", vec![Color::Red, Color::Green, Color::Blue]);
+            let span = single_span(format.as_span(None, &ctx, "", TagResolutionStrategy::All));
+
+            assert_eq!(span.content.as_ref(), "hello");
+        }
+
+        #[rstest]
+        fn colors_deterministically_from_the_palette(ctx: Ctx) {
+            let colors = vec![Color::Red, Color::Green, Color::Blue];
+            let fg_of = |text: &str| {
+                let format = hash_of(text, colors.clone());
+                single_span(format.as_span(None, &ctx, "", TagResolutionStrategy::All)).style.fg
+            };
+
+            let chosen = fg_of("2024").expect("a color should be applied");
+            assert!(colors.contains(&chosen), "{chosen:?} is not part of the palette");
+            assert_eq!(fg_of("2024"), Some(chosen), "same content must map to the same color");
+        }
+
+        #[rstest]
+        fn empty_palette_leaves_the_style_untouched(ctx: Ctx) {
+            // The bare text span the transform wraps, with no color applied.
+            let plain = Property::<PropertyKind> {
+                kind: PropertyKindOrText::Text("hello".into()),
+                style: None,
+                default: None,
+            };
+            let expected =
+                single_span(plain.as_span(None, &ctx, "", TagResolutionStrategy::All)).style;
+
+            let format = hash_of("hello", Vec::new());
+            let styled = single_span(format.as_span(None, &ctx, "", TagResolutionStrategy::All));
+
+            assert_eq!(styled.style, expected);
         }
     }
 

--- a/rmpc/src/ui/song_ext.rs
+++ b/rmpc/src/ui/song_ext.rs
@@ -15,7 +15,7 @@ use crate::{
         theme::{
             SymbolsConfig,
             TagResolutionStrategy,
-            properties::{Property, PropertyKindOrText, SongProperty, Transform},
+            properties::{Property, PropertyKindOrText, SongProperty, Transform, hashed_color},
         },
     },
     ctx::Ctx,
@@ -397,6 +397,9 @@ impl SongExt for Song {
                 PropertyKindOrText::Transform(Transform::Replace { .. }) => format
                     .as_string(Some(self), "", TagResolutionStrategy::All, ctx)
                     .map(|v| v.to_lowercase().contains(&filter.to_lowercase())),
+                PropertyKindOrText::Transform(Transform::Hash { .. }) => format
+                    .as_string(Some(self), "", TagResolutionStrategy::All, ctx)
+                    .map(|v| v.to_lowercase().contains(&filter.to_lowercase())),
             };
             if match_found.is_some_and(|v| v) {
                 return true;
@@ -518,6 +521,28 @@ impl SongExt for Song {
                             .and_then(|format| self.as_line(format, tag_separator, strategy, ctx))
                     })
             }
+            PropertyKindOrText::Transform(Transform::Hash { content, colors }) => self
+                .as_line(content, tag_separator, strategy, ctx)
+                .map(|mut line| {
+                    let mut buf = String::new();
+                    for span in &line.spans {
+                        buf.push_str(span.content.as_ref());
+                    }
+
+                    if let Some(color) = hashed_color(&buf, colors) {
+                        for span in &mut line.spans {
+                            span.style = span.style.fg(color);
+                        }
+                    }
+
+                    line
+                })
+                .or_else(|| {
+                    format
+                        .default
+                        .as_ref()
+                        .and_then(|format| self.as_line(format, tag_separator, strategy, ctx))
+                }),
         }
     }
 


### PR DESCRIPTION
Closes #839.

### What

Adds a new `Hash` property transform. It renders its `content` and applies a foreground color chosen from a configured `colors` palette based on a stable hash of the rendered text. The same value always maps to the same color while different values spread across the palette, which makes it easy to tell artists, years or albums apart at a glance in a list view.

```ron
Transform(Hash(
    content: Property(Artist),
    colors: ["red", "green", "blue", "magenta", "cyan"],
))
```

### How

It mirrors the existing `Truncate`/`Replace` transforms:

- a new `Hash` variant on both `TransformFile` (config) and `Transform` (runtime); the palette strings are parsed into `ratatui` colors once, during config conversion, in both `properties.rs` and `queue_table.rs`;
- render hooks in the string / span / line paths (`panes/mod.rs`, `song_ext.rs`). The string path returns the content unchanged; the span and line paths override the foreground with the hashed color and leave the rest of the style intact.

The color is selected with a small FNV-1a hash so the mapping is stable across runs and platforms. An empty palette is a no-op (the content stays unstyled), so it degrades gracefully.

### Tests

- unit tests for the selection helper: determinism, palette membership, empty palette, single-color palette, and spread across the palette;
- `as_span` tests for content pass-through, deterministic coloring from the palette, and the empty-palette no-op.

`cargo test`, `cargo fmt` (nightly) and `cargo clippy` are all clean.