### PR TITLE
fix: rmpcd - emit song_change only when the queue entry changes

### DIFF
--- a/rmpcd/src/event_loop.rs
+++ b/rmpcd/src/event_loop.rs
@@ -79,20 +79,32 @@ pub async fn init(
                 let ro_status = &ro_mpd_state.status;
                 let ro_song = &ro_mpd_state.current_song;
                 if ro_song != &song {
-                    album_art = if let Some(s) = &song {
-                        let uri = s.file.clone();
-                        album_art_changed = true;
-                        client
-                            .run(move |c| c.find_album_art(&uri, AlbumArtOrder::EmbeddedFirst))
-                            .await?
-                    } else {
-                        None
-                    };
+                    // A database update can rewrite metadata or last_modified
+                    // of the entry that is currently playing (auto_update,
+                    // manual update/rescan). That is not a song change: only
+                    // a different queue entry or file is. Plugins otherwise
+                    // see phantom song changes mid-song (double
+                    // notifications, broken scrobbles), while MPRIS still
+                    // wants the refreshed metadata.
+                    let identity_changed = ro_song.as_ref().map(|s| (s.id, s.file.as_str()))
+                        != song.as_ref().map(|s| (s.id, s.file.as_str()));
 
-                    tx.send_safe(PluginsEvent::SongChange {
-                        old: ro_song.as_ref().map(Song::from),
-                        new: song.as_ref().map(Song::from),
-                    });
+                    if identity_changed {
+                        album_art = if let Some(s) = &song {
+                            let uri = s.file.clone();
+                            album_art_changed = true;
+                            client
+                                .run(move |c| c.find_album_art(&uri, AlbumArtOrder::EmbeddedFirst))
+                                .await?
+                        } else {
+                            None
+                        };
+
+                        tx.send_safe(PluginsEvent::SongChange {
+                            old: ro_song.as_ref().map(Song::from),
+                            new: song.as_ref().map(Song::from),
+                        });
+                    }
 
                     change_buffer.push(Change::Metadata);
                 }


### PR DESCRIPTION
## Description

Reproduce: play any song, then `touch` its file and run `mpc update <uri>` (or just retag files while auto_update is on). The playcount builtin increments mid-song, notify re-notifies the playing track, and lastfm's scrobble clock restarts, which can suppress the legitimate scrobble of the track entirely.

Cause and fix are in the commit message; the short version is that the event loop compared the whole Song struct, and a database reread of the playing entry changes metadata/last_modified without being a song change. Verified in both directions: the reproducer fires on a build without this patch and is silent with it, while real track changes still fire.

Two things you may want to weigh in on: art replaced mid-song is no longer refetched until the next real song change (deliberate, noted in the commit message), and if a plugin should ever see metadata-rewrite events, a separate tag_change hook would be the shape. Happy to add it if wanted.

### Related issues

None filed; found running rmpcd master with MPD auto_update.

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed) - no docs describe this behavior
- [x] Changelog has been updated - rmpcd changes are not tracked in the rmpc changelog