### PR TITLE
fix: rmpcd - restore channel subscriptions after reconnect

### DIFF
--- a/rmpcd/src/async_client.rs
+++ b/rmpcd/src/async_client.rs
@@ -4,7 +4,6 @@ use std::{
     sync::{
         Arc,
         Mutex as StdMutex,
-        PoisonError,
         atomic::{AtomicU8, Ordering},
     },
     thread,
@@ -52,16 +51,14 @@ struct Shared {
     #[debug(skip)]
     interrupt_stream: StdMutex<Option<MpdStream>>,
     idle_state: AtomicU8,
-    /// Channels this client is subscribed to. MPD forgets subscriptions when
-    /// the connection goes away, so they have to be restored on reconnect.
-    subscriptions: StdMutex<HashSet<String>>,
+    subscribed_channels: StdMutex<HashSet<String>>,
 }
 
 fn resubscribe(client: &mut MpdClient, shared: &Shared) {
     let channels: Vec<String> = shared
-        .subscriptions
+        .subscribed_channels
         .lock()
-        .unwrap_or_else(PoisonError::into_inner)
+        .expect("Failed to lock subscribed channels")
         .iter()
         .cloned()
         .collect();
@@ -218,7 +215,7 @@ impl AsyncClient {
         let shared = Arc::new(Shared {
             interrupt_stream: StdMutex::new(None),
             idle_state: AtomicU8::new(IDLE_STATE_NOT_IDLE),
-            subscriptions: StdMutex::new(HashSet::new()),
+            subscribed_channels: StdMutex::new(HashSet::new()),
         });
 
         let init =
@@ -276,13 +273,13 @@ impl AsyncClient {
     pub async fn subscribe(&self, channel: String) -> Result<(), MpdError> {
         let shared = Arc::clone(&self.shared);
 
-        // Recorded inside the closure so it happens on the worker thread, in the
-        // same step as the command. Doing it after run() returns leaves a window
-        // where a reconnect can snapshot the set before the caller records, and
-        // run()'s timeout can abandon a command that later executes anyway.
         self.run(move |c| {
             c.subscribe(&channel)?;
-            shared.subscriptions.lock().unwrap_or_else(PoisonError::into_inner).insert(channel);
+            shared
+                .subscribed_channels
+                .lock()
+                .expect("Failed to lock subscribed channels")
+                .insert(channel);
             Ok(())
         })
         .await
@@ -293,7 +290,11 @@ impl AsyncClient {
 
         self.run(move |c| {
             c.unsubscribe(&channel)?;
-            shared.subscriptions.lock().unwrap_or_else(PoisonError::into_inner).remove(&channel);
+            shared
+                .subscribed_channels
+                .lock()
+                .expect("Failed to lock subscribed channels")
+                .remove(&channel);
             Ok(())
         })
         .await

--- a/rmpcd/src/async_client.rs
+++ b/rmpcd/src/async_client.rs
@@ -1,8 +1,10 @@
 use std::{
+    collections::HashSet,
     io::Write,
     sync::{
         Arc,
         Mutex as StdMutex,
+        PoisonError,
         atomic::{AtomicU8, Ordering},
     },
     thread,
@@ -50,6 +52,26 @@ struct Shared {
     #[debug(skip)]
     interrupt_stream: StdMutex<Option<MpdStream>>,
     idle_state: AtomicU8,
+    /// Channels this client is subscribed to. MPD forgets subscriptions when
+    /// the connection goes away, so they have to be restored on reconnect.
+    subscriptions: StdMutex<HashSet<String>>,
+}
+
+fn resubscribe(client: &mut MpdClient, shared: &Shared) {
+    let channels: Vec<String> = shared
+        .subscriptions
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .iter()
+        .cloned()
+        .collect();
+
+    for channel in channels {
+        match client.subscribe(&channel) {
+            Ok(()) => info!(channel, "Resubscribed to channel"),
+            Err(err) => error!(channel, error = ?err, "Failed to resubscribe to channel"),
+        }
+    }
 }
 
 fn preempt_idle(shared: &Shared) {
@@ -162,6 +184,7 @@ fn worker_loop(
                                     }
                                 }
                                 info!("Reconnected to MPD");
+                                resubscribe(&mut client, &shared);
                                 on_reconnect();
                                 continue 'outer;
                             }
@@ -195,6 +218,7 @@ impl AsyncClient {
         let shared = Arc::new(Shared {
             interrupt_stream: StdMutex::new(None),
             idle_state: AtomicU8::new(IDLE_STATE_NOT_IDLE),
+            subscriptions: StdMutex::new(HashSet::new()),
         });
 
         let init =
@@ -247,6 +271,32 @@ impl AsyncClient {
             .await
             .map_err(|err| MpdError::Generic(format!("Timed out waiting for response: {err}")))?
             .map_err(|err| MpdError::Generic(format!("Worker dropped response: {err}")))?
+    }
+
+    pub async fn subscribe(&self, channel: String) -> Result<(), MpdError> {
+        let shared = Arc::clone(&self.shared);
+
+        // Recorded inside the closure so it happens on the worker thread, in the
+        // same step as the command. Doing it after run() returns leaves a window
+        // where a reconnect can snapshot the set before the caller records, and
+        // run()'s timeout can abandon a command that later executes anyway.
+        self.run(move |c| {
+            c.subscribe(&channel)?;
+            shared.subscriptions.lock().unwrap_or_else(PoisonError::into_inner).insert(channel);
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn unsubscribe(&self, channel: String) -> Result<(), MpdError> {
+        let shared = Arc::clone(&self.shared);
+
+        self.run(move |c| {
+            c.unsubscribe(&channel)?;
+            shared.subscriptions.lock().unwrap_or_else(PoisonError::into_inner).remove(&channel);
+            Ok(())
+        })
+        .await
     }
 
     pub fn skip_to_idle(&self) {

--- a/rmpcd/src/lua/lualib/mpd/c2c.rs
+++ b/rmpcd/src/lua/lualib/mpd/c2c.rs
@@ -11,7 +11,7 @@ pub fn init(lua: &Lua, mpd: &Table, client: &Arc<AsyncClient>) -> Result<()> {
     let subscribe = lua.create_async_function(move |lua, channel: String| {
         let client = Arc::clone(&c);
         async move {
-            match client.run(move |c| c.subscribe(&channel)).await {
+            match client.subscribe(channel).await {
                 Ok(()) => true.into_lua_multi(&lua),
                 Err(err) => {
                     tracing::error!(err = ?err, "Failed to subscribe to a channel");
@@ -25,7 +25,7 @@ pub fn init(lua: &Lua, mpd: &Table, client: &Arc<AsyncClient>) -> Result<()> {
     let unsubscribe = lua.create_async_function(move |lua, channel: String| {
         let client = Arc::clone(&c);
         async move {
-            match client.run(move |c| c.unsubscribe(&channel)).await {
+            match client.unsubscribe(channel).await {
                 Ok(()) => true.into_lua_multi(&lua),
                 Err(err) => {
                     tracing::error!(err = ?err, "Failed to unsubscribe from a channel");

--- a/rmpcd/src/lua/types/rmpcd.lua
+++ b/rmpcd/src/lua/types/rmpcd.lua
@@ -21,7 +21,7 @@
 ---@field message fun(self, channel: string, message: string)|nil
 ---@field idle_event fun(self, event: IdleEvent)|nil
 ---@field shutdown fun(self)|nil
----@field reconnect fun(self)|nil
+---@field reconnect fun(self)|nil Called after the connection to MPD is re-established. Channels from `subscribed_channels` are resubscribed before this runs.
 
 ---@type RmpcdGlobal
 ---@diagnostic disable-next-line: lowercase-global

--- a/rmpcd/src/main.rs
+++ b/rmpcd/src/main.rs
@@ -242,8 +242,7 @@ async fn run() -> Result<()> {
         plugin_store.all().flat_map(|p| &p.subscribed_channels).chain(subscribed_channels.iter())
     {
         info!(channel, "Subscribing to channel");
-        let channel = channel.clone();
-        mpd.run(move |c| c.subscribe(&channel)).await?;
+        mpd.subscribe(channel.clone()).await?;
     }
 
     let status = mpd.run(|c| c.get_status()).await?;


### PR DESCRIPTION
## Description
MPD maintains channel subscriptions per connection. When the connection drops, every subscription made on it is gone. `rmpcd` only subscribes in one loop at `startup`, (`main.rs`, right after `mpd.connect`). It never resubscribes again.

`async_client.rs` recovers the connection and `PluginEvent::Reconnect` is sent to Lua plugins, but subscribe commands are not re-issued.

So after any / every reconnect it results in `rmpcd` connected and appearing healthy, but every plugin channel is unsubscribed.

```sh
RPID=$(systemctl --user show -p MainPID --value rmpcd.service)
PORT=$(ss -tanp | grep "pid=$RPID" | grep -oP '127\.0\.0\.1:\K[0-9]+(?=\s)' | head -1)
sudo ss -K src 127.0.0.1:$PORT dst 127.0.0.1:6600
sleep 5
mpc channels
```

Before the patch, `rmpcd` reconnects and `mpc channels` comes back empty:

```
WARN  Lost MPD connection, attempting reconnect error=Software caused connection abort (os error 103)
INFO  Reconnected to MPD
```

```
$ mpc channels
$ mpc sendmessage rmpcd.lyrics test
MPD error: nobody is subscribed to this channel
```

After the patch all five channels are listed again and `sendmessage` works:

```
WARN  Lost MPD connection, attempting reconnect error=Software caused connection abort (os error 103)
INFO  Reconnected to MPD
INFO  Resubscribed to channel channel="rmpcd.lastfm"
INFO  Resubscribed to channel channel="rmpcd.playcount"
INFO  Resubscribed to channel channel="rmpcd.notify"
INFO  Resubscribed to channel channel="rmpcd.lyrics"
INFO  Resubscribed to channel channel="rmpcd.favorites"
```
cargo +nightly fmt --all --check clean, cargo clippy -p rmpcd --release clean.
Assisted-by Claude Opus 5

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [ ] Changelog has been updated