### PR TITLE
feat: add `current` option to Save action to save currently playing song

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added `current` option to `Save()` keybind to save the currently playing song
 - Added a new vertical volume slider pane.
 - **Breaking** `ExternalCommand` can now have arguments supplied at runtime. This will break your
   existing keybinds if they contained either `{` or `}`. You will now need to escape these by

--- a/assets/example_config.ron
+++ b/assets/example_config.ron
@@ -119,6 +119,7 @@
             "oi":         ShowInfo,
             "<C-x>":      ContextMenu(),
             "<C-s>s":     Save(kind: Modal(all: false, duplicates_strategy: Ask)),
+            "<C-s>c": Save(kind: Modal(all: false, duplicates_strategy: Ask), current: true),
             "<C-s>a":     Save(kind: Modal(all: true, duplicates_strategy: Ask)),
             "r":          Rate(),
             "Y":          CopyToClipboard(kind: Modal([

--- a/assets/example_config.ron
+++ b/assets/example_config.ron
@@ -119,7 +119,7 @@
             "oi":         ShowInfo,
             "<C-x>":      ContextMenu(),
             "<C-s>s":     Save(kind: Modal(all: false, duplicates_strategy: Ask)),
-            "<C-s>c": Save(kind: Modal(all: false, duplicates_strategy: Ask), current: true),
+            "<C-s>c":     Save(kind: Modal(all: false, duplicates_strategy: Ask), current: true),
             "<C-s>a":     Save(kind: Modal(all: true, duplicates_strategy: Ask)),
             "r":          Rate(),
             "Y":          CopyToClipboard(kind: Modal([

--- a/rmpc/src/config/keys/actions.rs
+++ b/rmpc/src/config/keys/actions.rs
@@ -990,6 +990,8 @@ pub enum CommonActionFile {
     Save {
         #[serde(default)]
         kind: SaveKind,
+        #[serde(default)]
+        current: bool,
     },
     DeleteFromPlaylist {
         #[serde(default)]
@@ -1046,6 +1048,7 @@ pub enum CommonAction {
     },
     Save {
         kind: SaveKind,
+        current: bool,
     },
     DeleteFromPlaylist {
         kind: DeleteKind,
@@ -1168,9 +1171,11 @@ impl ToDescription for CommonAction {
 
                 buf.into()
             },
-            CommonAction::Save { kind: SaveKind::Modal { all, duplicates_strategy } } => {
+            CommonAction::Save { kind: SaveKind::Modal { all, duplicates_strategy }, current } => {
                 let mut buf = String::from("Open a modal popup with options to save ");
-                if *all {
+                if *current {
+                    buf.push_str("the currently playing song");
+                } else if *all {
                     buf.push_str("all items");
                 } else {
                     buf.push_str("the item under cursor");
@@ -1187,9 +1192,11 @@ impl ToDescription for CommonAction {
 
                 buf.into()
             },
-            CommonAction::Save { kind: SaveKind::Playlist { name, all, duplicates_strategy } } => {
+            CommonAction::Save { kind: SaveKind::Playlist { name, all, duplicates_strategy }, current } => {
                 let mut buf = String::from("Save ");
-                if *all {
+                if *current {
+                    buf.push_str("the currently playing song");
+                } else if *all {
                     buf.push_str("all items");
                 } else {
                     buf.push_str("the item under cursor");
@@ -1356,7 +1363,7 @@ impl TryFrom<CommonActionFile> for CommonAction {
                 }
                 CommonAction::Rate { kind, current, min_rating, max_rating }
             }
-            CommonActionFile::Save { kind } => CommonAction::Save { kind },
+            CommonActionFile::Save { kind, current } => CommonAction::Save { kind, current },
             CommonActionFile::DeleteFromPlaylist { kind } => {
                 CommonAction::DeleteFromPlaylist { kind }
             }

--- a/rmpc/src/config/keys/mod.rs
+++ b/rmpc/src/config/keys/mod.rs
@@ -161,8 +161,9 @@ impl Default for KeyConfigFile {
             (s().char('i'),                       C::FocusInput),
             (s().char('o').char('i'),             C::ShowInfo),
             (s().char('x').ctrl(),                C::ContextMenu {}),
-            (s().char('s').ctrl().char('s'),      C::Save { kind: SaveKind::Modal { all: false, duplicates_strategy: DuplicateStrategy::Ask } }),
-            (s().char('s').ctrl().char('a'),      C::Save { kind: SaveKind::Modal { all: true, duplicates_strategy: DuplicateStrategy::Ask } }),
+            (s().char('s').ctrl().char('s'),      C::Save { kind: SaveKind::Modal { all: false, duplicates_strategy: DuplicateStrategy::Ask }, current: false }),
+            (s().char('s').ctrl().char('a'),      C::Save { kind: SaveKind::Modal { all: true, duplicates_strategy: DuplicateStrategy::Ask }, current: false }),
+            (s().char('s').ctrl().char('c'),      C::Save { kind: SaveKind::Modal { all: false, duplicates_strategy: DuplicateStrategy::Ask }, current: true }),
             (s().char('r'),                       C::Rate { kind: RateKind::default(), current: false, min_rating: 0, max_rating: 10 }),
         ]);
 

--- a/rmpc/src/ui/browser.rs
+++ b/rmpc/src/ui/browser.rs
@@ -710,7 +710,13 @@ where
             CommonAction::Rate { kind: _, current: true, min_rating: _, max_rating: _ } => {
                 event.abandon();
             }
-            CommonAction::Save { kind: SaveKind::Playlist { name, all, duplicates_strategy } } => {
+            CommonAction::Save { kind: _, current: true } => {
+                event.abandon();
+            }
+            CommonAction::Save {
+                kind: SaveKind::Playlist { name, all, duplicates_strategy },
+                current: false,
+            } => {
                 let list_songs = self.list_songs_in_items(all);
                 let all_songs: Vec<_> = ctx.query_sync(move |client| {
                     Ok(list_songs(client)?.into_iter().map(|s| s.file).collect())
@@ -723,7 +729,10 @@ where
 
                 add_to_playlist_or_show_modal(name, all_songs, duplicates_strategy, ctx);
             }
-            CommonAction::Save { kind: SaveKind::Modal { all, duplicates_strategy } } => {
+            CommonAction::Save {
+                kind: SaveKind::Modal { all, duplicates_strategy },
+                current: false,
+            } => {
                 let list_songs = self.list_songs_in_items(all);
                 let song_paths: Vec<_> = ctx.query_sync(move |client| {
                     Ok(list_songs(client)?.into_iter().map(|s| s.file).collect())

--- a/rmpc/src/ui/mod.rs
+++ b/rmpc/src/ui/mod.rs
@@ -33,7 +33,12 @@ use crate::{
     config::{
         Config,
         cli::{Args, Command},
-        keys::{CommonAction, GlobalAction, Key, actions::{RateKind, SaveKind}},
+        keys::{
+            CommonAction,
+            GlobalAction,
+            Key,
+            actions::{RateKind, SaveKind},
+        },
         tabs::{PaneType, SizedPaneOrSplit, TabName},
         theme::level_styles::LevelStyles,
     },
@@ -786,12 +791,8 @@ impl<'ui> Ui<'ui> {
                         let song_paths = vec![song.file.clone()];
                         match kind {
                             SaveKind::Modal { duplicates_strategy, .. } => {
-                                match create_save_modal(
-                                    song_paths,
-                                    None,
-                                    *duplicates_strategy,
-                                    ctx,
-                                ) {
+                                match create_save_modal(song_paths, None, *duplicates_strategy, ctx)
+                                {
                                     Ok(modal) => {
                                         modal!(ctx, modal);
                                     }

--- a/rmpc/src/ui/mod.rs
+++ b/rmpc/src/ui/mod.rs
@@ -33,7 +33,7 @@ use crate::{
     config::{
         Config,
         cli::{Args, Command},
-        keys::{CommonAction, GlobalAction, Key, actions::RateKind},
+        keys::{CommonAction, GlobalAction, Key, actions::{RateKind, SaveKind}},
         tabs::{PaneType, SizedPaneOrSplit, TabName},
         theme::level_styles::LevelStyles,
     },
@@ -55,7 +55,11 @@ use crate::{
     ui::{
         image::facade::EncodeData,
         input::{InputEvent, InputResultEvent},
-        modals::{downloads::DownloadsModal, info_list_modal::SongCtx, menu::create_rating_modal},
+        modals::{
+            downloads::DownloadsModal,
+            info_list_modal::SongCtx,
+            menu::{add_to_playlist_or_show_modal, create_rating_modal, create_save_modal},
+        },
     },
 };
 
@@ -771,6 +775,38 @@ impl<'ui> Ui<'ui> {
                                     client.set_sticker(&uri, LIKE_STICKER, "1")?;
                                     Ok(())
                                 });
+                            }
+                        }
+                    } else {
+                        status_error!("No song is currently playing");
+                    }
+                }
+                CommonAction::Save { kind, current: true } => {
+                    if let Some(song) = ctx.current_song() {
+                        let song_paths = vec![song.file.clone()];
+                        match kind {
+                            SaveKind::Modal { duplicates_strategy, .. } => {
+                                match create_save_modal(
+                                    song_paths,
+                                    None,
+                                    *duplicates_strategy,
+                                    ctx,
+                                ) {
+                                    Ok(modal) => {
+                                        modal!(ctx, modal);
+                                    }
+                                    Err(err) => {
+                                        status_error!("Failed to open save modal: {err}");
+                                    }
+                                }
+                            }
+                            SaveKind::Playlist { name, duplicates_strategy, .. } => {
+                                add_to_playlist_or_show_modal(
+                                    name.clone(),
+                                    song_paths,
+                                    *duplicates_strategy,
+                                    ctx,
+                                );
                             }
                         }
                     } else {

--- a/rmpc/src/ui/panes/queue.rs
+++ b/rmpc/src/ui/panes/queue.rs
@@ -1306,8 +1306,12 @@ impl Pane for QueuePane {
                 CommonAction::Rate { kind: _, current: true, min_rating: _, max_rating: _ } => {
                     event.abandon();
                 }
+                CommonAction::Save { kind: _, current: true } => {
+                    event.abandon();
+                }
                 CommonAction::Save {
                     kind: SaveKind::Playlist { name, all, duplicates_strategy },
+                    current: false,
                 } => {
                     let song_paths: Vec<String> =
                         self.items(all).map(|(_, song)| song.file.clone()).collect();
@@ -1318,7 +1322,10 @@ impl Pane for QueuePane {
 
                     add_to_playlist_or_show_modal(name, song_paths, duplicates_strategy, ctx);
                 }
-                CommonAction::Save { kind: SaveKind::Modal { all, duplicates_strategy } } => {
+                CommonAction::Save {
+                    kind: SaveKind::Modal { all, duplicates_strategy },
+                    current: false,
+                } => {
                     let song_paths: Vec<String> =
                         self.items(all).map(|(_, song)| song.file.clone()).collect();
                     if song_paths.is_empty() {

--- a/rmpc/src/ui/panes/search/mod.rs
+++ b/rmpc/src/ui/panes/search/mod.rs
@@ -479,8 +479,12 @@ impl SearchPane {
                     event.abandon();
                 }
                 CommonAction::Rate { .. } => {}
+                CommonAction::Save { kind: _, current: true } => {
+                    event.abandon();
+                }
                 CommonAction::Save {
                     kind: SaveKind::Playlist { name, all: true, duplicates_strategy },
+                    current: false,
                 } => {
                     let song_paths: Vec<String> =
                         self.items(true).map(|(_, song)| song.file.clone()).collect();
@@ -491,7 +495,10 @@ impl SearchPane {
 
                     add_to_playlist_or_show_modal(name, song_paths, duplicates_strategy, ctx);
                 }
-                CommonAction::Save { kind: SaveKind::Modal { all: true, duplicates_strategy } } => {
+                CommonAction::Save {
+                    kind: SaveKind::Modal { all: true, duplicates_strategy },
+                    current: false,
+                } => {
                     let song_paths: Vec<String> =
                         self.items(true).map(|(_, song)| song.file.clone()).collect();
                     if song_paths.is_empty() {
@@ -841,8 +848,12 @@ impl SearchPane {
                 CommonAction::Rate { kind: _, current: true, min_rating: _, max_rating: _ } => {
                     event.abandon();
                 }
+                CommonAction::Save { kind: _, current: true } => {
+                    event.abandon();
+                }
                 CommonAction::Save {
                     kind: SaveKind::Playlist { name, all, duplicates_strategy },
+                    current: false,
                 } => {
                     let song_paths: Vec<String> =
                         self.items(all).map(|(_, song)| song.file.clone()).collect();
@@ -853,7 +864,10 @@ impl SearchPane {
 
                     add_to_playlist_or_show_modal(name, song_paths, duplicates_strategy, ctx);
                 }
-                CommonAction::Save { kind: SaveKind::Modal { all, duplicates_strategy } } => {
+                CommonAction::Save {
+                    kind: SaveKind::Modal { all, duplicates_strategy },
+                    current: false,
+                } => {
                     let song_paths: Vec<_> =
                         self.items(all).map(|(_, song)| song.file.clone()).collect();
                     if song_paths.is_empty() {


### PR DESCRIPTION
Closes #1066 

Adds a `current: bool` field to the `Save` keybind action, mirroring the existing `Rate(current: bool)` option. When `current: true`, the action ignores the cursor position and selection in the focused pane and instead saves the song currently playing (as reported by `ctx.current_song()`) to a playlist, either via the picker modal (`SaveKind::Modal`) or directly to a named playlist (`SaveKind::Playlist`).

This allows binding a single keybind to "add currently playing song to playlist" that works from any pane/tab, without first having to jump to the Queue tab and move the cursor onto the playing song.

Implementation follows the same pattern already used for `Rate(current: true)`: each pane's `Save` handler now matches `current: true` first and calls `event.abandon()`, letting the event bubble up to the shared handler in `ui/mod.rs`, which resolves the currently playing song and opens the save modal or saves directly.

Changes:
- config/keys/actions.rs: add `current: bool` to `CommonActionFile::Save` and `CommonAction::Save`, update `TryFrom` conversion and `to_description` text.
- config/keys/mod.rs: update default keybinds for the new field and add a new default binding for saving the current song.
- ui/mod.rs: handle `CommonAction::Save { current: true, .. }` globally, resolving `ctx.current_song()` and reusing `create_save_modal` / `add_to_playlist_or_show_modal`.
- ui/browser.rs, ui/panes/queue.rs, ui/panes/search/mod.rs: abandon the `Save` event when `current: true` so it bubbles up to the shared handler; explicit `current: false` added to existing arms.


### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
