### PR TITLE
feat: add output status properties and improve the outputs modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - `directories_hidden_dirs` config option to hide directories with the given names from the
   `Directories` pane
+- Added `ActiveOutputs` and `ActiveOutput` status properties showing the enabled outputs
 - Added `current` option to `Save()` keybind to save the currently playing song
 - Added a new vertical volume slider pane.
 - **Breaking** `ExternalCommand` can now have arguments supplied at runtime. This will break your

--- a/rmpc/src/config/defaults.rs
+++ b/rmpc/src/config/defaults.rs
@@ -81,6 +81,10 @@ pub fn default_thousands_separator() -> String {
     ",".to_string()
 }
 
+pub fn default_output_separator() -> String {
+    ", ".to_string()
+}
+
 pub fn rating_options() -> Vec<i32> {
     vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 }

--- a/rmpc/src/config/theme/properties.rs
+++ b/rmpc/src/config/theme/properties.rs
@@ -148,6 +148,21 @@ pub enum StatusPropertyFile {
     SampleRate(),
     Bits(),
     Channels(),
+    ActiveOutputs {
+        #[serde(default = "defaults::default_output_separator")]
+        separator: String,
+    },
+    ActiveOutput {
+        name: String,
+        #[serde(default)]
+        on_label: Option<String>,
+        #[serde(default)]
+        off_label: Option<String>,
+        #[serde(default)]
+        on_style: Option<StyleFile>,
+        #[serde(default)]
+        off_style: Option<StyleFile>,
+    },
 }
 
 #[derive(Debug, Clone, Display, Hash, Eq, PartialEq)]
@@ -209,6 +224,16 @@ pub enum StatusProperty {
     SampleRate(),
     Bits(),
     Channels(),
+    ActiveOutputs {
+        separator: String,
+    },
+    ActiveOutput {
+        name: String,
+        on_label: String,
+        off_label: String,
+        on_style: Option<Style>,
+        off_style: Option<Style>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -521,6 +546,22 @@ impl TryFrom<StatusPropertyFile> for StatusProperty {
             StatusPropertyFile::SampleRate() => StatusProperty::SampleRate(),
             StatusPropertyFile::Bits() => StatusProperty::Bits(),
             StatusPropertyFile::Channels() => StatusProperty::Channels(),
+            StatusPropertyFile::ActiveOutputs { separator } => {
+                StatusProperty::ActiveOutputs { separator }
+            }
+            StatusPropertyFile::ActiveOutput { name, on_label, off_label, on_style, off_style } => {
+                StatusProperty::ActiveOutput {
+                    on_label: on_label.unwrap_or_else(|| name.clone()),
+                    off_label: off_label.unwrap_or_else(|| name.clone()),
+                    name,
+                    on_style: on_style
+                        .map(|s| -> Result<_> { s.to_config_or(None, None) })
+                        .transpose()?,
+                    off_style: off_style
+                        .map(|s| -> Result<_> { s.to_config_or(None, None) })
+                        .transpose()?,
+                }
+            }
         })
     }
 }

