### PR TITLE
fix: parse DSD and float audio formats in SampleRate, Bits and Channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- `Bits()` reporting the channel count as bit depth during DSD playback. MPD formats DSD audio as
+  `dsd64:2` or `384000:dsd:2`, neither of which parsed; DSD now reports its real sample rate,
+  1 bit and the channel count, and the float bit depth marker (`f`) no longer breaks the other fields
+- `SampleRate()`, `Bits()` and `Channels()` status properties ignoring their `default:`, unlike
+  `Bitrate` and `Crossfade`
 - Kitty image backend never displaying images whose encoded data fits into a single 4096 byte
   chunk, because the first chunk always claimed more data would follow (`m=1`)
 - Benign error log when reading a sticker that does not exist

--- a/rmpc-mpd/Cargo.toml
+++ b/rmpc-mpd/Cargo.toml
@@ -21,6 +21,7 @@ socket2 = { workspace = true }
 strum = { workspace = true }
 
 [dev-dependencies]
+rmpc-shared = { path = "../rmpc-shared", features = ["test-impl"] }
 rstest = "0.26.1"
 test-case = "3.3.1"
 

--- a/rmpc-mpd/src/commands/current_song.rs
+++ b/rmpc-mpd/src/commands/current_song.rs
@@ -23,21 +23,15 @@ pub struct Song {
 
 impl Song {
     pub fn samplerate(&self) -> Option<u32> {
-        self.metadata.get("format").and_then(|audio| {
-            audio.first().split(':').next().and_then(|rate_str| rate_str.parse().ok())
-        })
+        self.metadata.get("format").and_then(|audio| super::parse_audio_format(audio.first()).0)
     }
 
     pub fn bits(&self) -> Option<u32> {
-        self.metadata.get("format").and_then(|audio| {
-            audio.first().split(':').nth(1).and_then(|bits_str| bits_str.parse().ok())
-        })
+        self.metadata.get("format").and_then(|audio| super::parse_audio_format(audio.first()).1)
     }
 
     pub fn channels(&self) -> Option<u32> {
-        self.metadata.get("format").and_then(|audio| {
-            audio.first().split(':').nth(2).and_then(|channels_str| channels_str.parse().ok())
-        })
+        self.metadata.get("format").and_then(|audio| super::parse_audio_format(audio.first()).2)
     }
 }
 
@@ -90,5 +84,46 @@ impl FromMpd for Song {
             }
         }
         Ok(LineHandled::Yes)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use rstest::rstest;
+
+    use super::Song;
+    use crate::commands::metadata_tag::MetadataTag;
+
+    // Same grammar as the status "audio" field; songs carry it in the
+    // "Format" metadata key. See the table in status.rs for the source of
+    // the strings.
+    #[rstest]
+    #[case("44100:16:2", Some(44100), Some(16), Some(2))]
+    #[case("44100:f:2", Some(44100), None, Some(2))]
+    #[case("dsd64:2", Some(2_822_400), Some(1), Some(2))]
+    #[case("384000:dsd:2", Some(3_072_000), Some(1), Some(2))]
+    #[case("*:*:*", None, None, None)]
+    fn format_metadata_parses(
+        #[case] format: &str,
+        #[case] samplerate: Option<u32>,
+        #[case] bits: Option<u32>,
+        #[case] channels: Option<u32>,
+    ) {
+        let mut song = Song::default();
+        song.metadata.insert("format".to_owned(), MetadataTag::Single(format.to_owned()));
+
+        assert_eq!(song.samplerate(), samplerate);
+        assert_eq!(song.bits(), bits);
+        assert_eq!(song.channels(), channels);
+    }
+
+    #[test]
+    fn format_metadata_absent() {
+        let song = Song::default();
+
+        assert_eq!(song.samplerate(), None);
+        assert_eq!(song.bits(), None);
+        assert_eq!(song.channels(), None);
     }
 }

--- a/rmpc-mpd/src/commands/mod.rs
+++ b/rmpc-mpd/src/commands/mod.rs
@@ -30,3 +30,32 @@ pub use self::{
     update::Update,
     volume::Volume,
 };
+
+/// Parses MPD's audio format string into (samplerate, bits, channels).
+///
+/// MPD emits "samplerate:bits:channels" where bits can also be "f" (float),
+/// any field can be "*" (unknown), and DSD is special-cased: "dsdNN:channels"
+/// where NN * 44100 is the DSD sample rate, or "samplerate:dsd:channels" for
+/// rates not divisible by 44100, where samplerate is MPD's internal byte rate
+/// (one eighth of the DSD sample rate). DSD is one bit per sample.
+pub(crate) fn parse_audio_format(audio: &str) -> (Option<u32>, Option<u32>, Option<u32>) {
+    let mut fields = audio.split(':');
+    let first = fields.next();
+    let second = fields.next();
+    let third = fields.next();
+
+    if let Some(multiple) = first.and_then(|v| v.strip_prefix("dsd")) {
+        let samplerate = multiple.parse::<u32>().ok().and_then(|v| v.checked_mul(44100));
+        return (samplerate, samplerate.map(|_| 1), second.and_then(|v| v.parse().ok()));
+    }
+
+    let samplerate = first.and_then(|v| v.parse::<u32>().ok());
+    let channels = third.and_then(|v| v.parse().ok());
+    if second == Some("dsd") {
+        // The dsd marker alone proves 1 bit per sample, even when the rate
+        // is unknown ("*:dsd:2").
+        return (samplerate.and_then(|v| v.checked_mul(8)), Some(1), channels);
+    }
+
+    (samplerate, second.and_then(|v| v.parse().ok()), channels)
+}

