### PR TITLE
feat(directories): blacklist folders from the browser pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `directories_hidden_dirs` config option to hide directories with the given names from the
+  `Directories` pane
 - Added `current` option to `Save()` keybind to save the currently playing song
 - Added a new vertical volume slider pane.
 - **Breaking** `ExternalCommand` can now have arguments supplied at runtime. This will break your

--- a/assets/example_config.ron
+++ b/assets/example_config.ron
@@ -26,6 +26,7 @@
     ignore_leading_the: false,
     browser_song_sort: [Disc, Track, Artist, Title],
     directories_sort: SortFormat(group_by_type: true, reverse: false),
+    directories_hidden_dirs: [],
     auto_open_downloads: true,
     quit_closes_modal: false,
     queue_disable_current_item_style_timeout_ms: None,

--- a/rmpc/src/config/mod.rs
+++ b/rmpc/src/config/mod.rs
@@ -84,6 +84,7 @@ pub struct Config {
     pub browser_song_sort: Arc<SortOptions>,
     pub show_playlists_in_browser: ShowPlaylistsMode,
     pub directories_sort: Arc<SortOptions>,
+    pub directories_hidden_dirs: Arc<Vec<String>>,
     pub cava: Cava,
     pub auto_open_downloads: bool,
     pub extra_yt_dlp_args: Vec<String>,
@@ -156,6 +157,7 @@ pub struct ConfigFile {
     pub browser_song_sort: Vec<SongPropertyFile>,
     pub show_playlists_in_browser: ShowPlaylistsMode,
     pub directories_sort: SortModeFile,
+    pub directories_hidden_dirs: Vec<String>,
     pub cava: CavaFile,
     pub extra_yt_dlp_args: Vec<String>,
     pub auto_open_downloads: bool,
@@ -232,6 +234,7 @@ impl Default for ConfigFile {
             reflect_changes_to_playlist: false,
             cava: CavaFile::default(),
             show_playlists_in_browser: ShowPlaylistsMode::default(),
+            directories_hidden_dirs: Vec::new(),
             extra_yt_dlp_args: Vec::new(),
             auto_open_downloads: true,
             duration_format: "%m:%S".to_string(),
@@ -339,6 +342,7 @@ impl ConfigFile {
                 Arc::new(arr.into_iter().map(|v| tilde_expand(&v).into_owned()).collect_vec())
             }),
             show_playlists_in_browser: self.show_playlists_in_browser,
+            directories_hidden_dirs: Arc::new(self.directories_hidden_dirs),
             browser_song_sort: Arc::new(SortOptions {
                 mode: SortMode::Format(
                     self.browser_song_sort.iter().cloned().map(SongProperty::from).collect_vec(),

--- a/rmpc/src/ui/dir_or_song.rs
+++ b/rmpc/src/ui/dir_or_song.rs
@@ -84,6 +84,10 @@ impl DirOrSong {
         }
     }
 
+    pub fn is_hidden_dir(&self, hidden: &[String]) -> bool {
+        matches!(self, DirOrSong::Dir { name, playlist: false, .. } if hidden.iter().any(|h| h == name))
+    }
+
     pub fn last_modified(&self) -> chrono::DateTime<chrono::Utc> {
         match self {
             DirOrSong::Dir { last_modified, .. } => *last_modified,
@@ -1006,5 +1010,21 @@ mod ordtest {
             Ordering::Less,
             "transitivity requires: if a<b and b<c then a<c, but got ac={ac:?}"
         );
+    }
+
+    #[test]
+    fn is_hidden_dir_matches_dirs_by_leaf_name() {
+        let hidden = vec![".Trash-1000".to_string()];
+
+        // A directory whose leaf name is blacklisted is hidden.
+        assert!(dir(".Trash-1000").is_hidden_dir(&hidden));
+        // Other directories are kept.
+        assert!(!dir("Music").is_hidden_dir(&hidden));
+        // Songs are never hidden, even if their file matches.
+        assert!(!song(".Trash-1000", &[]).is_hidden_dir(&hidden));
+        // Playlists sharing the name are not hidden (blacklist targets folders).
+        assert!(!DirOrSong::playlist_name_only(".Trash-1000".to_string()).is_hidden_dir(&hidden));
+        // Empty blacklist hides nothing.
+        assert!(!dir(".Trash-1000").is_hidden_dir(&[]));
     }
 }

--- a/rmpc/src/ui/panes/directories.rs
+++ b/rmpc/src/ui/panes/directories.rs
@@ -52,12 +52,14 @@ impl Pane for DirectoriesPane {
         if !self.initialized {
             let sort = ctx.config.directories_sort.clone();
             let playlist_display_mode = ctx.config.show_playlists_in_browser;
+            let hidden_dirs = ctx.config.directories_hidden_dirs.clone();
             ctx.query().id(INIT).replace_id(INIT).target(PaneType::Directories).query(
                 move |client| {
                     let result = client
                         .lsinfo(None)?
                         .into_iter()
                         .filter_map(|v| v.into_dir_or_song(playlist_display_mode))
+                        .filter(|v| !v.is_hidden_dir(&hidden_dirs))
                         .sorted_by(|a, b| a.with_custom_sort(&sort).cmp(&b.with_custom_sort(&sort)))
                         .collect::<Vec<_>>();
                     Ok(MpdQueryResult::DirOrSong { data: result, path: None })
@@ -74,12 +76,14 @@ impl Pane for DirectoriesPane {
             UiEvent::Database => {
                 let sort = ctx.config.directories_sort.clone();
                 let playlist_display_mode = ctx.config.show_playlists_in_browser;
+                let hidden_dirs = ctx.config.directories_hidden_dirs.clone();
                 ctx.query().id(INIT).replace_id(INIT).target(PaneType::Directories).query(
                     move |client| {
                         let result = client
                             .lsinfo(None)?
                             .into_iter()
                             .filter_map(|v| v.into_dir_or_song(playlist_display_mode))
+                            .filter(|v| !v.is_hidden_dir(&hidden_dirs))
                             .sorted_by(|a, b| {
                                 a.with_custom_sort(&sort).cmp(&b.with_custom_sort(&sort))
                             })
@@ -185,6 +189,7 @@ impl BrowserPane<DirOrSong> for DirectoriesPane {
 
                 let is_playlist = *is_playlist;
                 let playlist_display_mode = ctx.config.show_playlists_in_browser;
+                let hidden_dirs = ctx.config.directories_hidden_dirs.clone();
 
                 let sort = ctx.config.directories_sort.clone();
                 ctx.query()
@@ -212,6 +217,7 @@ impl BrowserPane<DirOrSong> for DirectoriesPane {
                             .0
                             .into_iter()
                             .filter_map(|v| v.into_dir_or_song(playlist_display_mode))
+                            .filter(|v| !v.is_hidden_dir(&hidden_dirs))
                             .sorted_by(|a, b| {
                                 a.with_custom_sort(&sort).cmp(&b.with_custom_sort(&sort))
                             })


### PR DESCRIPTION
Adds a `browser_hidden_dirs` config option: a list of directory names to hide from the Directories browser pane.

Names are matched against each directory's leaf name at any depth, so e.g. `browser_hidden_dirs: [".Trash-1000"]` keeps trash folders out of the browser no matter where they appear in the library. Only filesystem directories are filtered — songs and playlists sharing a hidden name are untouched.

- New `Vec<String>` option in `ConfigFile`, defaults to empty (no behavior change unless set)
- Filtering applied at root listing, database refresh, and nested `fetch_data`
- Example config updated, changelog entry added, unit test for the leaf-name matching
