### PR TITLE
fix: rmpcd - boolean plugin options cannot be set to false

### DIFF
--- a/rmpcd/src/lua/builtin/lastfm.lua
+++ b/rmpcd/src/lua/builtin/lastfm.lua
@@ -254,8 +254,8 @@ end
 M.setup = function(self, args)
     self.api_key = args.api_key
     self.shared_secret = args.shared_secret
-    self.update_now_playing = (args.update_now_playing ~= nil) and args.update_now_playing or false
-    self.enabled = (args.update_now_playing ~= nil) and args.enabled or true
+    self.update_now_playing = args.update_now_playing == true
+    self.enabled = args.enabled == nil or args.enabled
 
     local xdg_open = util.which("xdg-open")
     if not xdg_open then
@@ -310,6 +310,10 @@ M.setup = function(self, args)
 end
 
 M.song_change = function(self, old, new)
+    if not self.enabled then
+        return
+    end
+
     if new ~= nil and (self.update_now_playing or false) then
         lastfm_update_now_playing(self.api_key, self.shared_secret, self.session_key, new, new.duration / 1000)
     end
@@ -330,6 +334,10 @@ M.song_change = function(self, old, new)
 end
 
 M.state_change = function(self, old, new)
+    if not self.enabled then
+        return
+    end
+
     if new ~= "play" and old == "play" then
         local current_time = os.time()
 

--- a/rmpcd/src/lua/builtin/lyrics.lua
+++ b/rmpcd/src/lua/builtin/lyrics.lua
@@ -103,7 +103,7 @@ end
 local function download_debounced(_self, _song) end
 
 M.setup = function(self, args)
-    self.enabled = (args.enabled ~= nil) and args.enabled or true
+    self.enabled = args.enabled == nil or args.enabled
 
     if args.lyrics_dir ~= nil then
         self.lyrics_dir = args.lyrics_dir

--- a/rmpcd/src/lua/builtin/notify.lua
+++ b/rmpcd/src/lua/builtin/notify.lua
@@ -36,9 +36,9 @@ end
 local function notify_debounced(_new_song, _with_album_art, _album_art_path) end
 
 M.setup = function(self, args)
-    self.with_album_art = (args.with_album_art ~= nil) and args.with_album_art or true
+    self.with_album_art = args.with_album_art == nil or args.with_album_art
     self.album_art_path = args.album_art_path or "/tmp/rmpcd-notify-album-art"
-    self.enabled = (args.enabled ~= nil) and args.enabled or true
+    self.enabled = args.enabled == nil or args.enabled
 
     local notify_send = util.which("notify-send")
     if not notify_send then
@@ -63,7 +63,7 @@ M.song_change = function(self, _old_song, new_song)
         return
     end
 
-    notify_debounced(new_song, self.with_album_art or true, self.album_art_path)
+    notify_debounced(new_song, self.with_album_art, self.album_art_path)
 end
 
 M.subscribed_channels = { "rmpcd.notify" }


### PR DESCRIPTION
## Description

Setting `enabled = false` on the notify or lyrics builtin does nothing, and neither does `with_album_art = false` on notify. The cause is the and-or defaulting idiom in setup; the commit message has the truth table. lastfm additionally read enabled from the wrong key and never consulted the flag in its playback callbacks, so it kept scrobbling regardless.

How easy is this trap to hit? A stub wrote `ART and nil or "no pic"` and reported missing art while art was present - in the test harness of the external review that verified this very fix.

Quick check after merge: `enabled = false` on lastfm now means no scrobbles and no now-playing updates across a song change.

### Related issues

None filed.

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed) - behavior now matches what the docs already imply
- [x] Changelog has been updated - rmpcd changes are not tracked in the rmpc changelog