--- a/rmpc-mpd/src/commands/status.rs
+++ b/rmpc-mpd/src/commands/status.rs
@@ -52,21 +52,15 @@ pub struct Status {
 
 impl Status {
     pub fn samplerate(&self) -> Option<u32> {
-        self.audio
-            .as_ref()
-            .and_then(|audio| audio.split(':').next().and_then(|rate_str| rate_str.parse().ok()))
+        self.audio.as_ref().and_then(|audio| super::parse_audio_format(audio).0)
     }
 
     pub fn bits(&self) -> Option<u32> {
-        self.audio
-            .as_ref()
-            .and_then(|audio| audio.split(':').nth(1).and_then(|bits_str| bits_str.parse().ok()))
+        self.audio.as_ref().and_then(|audio| super::parse_audio_format(audio).1)
     }
 
     pub fn channels(&self) -> Option<u32> {
-        self.audio.as_ref().and_then(|audio| {
-            audio.split(':').nth(2).and_then(|channels_str| channels_str.parse().ok())
-        })
+        self.audio.as_ref().and_then(|audio| super::parse_audio_format(audio).2)
     }
 }
 
@@ -202,5 +196,53 @@ impl std::str::FromStr for State {
             "pause" => Ok(Self::Pause),
             _ => Err(anyhow!("Invalid State: '{s}'")),
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use rstest::rstest;
+
+    use super::Status;
+
+    // Format strings exactly as MPD's AudioFormat.cxx ToString() emits them:
+    // PCM "rate:bits:channels", float bits as "f", wildcards as "*", DSD as
+    // the "dsdNN:channels" shortcut (NN * 44100 bit rate) or, for rates not
+    // divisible by 44100, "rate:dsd:channels" where rate is MPD's internal
+    // byte rate (bit rate / 8).
+    #[rstest]
+    #[case("44100:16:2", Some(44100), Some(16), Some(2))]
+    #[case("96000:24:2", Some(96000), Some(24), Some(2))]
+    #[case("44100:f:2", Some(44100), None, Some(2))]
+    #[case("44100:*:2", Some(44100), None, Some(2))]
+    #[case("*:*:*", None, None, None)]
+    #[case("dsd64:2", Some(2_822_400), Some(1), Some(2))]
+    #[case("dsd128:2", Some(5_644_800), Some(1), Some(2))]
+    #[case("dsd512:2", Some(22_579_200), Some(1), Some(2))]
+    #[case("dsd64:*", Some(2_822_400), Some(1), None)]
+    #[case("384000:dsd:2", Some(3_072_000), Some(1), Some(2))]
+    #[case("*:dsd:2", None, Some(1), Some(2))]
+    #[case("garbage", None, None, None)]
+    fn audio_format_parses(
+        #[case] audio: &str,
+        #[case] samplerate: Option<u32>,
+        #[case] bits: Option<u32>,
+        #[case] channels: Option<u32>,
+    ) {
+        let status = Status { audio: Some(audio.to_owned()), ..Default::default() };
+
+        assert_eq!(status.samplerate(), samplerate);
+        assert_eq!(status.bits(), bits);
+        assert_eq!(status.channels(), channels);
+    }
+
+    #[test]
+    fn audio_format_absent() {
+        let status = Status::default();
+
+        assert_eq!(status.samplerate(), None);
+        assert_eq!(status.bits(), None);
+        assert_eq!(status.channels(), None);
     }
 }

--- a/rmpc/src/ui/panes/mod.rs
+++ b/rmpc/src/ui/panes/mod.rs
@@ -709,15 +709,18 @@ impl Property<PropertyKind> {
                     ctx.input.mode().discriminant().to_string(),
                     style,
                 ))),
