### PR TITLE
fix: rmpcd - connect to MPD before loading plugins

### DIFF
--- a/rmpcd/src/async_client.rs
+++ b/rmpcd/src/async_client.rs
@@ -92,7 +92,11 @@ fn worker_loop(
         let mut shutting_down = false;
         let reconnect_base_delay = Duration::from_millis(500);
         let reconnect_max_delay = Duration::from_secs(16);
-        let mut skip_recv = false;
+        // Start in idle rather than waiting for a first command. MPD closes a
+        // connected client that is neither idle nor sending after
+        // connection_timeout (60s by default), and nothing guarantees a command
+        // arrives before then now that plugins load after the connect.
+        let mut skip_recv = true;
 
         'outer: while !shutting_down {
             if !skip_recv {

--- a/rmpcd/src/main.rs
+++ b/rmpcd/src/main.rs
@@ -213,6 +213,15 @@ async fn run() -> Result<()> {
         error!(err = ?err, "Failed to eject Lua type definitions");
     }
 
+    let address = lua_config.get::<String>("address")?;
+    let password = lua_config.get::<Option<String>>("password")?;
+    let (address, password) = rmpc_mpd::address::resolve(None, None, address, password);
+    let subscribed_channels =
+        lua_config.get::<Option<Vec<String>>>("subscribed_channels")?.unwrap_or_default();
+    let enable_keepalive = lua_config.get::<Option<bool>>("enable_keepalive")?.unwrap_or(true);
+
+    mpd.connect(address, password, enable_keepalive).await?;
+
     let mut plugin_store = PluginStore::new();
     let mut lockfile = Lockfile::read_or_default().await?;
     for plugin in plugins.read().await.iter() {
@@ -228,15 +237,6 @@ async fn run() -> Result<()> {
         }
     }
     lockfile.write().await?;
-
-    let address = lua_config.get::<String>("address")?;
-    let password = lua_config.get::<Option<String>>("password")?;
-    let (address, password) = rmpc_mpd::address::resolve(None, None, address, password);
-    let subscribed_channels =
-        lua_config.get::<Option<Vec<String>>>("subscribed_channels")?.unwrap_or_default();
-    let enable_keepalive = lua_config.get::<Option<bool>>("enable_keepalive")?.unwrap_or(true);
-
-    mpd.connect(address, password, enable_keepalive).await?;
 
     for channel in
         plugin_store.all().flat_map(|p| &p.subscribed_channels).chain(subscribed_channels.iter())


### PR DESCRIPTION
Plugins are loaded, and their `setup()` runs, before `mpd.connect()`. Any MPD command a plugin issues from `setup()` runs with no connection and dies on `AsyncClient`'s 10 second deadline:
```
    Failed to get sticker err=Timed out waiting for response: deadline has elapsed
```
Every such call adds 10 seconds to startup and hands the plugin a wrong answer.
A plugin that ranks a playlist by a sticker gets a zero for every song.

Measured on a config with one such plugin holding a single favorite:

```
before:  rmpcd started in 10.26s      (with the timeout above logged)
after:   rmpcd started in 297.52ms    (sticker read succeeds)
```

Nothing between `eval_config` and the `plugin loop` needs the connection, and the address, password and keepalive settings are readable from `lua_config` as soon as the config is evaluated. Move the `connect` above the `plugin loop`. The `subscribe loop` stays where it is because it needs `plugin_store`.

Moving the `connect` earlier widens the gap between connecting and the first command from milliseconds to however long plugin loading takes, which on a first run includes fetching plugins. The worker only enters MPD idle after handling a command, and MPD closes a client that is neither idle nor sending after `connection_timeout`, 60 seconds by default. So a config whose plugins issue no MPD traffic in `setup()` could reach the subscribe loop on a dead socket. Starting the worker in idle closes that window, and the smaller one that already existed before this change.

Tested with a plugin whose `setup()` blocks 70 seconds and sends nothing. With the old initializer startup aborts at the subscribe loop on an `EOF` from MPD, while the worker independently logs a broken pipe on its way into idle; with the worker starting in idle, startup completes and the channel is subscribed.

Worth noting CI will not exercise any of this. `default-members` is `["rmpc"]` and none of the cargo invocations in `ci.yml` pass `-p` or `--workspace`, so `rmpcd` is never built there. Checked locally instead: `cargo test -p rmpcd`, `cargo +nightly fmt --all -- --check`, and `cargo clippy --workspace --all-targets -- -D warnings`.

Assisted-by Claude Opus 5