### PR TITLE
feat: use RealUri's extension when the song URI has none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `FileExtension` falls back to the underlying file's extension (`RealUri`, MPD 0.25) for
+  songs inside a CUE sheet
 - `directories_hidden_dirs` config option to hide directories with the given names from the
   `Directories` pane
 - Added `ActiveOutputs` and `ActiveOutput` status properties showing the enabled outputs

--- a/rmpc/src/ui/song_ext.rs
+++ b/rmpc/src/ui/song_ext.rs
@@ -306,7 +306,13 @@ impl SongExt for Song {
     }
 
     fn file_ext(&self) -> Option<Cow<'_, str>> {
-        std::path::Path::new(&self.file).extension().map(|ext| ext.to_string_lossy())
+        std::path::Path::new(&self.file).extension().map(|ext| ext.to_string_lossy()).or_else(
+            || {
+                self.metadata.get("realuri").and_then(|uri| {
+                    std::path::Path::new(uri.first()).extension().map(|ext| ext.to_string_lossy())
+                })
+            },
+        )
     }
 
     fn format<'song>(
@@ -663,5 +669,45 @@ impl SongExt for Song {
         }
 
         Some(line)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use rmpc_mpd::commands::Song;
+    use rstest::rstest;
+
+    use super::SongExt;
+
+    fn song(file: &str, realuri: Option<&str>) -> Song {
+        let mut metadata = HashMap::new();
+        if let Some(realuri) = realuri {
+            metadata.insert("realuri".to_string(), realuri.into());
+        }
+        Song {
+            id: 1,
+            file: file.to_string(),
+            duration: None,
+            metadata,
+            last_modified: chrono::Utc::now(),
+            added: None,
+        }
+    }
+
+    #[rstest]
+    #[case("album/track.flac", None, Some("flac"))]
+    // relative RealUri, the form lsinfo and search report
+    #[case("album/album.cue/track0007", Some("../01 - Title.flac"), Some("flac"))]
+    // absolute RealUri, the form currentsong and playlistinfo report
+    #[case("album/album.cue/track0007", Some("/mnt/music/album/01 - Title.flac"), Some("flac"))]
+    #[case("album/track.mp3", Some("../01 - Title.flac"), Some("mp3"))]
+    #[case("album/album.cue/track0007", None, None)]
+    #[case("album/album.cue/track0007", Some("../CDImage"), None)]
+    fn file_ext(#[case] file: &str, #[case] realuri: Option<&str>, #[case] expected: Option<&str>) {
+        let song = song(file, realuri);
+
+        assert_eq!(song.file_ext().as_deref(), expected);
     }
 }


### PR DESCRIPTION
### Description

Tracks inside a CUE sheet have a virtual URI (`album.cue/track0001`)
with no extension, so `FileExtension` resolves to nothing and extension
driven theme formats cannot tell the codec. The same holds for any
playlist MPD exposes as a directory; CUE sheets are the common case and
the one verified here. MPD reports the underlying file as
`RealUri` starting with 0.25; this PR makes `file_ext()` fall back to
that file's extension. The change covers both the `FileExtension`
property and extension sorting, which route through the same helper.
The URI's own extension always wins when present, and nothing changes
when the server sends no `RealUri`.

Scope decision: `Filename` stays the virtual name (`track0007`) on
purpose. The extension answers "what codec", the virtual name answers
"which track"; a `Filename` fallback would compose names for files
whose per track identity does not exist on disk.

Notes on the server side, verified against an MPD 0.24.15 build
carrying the RealUri commit:

- `lsinfo` and `search` report `RealUri` only for playlist backed
  tracks, as a path relative to the virtual directory
  (`../01 - Title.flac`).
- `currentsong` and `playlistinfo` report `RealUri` for every database
  song, as an absolute filesystem path. The fallback is unaffected
  (plain songs keep their own extension), but themes using
  `Other("realuri")` will render that path for every queue song, and
  the song info modal shows a `realuri` row there. The key arrives
  lowercased, so `Other("realuri")`, not `Other("RealUri")`.

Both wire forms are pinned in the tests, along with a
RealUri-without-extension case and the plain song and URI-wins cases.

Activation framing: no released MPD sends `RealUri`. The server commit
(3dfbbeeb) was merged to MPD master on 2026-06-17 and is slated for
0.25. Verified end to end against 0.24.15 plus that 39 line commit: cue
tracks report the underlying `.flac`, and an extension driven theme
lights its FLAC indicator instead of a CUE fallback with no theme
edits.

Assisted by Claude Fable 5

### Related issues

None found for RealUri or CUE handling.

### Checklist

- [x] All tests passed (six new rstest cases: plain song, relative and
      absolute RealUri forms, URI extension wins, no extension anywhere,
      RealUri without extension)
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] Documentation has been updated (companion PR: rmpc-org/rmpc-org.github.io#78)
- [x] Changelog has been updated
