### PR TITLE
fix: rmpcd - same channel on multiple plugins

### DIFF
--- a/rmpcd/src/async_client.rs
+++ b/rmpcd/src/async_client.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashSet,
     io::Write,
     sync::{
         Arc,
@@ -21,6 +20,8 @@ use tokio::{
     time::timeout,
 };
 use tracing::{error, info, trace, warn};
+
+use crate::subscribed_channels::SubscribedChannels;
 
 pub type MpdClient = rmpc_mpd::client::Client<'static>;
 pub type MpdError = rmpc_mpd::errors::MpdError;
@@ -51,19 +52,11 @@ struct Shared {
     #[debug(skip)]
     interrupt_stream: StdMutex<Option<MpdStream>>,
     idle_state: AtomicU8,
-    subscribed_channels: StdMutex<HashSet<String>>,
+    subscribed_channels: SubscribedChannels,
 }
 
 fn resubscribe(client: &mut MpdClient, shared: &Shared) {
-    let channels: Vec<String> = shared
-        .subscribed_channels
-        .lock()
-        .expect("Failed to lock subscribed channels")
-        .iter()
-        .cloned()
-        .collect();
-
-    for channel in channels {
+    for channel in shared.subscribed_channels.list() {
         match client.subscribe(&channel) {
             Ok(()) => info!(channel, "Resubscribed to channel"),
             Err(err) => error!(channel, error = ?err, "Failed to resubscribe to channel"),
@@ -219,7 +212,7 @@ impl AsyncClient {
         let shared = Arc::new(Shared {
             interrupt_stream: StdMutex::new(None),
             idle_state: AtomicU8::new(IDLE_STATE_NOT_IDLE),
-            subscribed_channels: StdMutex::new(HashSet::new()),
+            subscribed_channels: SubscribedChannels::default(),
         });
 
         let init =
@@ -278,12 +271,18 @@ impl AsyncClient {
         let shared = Arc::clone(&self.shared);
 
         self.run(move |c| {
-            c.subscribe(&channel)?;
-            shared
-                .subscribed_channels
-                .lock()
-                .expect("Failed to lock subscribed channels")
-                .insert(channel);
+            match shared.subscribed_channels.increment(&channel) {
+                1 => {
+                    if let Err(err) = c.subscribe(&channel) {
+                        shared.subscribed_channels.decrement(&channel);
+                        return Err(err);
+                    }
+                }
+                count => {
+                    trace!(channel, count, "Channel already subscribed to, increased refcount");
+                }
+            }
+
             Ok(())
         })
         .await
@@ -293,12 +292,21 @@ impl AsyncClient {
         let shared = Arc::clone(&self.shared);
 
         self.run(move |c| {
-            c.unsubscribe(&channel)?;
-            shared
-                .subscribed_channels
-                .lock()
-                .expect("Failed to lock subscribed channels")
-                .remove(&channel);
+            match shared.subscribed_channels.decrement(&channel) {
+                Some(0) => {
+                    if let Err(err) = c.unsubscribe(&channel) {
+                        shared.subscribed_channels.increment(&channel);
+                        return Err(err);
+                    }
+                }
+                Some(remaining) => {
+                    trace!(channel, remaining, "Channel still has other subscribers");
+                }
+                None => {
+                    warn!(channel, "Not subscribed to channel, ignoring");
+                }
+            }
+
             Ok(())
         })
         .await

--- a/rmpcd/src/main.rs
+++ b/rmpcd/src/main.rs
@@ -36,6 +36,7 @@ mod mpd_ext;
 mod mpris;
 mod paths;
 mod pkg;
+mod subscribed_channels;
 
 #[derive(Parser, Debug)]
 #[command(version, about)]

--- a/rmpcd/src/subscribed_channels.rs
+++ b/rmpcd/src/subscribed_channels.rs
@@ -1,0 +1,109 @@
+use std::{collections::HashMap, sync::Mutex as StdMutex};
+
+#[derive(Debug, Default)]
+pub(crate) struct SubscribedChannels {
+    channels: StdMutex<HashMap<String, usize>>,
+}
+
+impl SubscribedChannels {
+    pub(crate) fn increment(&self, channel: &str) -> usize {
+        let mut channels = self.channels.lock().expect("Failed to lock subscribed channels");
+        let count = channels.entry(channel.to_owned()).or_insert(0);
+        *count += 1;
+        *count
+    }
+
+    pub(crate) fn decrement(&self, channel: &str) -> Option<usize> {
+        let mut channels = self.channels.lock().expect("Failed to lock subscribed channels");
+        let count = channels.get_mut(channel)?;
+
+        *count = count.saturating_sub(1);
+        let remaining = *count;
+        if remaining == 0 {
+            channels.remove(channel);
+        }
+
+        Some(remaining)
+    }
+
+    pub(crate) fn list(&self) -> Vec<String> {
+        let channels = self.channels.lock().expect("Failed to lock subscribed channels");
+        channels.keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SubscribedChannels;
+
+    #[test]
+    fn first_increment_returns_one() {
+        let channels = SubscribedChannels::default();
+
+        assert_eq!(channels.increment("a"), 1);
+    }
+
+    #[test]
+    fn repeat_increment() {
+        let channels = SubscribedChannels::default();
+
+        assert_eq!(channels.increment("a"), 1);
+        assert_eq!(channels.increment("a"), 2);
+        assert_eq!(channels.increment("a"), 3);
+    }
+
+    #[test]
+    fn distinct_channels_count_independently() {
+        let channels = SubscribedChannels::default();
+        channels.increment("a");
+
+        assert_eq!(channels.increment("a"), 2);
+        assert_eq!(channels.increment("b"), 1);
+    }
+
+    #[test]
+    fn decrement_returns_remaining() {
+        let channels = SubscribedChannels::default();
+        channels.increment("a");
+        channels.increment("a");
+
+        assert_eq!(channels.decrement("a"), Some(1));
+        assert_eq!(channels.list(), vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn last_decrement_returns_zero_and_removes_key() {
+        let channels = SubscribedChannels::default();
+        channels.increment("a");
+
+        assert_eq!(channels.decrement("a"), Some(0));
+        assert!(channels.list().is_empty());
+    }
+
+    #[test]
+    fn decrement_unknown_channel_returns_none() {
+        let channels = SubscribedChannels::default();
+        channels.increment("a");
+
+        assert_eq!(channels.decrement("b"), None);
+        assert_eq!(channels.list(), vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn decrement_below_zero_returns_none() {
+        let channels = SubscribedChannels::default();
+        channels.increment("a");
+
+        assert_eq!(channels.decrement("a"), Some(0));
+        assert_eq!(channels.decrement("a"), None);
+    }
+
+    #[test]
+    fn increment_after_decrement_to_zero() {
+        let channels = SubscribedChannels::default();
+        channels.increment("a");
+        channels.decrement("a");
+
+        assert_eq!(channels.increment("a"), 1);
+    }
+}


### PR DESCRIPTION
## Description

A bit of continuation on work on correcting the MPD channel subscription that was done by @Strykar in https://github.com/mierak/rmpc/pull/1078.

This essentially refcounts the channel subscriptions since there is nothing stopping multiple plugins from sharing the same channel and before this change, rmpcd would fail to start when the second plugin initializes. The channel is only subscribed to when subscription is asked for the first time. Likewise, it is only unsubscribed from when there are no more subscriptions. Otherwise the sub/unsub are simple noops.

One issue remaining is when a plugin acts badly and repeatedly unsubscribes from a channel that another plugin is using, but that is an ok limitation in my book.

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