-                StatusProperty::SampleRate() => {
-                    status.samplerate().map(|v| Either::Left(Span::styled(v.to_string(), style)))
-                }
-                StatusProperty::Bits() => {
-                    status.bits().map(|v| Either::Left(Span::styled(v.to_string(), style)))
-                }
-                StatusProperty::Channels() => {
-                    status.channels().map(|v| Either::Left(Span::styled(v.to_string(), style)))
-                }
+                StatusProperty::SampleRate() => status.samplerate().map_or_else(
+                    || self.default_as_span(song, ctx, tag_separator, strategy),
+                    |v| Some(Either::Left(Span::styled(v.to_string(), style))),
+                ),
+                StatusProperty::Bits() => status.bits().map_or_else(
+                    || self.default_as_span(song, ctx, tag_separator, strategy),
+                    |v| Some(Either::Left(Span::styled(v.to_string(), style))),
+                ),
+                StatusProperty::Channels() => status.channels().map_or_else(
+                    || self.default_as_span(song, ctx, tag_separator, strategy),
+                    |v| Some(Either::Left(Span::styled(v.to_string(), style))),
+                ),
             },
             PropertyKindOrText::Property(PropertyKind::Widget(w)) => match w {
                 WidgetProperty::Volume => {
@@ -1481,6 +1484,9 @@ mod format_tests {
         #[case(StatusProperty::Duration, "2:03")]
         #[case(StatusProperty::Crossfade, "3")]
         #[case(StatusProperty::Bitrate, "123")]
+        #[case(StatusProperty::SampleRate(), "2822400")]
+        #[case(StatusProperty::Bits(), "1")]
+        #[case(StatusProperty::Channels(), "2")]
         fn status_property_resolves_correctly(
             mut ctx: Ctx,
             #[case] prop: StatusProperty,
@@ -1516,6 +1522,7 @@ mod format_tests {
                 duration: Duration::from_secs(123),
                 xfade: Some(3),
                 state: State::Play,
+                audio: Some("dsd64:2".to_string()),
                 ..Default::default()
             };
 
@@ -1524,6 +1531,31 @@ mod format_tests {
             assert_eq!(
                 result,
                 Some(either::Either::<Span<'_>, Vec<Span<'_>>>::Left(Span::raw(expected)))
+            );
+        }
+
+        #[rstest]
+        #[case(StatusProperty::Bitrate)]
+        #[case(StatusProperty::SampleRate())]
+        #[case(StatusProperty::Bits())]
+        #[case(StatusProperty::Channels())]
+        fn status_property_falls_back_to_default(mut ctx: Ctx, #[case] prop: StatusProperty) {
+            let format = Property::<PropertyKind> {
+                kind: PropertyKindOrText::Property(PropertyKind::Status(prop)),
+                style: None,
+                default: Some(Box::new(Property::<PropertyKind> {
+                    kind: PropertyKindOrText::Text("default".to_string()),
+                    style: None,
+                    default: None,
+                })),
+            };
+            ctx.status = Status::default();
+
+            let result = format.as_span(None, &ctx, "", TagResolutionStrategy::All);
+
+            assert_eq!(
+                result,
+                Some(either::Either::<Span<'_>, Vec<Span<'_>>>::Left(Span::raw("default")))
             );
         }
 


### PR DESCRIPTION
## Description

MPD formats DSD audio as `dsd64:2`, or as `384000:dsd:2` for rates not
divisible by 44100, and float bit depth as the letter `f` (`ToString()` in
MPD's `src/pcm/AudioFormat.cxx`). The `SampleRate()`, `Bits()` and
`Channels()` accessors split the string on `:` and parsed every field as a
plain integer, so during DSD playback `Bits()` showed the channel count
while the other two showed nothing.

This PR parses the format string in one shared helper that understands both
DSD encodings, the float marker and per-field wildcards (`*`). DSD reports
its real sample rate (dsd64 is 2822400 Hz), 1 bit per sample and the channel
count; the `rate:dsd:channels` form carries MPD's internal byte rate, so it
is multiplied by eight (384000:dsd:2 x 8 = 3072000, DSD64 at the 48k base).
The three status properties now also fall back to their configured
`default:` the way `Bitrate` and `Crossfade` already do.

One judgment call to flag: float keeps `Bits()` empty, because the protocol
string does not state a width. Alternatives are reporting 32 (MPD's internal
float width) or a richer value with a float variant; happy to change to
either if you prefer.

Tests cover every encoding with strings taken verbatim from AudioFormat.cxx,
including a DSD stream with unknown rate (`*:dsd:2`, the else-branch when
sample_rate is 0, where the dsd marker still proves 1 bit), plus the default
fallback. The dsd64:2 form was also verified against a live MPD 0.24 playing
2L's DSD64 test file (screenshot in the linked issue). The first commit
enables `cargo test -p rmpc-mpd` standalone (the address tests need
rmpc-shared's `test-impl` feature, which only rmpc and rmpcd enabled in
dev-dependencies), which the new tests rely on when run in isolation.

### Related issues

Fixes #1069

### Checklist

- [x] All tests pass (`cargo test --workspace`)
- [x] Formatted with nightly rustfmt
- [x] Clippy: no new lints from this branch; the pre-existing
      `manual_assert_eq` errors from clippy 1.97 are fixed separately in
      #1068
- [x] Documentation updated: companion docs PR describing the DSD/float
      behavior of these properties: rmpc-org/rmpc-org.github.io#74
- [x] Changelog updated
