### PR TITLE
chore: fix clippy 1.97 manual_assert_eq lints

### DIFF
--- a/rmpc-mpd/src/queue_position.rs
+++ b/rmpc-mpd/src/queue_position.rs
@@ -48,10 +48,10 @@ mod tests {
 
     #[test]
     fn test_queue_position_fromstr() {
-        assert!("+0".parse::<QueuePosition>().unwrap() == QueuePosition::RelativeAdd(0));
-        assert!("-0".parse::<QueuePosition>().unwrap() == QueuePosition::RelativeSub(0));
-        assert!("-15".parse::<QueuePosition>().unwrap() == QueuePosition::RelativeSub(15));
-        assert!("0".parse::<QueuePosition>().unwrap() == QueuePosition::Absolute(0));
-        assert!("15".parse::<QueuePosition>().unwrap() == QueuePosition::Absolute(15));
+        assert_eq!("+0".parse::<QueuePosition>().unwrap(), QueuePosition::RelativeAdd(0));
+        assert_eq!("-0".parse::<QueuePosition>().unwrap(), QueuePosition::RelativeSub(0));
+        assert_eq!("-15".parse::<QueuePosition>().unwrap(), QueuePosition::RelativeSub(15));
+        assert_eq!("0".parse::<QueuePosition>().unwrap(), QueuePosition::Absolute(0));
+        assert_eq!("15".parse::<QueuePosition>().unwrap(), QueuePosition::Absolute(15));
     }
 }

--- a/rmpc-shared/src/version.rs
+++ b/rmpc-shared/src/version.rs
@@ -74,7 +74,7 @@ mod tests {
         let version_1: Version = "0.22.0".parse().unwrap();
         let version_2: Version = "0.22.0".parse().unwrap();
 
-        assert!(version_1 == version_2);
+        assert_eq!(version_1, version_2);
     }
 
     #[test]

--- a/rmpc/src/shared/lrc/index.rs
+++ b/rmpc/src/shared/lrc/index.rs
@@ -400,7 +400,7 @@ mod tests {
 
         let result = index.find_entry(&song);
 
-        assert!(result.unwrap().0.to_string_lossy() == "1");
+        assert_eq!(result.unwrap().0.to_string_lossy(), "1");
     }
 
     #[test]
@@ -431,7 +431,7 @@ mod tests {
 
         let result = index.find_entry(&song);
 
-        assert!(result.unwrap().0.to_string_lossy() == "should match");
+        assert_eq!(result.unwrap().0.to_string_lossy(), "should match");
     }
 
     #[test]
@@ -462,7 +462,7 @@ mod tests {
 
         let result = index.find_entry(&song);
 
-        assert!(result.unwrap().0.to_string_lossy() == "should match");
+        assert_eq!(result.unwrap().0.to_string_lossy(), "should match");
     }
 
     #[test]
@@ -495,7 +495,7 @@ mod tests {
 
         let result = index.find_entry(&song);
 
-        assert!(result.unwrap().0.to_string_lossy() == "no length");
+        assert_eq!(result.unwrap().0.to_string_lossy(), "no length");
     }
 
     #[test]
@@ -526,6 +526,6 @@ mod tests {
 
         let result = index.find_entry(&song);
 
-        assert!(result.unwrap().0.to_string_lossy() == "no album");
+        assert_eq!(result.unwrap().0.to_string_lossy(), "no album");
     }
 }

--- a/rmpc/src/ui/input/buffer.rs
+++ b/rmpc/src/ui/input/buffer.rs
@@ -613,7 +613,7 @@ mod test {
             let res = input.handle_input(Some(InputEvent::PopRight));
             match res {
                 InputResultEvent::Pop => {
-                    assert!(input.value == " done");
+                    assert_eq!(input.value, " done");
                     assert_eq!(input.cursor, 1);
                 }
                 _ => panic!("Expected Pop"),
@@ -773,7 +773,7 @@ mod test {
 
             match res {
                 InputResultEvent::Pop => {
-                    assert!(input.value == "foo,!");
+                    assert_eq!(input.value, "foo,!");
                     assert_eq!(input.cursor, 4);
                 }
                 _ => panic!("Expected Pop event"),


### PR DESCRIPTION
## Description

Clippy 1.97 added `manual_assert_eq`, and the workspace denies pedantic, so
`cargo clippy --workspace --all-targets` now fails on 13 existing
`assert!(a == b)` test assertions. With the MSRV already at 1.97.1 this hits
CI as soon as its clippy updates. Converted them to `assert_eq!`; no behavior
change.

### Related issues

None.

### Checklist

- [x] All tests pass (`cargo test --workspace`)
- [x] Formatted with nightly rustfmt
- [x] `cargo clippy --workspace --all-targets` is clean again
- [x] Documentation: not applicable
- [x] Changelog: not applicable (no user-visible change; happy to add an entry if you want one)