--- a/rmpc/src/core/event_loop.rs
+++ b/rmpc/src/core/event_loop.rs
@@ -26,6 +26,7 @@ use crate::{
         mpd_client_ext::MpdClientExt,
         mpd_query::{
             EXTERNAL_COMMAND,
+            GLOBAL_OUTPUTS_UPDATE,
             GLOBAL_QUEUE_UPDATE,
             GLOBAL_STATUS_UPDATE,
             GLOBAL_STICKERS_UPDATE,
@@ -648,6 +649,10 @@ fn main_task<B: Backend + std::io::Write>(
                             ctx.status.volume = volume;
                             render_wanted = true;
                         }
+                        (GLOBAL_OUTPUTS_UPDATE, None, MpdQueryResult::Outputs(outputs)) => {
+                            ctx.outputs = outputs;
+                            render_wanted = true;
+                        }
                         (GLOBAL_QUEUE_UPDATE, None, MpdQueryResult::Queue(queue)) => {
                             ctx.queue = queue.unwrap_or_default();
                             ctx.cached_queue_time_total =
@@ -775,7 +780,12 @@ fn main_task<B: Backend + std::io::Write>(
                     }
                 }
                 AppEvent::Reconnected => {
-                    for ev in [IdleEvent::Player, IdleEvent::Playlist, IdleEvent::Options] {
+                    for ev in [
+                        IdleEvent::Player,
+                        IdleEvent::Playlist,
+                        IdleEvent::Options,
+                        IdleEvent::Output,
+                    ] {
                         handle_idle_event(ev, &ctx);
                     }
                     if let Err(err) = ui.on_event(UiEvent::Reconnected, &mut ctx) {
@@ -931,7 +941,11 @@ fn handle_idle_event(event: IdleEvent, ctx: &Ctx) {
                 })
             });
         }
-        IdleEvent::Output => {}
+        IdleEvent::Output => {
+            ctx.query().id(GLOBAL_OUTPUTS_UPDATE).replace_id("outputs").query(move |client| {
+                Ok(MpdQueryResult::Outputs(client.current_partition_outputs()?))
+            });
+        }
         IdleEvent::Partition
         | IdleEvent::Subscription
         | IdleEvent::Message

--- a/rmpc/src/ctx.rs
+++ b/rmpc/src/ctx.rs
@@ -33,7 +33,7 @@ use crate::{
         keys::KeyResolver,
         lrc::{Lrc, LrcIndex},
         macros::{status_error, status_warn},
-        mpd_client_ext::MpdClientExt,
+        mpd_client_ext::{MpdClientExt, PartitionedOutput},
         mpd_query::MpdQuerySync,
         ring_vec::RingVec,
         ytdlp::YtDlpManager,
@@ -55,6 +55,7 @@ pub struct Ctx {
     #[cfg(not(test))]
     current_song: Option<Song>,
     pub(crate) queue: Vec<Song>,
+    pub(crate) outputs: Vec<PartitionedOutput>,
     #[cfg(test)]
     pub(crate) stickers: HashMap<String, HashMap<String, String>>,
     #[cfg(not(test))]
@@ -106,6 +107,7 @@ impl Ctx {
         let status = client.get_status()?;
         let queue = client.playlist_info()?.unwrap_or_default();
         let current_song = client.get_current_song()?;
+        let outputs = client.current_partition_outputs()?;
         let cached_queue_time_total = queue.iter().filter_map(|s| s.duration).sum();
 
         if !supported_commands.contains("albumart") || !supported_commands.contains("readpicture") {
@@ -126,6 +128,7 @@ impl Ctx {
             config: std::sync::Arc::new(config),
             status,
             queue,
+            outputs,
             current_song,
             stickers: HashMap::new(),
             active_tab,

--- a/rmpc/src/shared/mpd_client_ext.rs
+++ b/rmpc/src/shared/mpd_client_ext.rs
@@ -71,6 +71,7 @@ pub trait MpdClientExt {
         &mut self,
         current_partition: &str,
     ) -> Result<Vec<PartitionedOutput>, MpdError>;
+    fn current_partition_outputs(&mut self) -> Result<Vec<PartitionedOutput>, MpdError>;
     fn create_playlist(&mut self, name: &str, items: Vec<String>) -> Result<(), MpdError>;
     fn next_keep_state(&mut self, keep: bool, state: State) -> Result<(), MpdError>;
     fn prev_keep_state(&mut self, keep: bool, state: State) -> Result<(), MpdError>;
@@ -278,22 +279,7 @@ impl<T: MpdClient + MpdCommand + ProtoClient> MpdClientExt for T {
         current_partition: &str,
     ) -> Result<Vec<PartitionedOutput>, MpdError> {
         if current_partition == "default" {
-            Ok(self
-                .outputs()?
-                .0
-                .into_iter()
-                .map(|output| PartitionedOutput {
-                    id: output.id,
-                    name: output.name,
-                    enabled: if output.plugin == "dummy" { false } else { output.enabled },
-                    kind: if output.plugin == "dummy" {
-                        PartitionedOutputKind::OtherPartition
-                    } else {
-                        PartitionedOutputKind::CurrentPartition
-                    },
-                    plugin: output.plugin,
-                })
-                .collect())
+            self.current_partition_outputs()
         } else {
             // MPD lists all outputs only on the default partition so we have to
             // switch to it, list the outputs and then switch back. We also have to
@@ -338,6 +324,28 @@ impl<T: MpdClient + MpdCommand + ProtoClient> MpdClientExt for T {
 
             Ok(result)
         }
+    }
+
+    // A plain outputs command reflects the partition the connection is on
+    // and never switches partitions. Outputs moved to another partition
+    // show up as the dummy plugin.
+    fn current_partition_outputs(&mut self) -> Result<Vec<PartitionedOutput>, MpdError> {
+        Ok(self
+            .outputs()?
+            .0
+            .into_iter()
+            .map(|output| PartitionedOutput {
+                id: output.id,
+                name: output.name,
+                enabled: if output.plugin == "dummy" { false } else { output.enabled },
+                kind: if output.plugin == "dummy" {
+                    PartitionedOutputKind::OtherPartition
+                } else {
+                    PartitionedOutputKind::CurrentPartition
+                },
+                plugin: output.plugin,
+            })
+            .collect())
     }
 
     fn create_playlist(&mut self, name: &str, items: Vec<String>) -> Result<(), MpdError> {
@@ -659,6 +667,12 @@ pub struct PartitionedOutput {
     pub enabled: bool,
     pub plugin: String,
     pub kind: PartitionedOutputKind,
+}
+
+impl PartitionedOutput {
+    pub fn is_on_current_partition(&self) -> bool {
+        matches!(self.kind, PartitionedOutputKind::CurrentPartition)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/rmpc/src/shared/mpd_query.rs
+++ b/rmpc/src/shared/mpd_query.rs
@@ -20,6 +20,7 @@ pub const EXTERNAL_COMMAND: &str = "external_command";
 pub const GLOBAL_STATUS_UPDATE: &str = "global_status_update";
 pub const GLOBAL_VOLUME_UPDATE: &str = "global_volume_update";
 pub const GLOBAL_QUEUE_UPDATE: &str = "global_queue_update";
+pub const GLOBAL_OUTPUTS_UPDATE: &str = "global_outputs_update";
 pub const GLOBAL_STICKERS_UPDATE: &str = "global_stickers_update";
 
 #[derive(derive_more::Debug, Builder)]

--- a/rmpc/src/tests/fixtures/mod.rs
+++ b/rmpc/src/tests/fixtures/mod.rs
@@ -69,6 +69,7 @@ pub fn ctx(
         status: Status::default(),
         config: std::sync::Arc::new(config),
         queue: Vec::default(),
+        outputs: Vec::default(),
         stickers: HashMap::new(),
         active_tab: TabName::from("test_tab"),
         app_event_sender: app_event_channel.0.clone(),

--- a/rmpc/src/ui/modals/outputs.rs
+++ b/rmpc/src/ui/modals/outputs.rs
@@ -172,7 +172,7 @@ impl Modal for OutputsModal {
 
     fn on_event(&mut self, event: &mut UiEvent, ctx: &Ctx) -> Result<()> {
         match event {
-            UiEvent::Output => self.refresh_outputs(ctx),
+            UiEvent::Output | UiEvent::Reconnected => self.refresh_outputs(ctx),
             _ => {}
         }
         Ok(())

--- a/rmpc/src/ui/panes/mod.rs
+++ b/rmpc/src/ui/panes/mod.rs
@@ -721,6 +721,31 @@ impl Property<PropertyKind> {
                     || self.default_as_span(song, ctx, tag_separator, strategy),
                     |v| Some(Either::Left(Span::styled(v.to_string(), style))),
                 ),
+                StatusProperty::ActiveOutputs { separator } => {
+                    let outputs = ctx
+                        .outputs
+                        .iter()
+                        .filter(|output| output.enabled && output.is_on_current_partition())
+                        .map(|output| output.name.as_str())
+                        .join(separator);
+                    if outputs.is_empty() {
+                        self.default_as_span(song, ctx, tag_separator, strategy)
+                    } else {
+                        Some(Either::Left(Span::styled(outputs, style)))
+                    }
+                }
+                StatusProperty::ActiveOutput { name, on_label, off_label, on_style, off_style } => {
+                    ctx.outputs.iter().find(|output| &output.name == name).map_or_else(
+                        || self.default_as_span(song, ctx, tag_separator, strategy),
+                        |output| {
+                            let on = output.enabled && output.is_on_current_partition();
+                            Some(Either::Left(Span::styled(
+                                if on { on_label } else { off_label },
+                                if on { on_style } else { off_style }.unwrap_or(style),
+                            )))
+                        },
+                    )
+                }
             },
             PropertyKindOrText::Property(PropertyKind::Widget(w)) => match w {
                 WidgetProperty::Volume => {
@@ -1440,6 +1465,11 @@ mod format_tests {
 
     mod correct_values {
         use super::*;
+        use crate::shared::mpd_client_ext::{
+            PartitionedOutput,
+            PartitionedOutputKind,
+            PartitionedOutputKind::{CurrentPartition, OtherPartition},
+        };
 
         #[rstest]
         #[case(SongProperty::Title, "title")]
@@ -1531,6 +1561,187 @@ mod format_tests {
             assert_eq!(
                 result,
                 Some(either::Either::<Span<'_>, Vec<Span<'_>>>::Left(Span::raw(expected)))
+            );
+        }
+
+        fn output(name: &str, enabled: bool, kind: PartitionedOutputKind) -> PartitionedOutput {
+            PartitionedOutput {
+                id: 0,
+                name: name.to_owned(),
+                enabled,
+                plugin: "pipewire".to_owned(),
+                kind,
+            }
+        }
+
+        #[rstest]
+        fn active_outputs_resolves_to_joined_enabled_names(mut ctx: Ctx) {
+            ctx.outputs = vec![
+                output("S/PDIF", true, CurrentPartition),
+                output("Speakers", false, CurrentPartition),
+                output("upstairs", true, OtherPartition),
+                output("my_fifo", true, CurrentPartition),
+            ];
+            let format = Property::<PropertyKind> {
+                kind: PropertyKindOrText::Property(PropertyKind::Status(
+                    StatusProperty::ActiveOutputs { separator: "+".to_string() },
+                )),
+                style: None,
+                default: None,
+            };
+
+            let result = format.as_span(None, &ctx, "", TagResolutionStrategy::All);
+
+            assert_eq!(
+                result,
+                Some(either::Either::<Span<'_>, Vec<Span<'_>>>::Left(Span::raw("S/PDIF+my_fifo")))
+            );
+        }
+
+        #[rstest]
+        fn active_outputs_falls_back_to_default_when_none_enabled(mut ctx: Ctx) {
+            ctx.outputs = vec![output("S/PDIF", false, CurrentPartition)];
+            let format = Property::<PropertyKind> {
+                kind: PropertyKindOrText::Property(PropertyKind::Status(
+                    StatusProperty::ActiveOutputs { separator: ", ".to_string() },
+                )),
+                style: None,
+                default: Some(Box::new(Property::<PropertyKind> {
+                    kind: PropertyKindOrText::Text("no output".to_string()),
+                    style: None,
+                    default: None,
+                })),
+            };
+
+            let result = format.as_span(None, &ctx, "", TagResolutionStrategy::All);
+
+            assert_eq!(
+                result,
+                Some(either::Either::<Span<'_>, Vec<Span<'_>>>::Left(Span::raw("no output")))
+            );
+        }
+
+        fn output_lamp(name: &str) -> StatusProperty {
+            StatusProperty::ActiveOutput {
+                name: name.to_owned(),
+                on_label: format!("{name} on"),
+                off_label: format!("{name} off"),
+                on_style: None,
+                off_style: None,
+            }
+        }
+
+        #[rstest]
+        #[case(true, "S/PDIF on")]
+        #[case(false, "S/PDIF off")]
+        fn active_output_lamp_follows_enabled_state(
+            mut ctx: Ctx,
+            #[case] enabled: bool,
+            #[case] expected: &str,
+        ) {
+            ctx.outputs = vec![output("S/PDIF", enabled, CurrentPartition)];
+            let format = Property::<PropertyKind> {
+                kind: PropertyKindOrText::Property(PropertyKind::Status(output_lamp("S/PDIF"))),
+                style: None,
+                default: None,
+            };
+
+            let result = format.as_span(None, &ctx, "", TagResolutionStrategy::All);
+
+            assert_eq!(
+                result,
+                Some(either::Either::<Span<'_>, Vec<Span<'_>>>::Left(Span::raw(expected)))
+            );
+        }
+
+        #[rstest]
+        #[case(true)]
+        #[case(false)]
+        fn active_output_lamp_labels_default_to_name(mut ctx: Ctx, #[case] enabled: bool) {
+            ctx.outputs = vec![output("S/PDIF", enabled, CurrentPartition)];
+            let prop = StatusPropertyFile::ActiveOutput {
+                name: "S/PDIF".to_owned(),
+                on_label: None,
+                off_label: None,
+                on_style: None,
+                off_style: None,
+            };
+            let format = Property::<PropertyKind> {
+                kind: PropertyKindOrText::Property(PropertyKind::Status(prop.try_into().unwrap())),
+                style: None,
+                default: None,
+            };
+
+            let result = format.as_span(None, &ctx, "", TagResolutionStrategy::All);
+
+            assert_eq!(
+                result,
+                Some(either::Either::<Span<'_>, Vec<Span<'_>>>::Left(Span::raw("S/PDIF")))
+            );
+        }
+
+        #[rstest]
+        fn active_output_lamp_with_empty_off_label_renders_nothing(mut ctx: Ctx) {
+            ctx.outputs = vec![output("Speakers", false, CurrentPartition)];
+            let prop = StatusPropertyFile::ActiveOutput {
+                name: "Speakers".to_owned(),
+                on_label: Some(" SPKR".to_owned()),
+                off_label: Some(String::new()),
+                on_style: None,
+                off_style: None,
+            };
+            let format = Property::<PropertyKind> {
+                kind: PropertyKindOrText::Property(PropertyKind::Status(prop.try_into().unwrap())),
+                style: None,
+                default: None,
+            };
+
+            let result = format.as_span(None, &ctx, "", TagResolutionStrategy::All);
+
+            assert_eq!(
+                result,
+                Some(either::Either::<Span<'_>, Vec<Span<'_>>>::Left(Span::raw("")))
+            );
+        }
+
+        #[rstest]
+        fn active_output_lamp_shows_off_label_for_output_on_other_partition(mut ctx: Ctx) {
+            ctx.outputs = vec![output("upstairs", true, OtherPartition)];
+            let format = Property::<PropertyKind> {
+                kind: PropertyKindOrText::Property(PropertyKind::Status(output_lamp("upstairs"))),
+                style: None,
+                default: None,
+            };
+
+            let result = format.as_span(None, &ctx, "", TagResolutionStrategy::All);
+
+            assert_eq!(
+                result,
+                Some(either::Either::<Span<'_>, Vec<Span<'_>>>::Left(Span::raw("upstairs off")))
+            );
+        }
+
+        #[rstest]
+        fn active_output_lamp_falls_back_when_output_unknown(mut ctx: Ctx) {
+            ctx.outputs = vec![
+                output("S/PDIF", true, CurrentPartition),
+                output("upstairs", true, OtherPartition),
+            ];
+            let format = Property::<PropertyKind> {
+                kind: PropertyKindOrText::Property(PropertyKind::Status(output_lamp("basement"))),
+                style: None,
+                default: Some(Box::new(Property::<PropertyKind> {
+                    kind: PropertyKindOrText::Text("?".to_string()),
+                    style: None,
+                    default: None,
+                })),
+            };
+
+            let result = format.as_span(None, &ctx, "", TagResolutionStrategy::All);
+
+            assert_eq!(
+                result,
+                Some(either::Either::<Span<'_>, Vec<Span<'_>>>::Left(Span::raw("?")))
             );
         }
 


### PR DESCRIPTION
### Description

MPD's `output` idle event was received and discarded
(`IdleEvent::Output => {}`) and no theme property could display which
outputs are enabled. This PR stores the current partition's outputs on
`Ctx` (fetched at startup, on the `output` idle event and on reconnect)
and adds two status properties.

`ActiveOutput` renders a fixed-width on/off lamp for one named output,
with the usual label and style pairs (the labels default to the
output's name). Composed one per output in a `Group`, the display keeps
a fixed width no matter how many outputs are enabled:

```ron
(kind: Property(Status(ActiveOutput(name: "S/PDIF",
    on_style: (fg: "yellow", modifiers: "Bold"), off_style: (fg: "gray"))))),
(kind: Text(" ")),
(kind: Property(Status(ActiveOutput(name: "Speakers", on_label: "SPKR", off_label: "SPKR",
    on_style: (fg: "yellow", modifiers: "Bold"), off_style: (fg: "gray"))))),
```

![ActiveOutput lamps: one per output, fixed width; enabled outputs light up](https://raw.githubusercontent.com/Strykar/rmpc/assets/activeoutputs-lamp-row.png)

The always-visible dimmed look is one choice, not a requirement: an
empty `off_label` hides a lamp entirely while its output is disabled
(put the spacing inside `on_label`), so space-constrained layouts show
only what is playing.

`ActiveOutputs` renders the enabled output names joined by a separator:

```ron
(kind: Property(Status(ActiveOutputs(separator: ", "))))
```

Why both: MPD plays to every enabled output at once, so the summary can
grow past a fixed pane and truncate (found in live testing). The lamp
row cannot grow, and per-output lamps cannot be built from the joined
string with `Transform`. The summary stays because it is the only
display that reveals an output the theme did not anticipate.

Behavior details:

- The fetch is a plain `outputs` command: it reflects the partition the
  connection is on and never switches partitions. A switch inside the
  fetch would raise another `output` idle event on the same connection
  and loop, and partition switches need no extra trigger because MPD's
  `Client::SetPartition` flags `IDLE_OUTPUT` on the switching client.
- The summary excludes outputs on other partitions (MPD reports them as
  the `dummy` plugin). A lamp for an output that was moved to another
  partition renders `off_label`; only an unknown name falls through to
  the item's `default:`, same as `Bitrate` and `Crossfade`. An empty
  summary resolves to `default:` too.
- Non-audio outputs (fifo, httpd) count as enabled. Lamps handle this
  naturally (do not author a lamp for them); for the summary a
  `Transform` arm can hide them, and the parsed `plugin` field is
  available if a built-in filter is preferred later.

Scope note: the outputs modal keeps its own fetch-on-open and
refresh-on-event queries, so while it is open an output change fetches
the list twice (once for the modal, once for the shared state). Left
that way deliberately to keep this PR from rewriting existing modal
behavior; a follow-up could render the modal from the shared outputs
state and drop its private copy. Happy to do that here instead if
preferred.

The second commit makes the modal refresh on reconnect; it only
refreshed on the output idle event, so a modal left open across an MPD
restart kept the pre-disconnect outputs.

My use case: one `pipewire` output per physical route pinned by
`target` in mpd.conf. The lamp row shows the active route at a glance,
toggling in the outputs modal switches it live, and it works for remote
MPD where host-side tools cannot answer this.

### Related issues

None found for output display in the status bar or theme.

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable, clean)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has
      been updated (companion PR: rmpc-org/rmpc-org.github.io#76)
- [x] Changelog has been updated
