### PR TITLE
fix: sixel img disappearing in tmux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ keybinds
 - The borders of browser panes are nolonger affected by the scrollbar track being set
 - Adding a directory to the queue now orders its songs by `directories_sort` instead of relying on MPD's default order
 - `addyt` sometimes failing when files with identical file name already exists it the dir
+- Sixel image disappearing when switching tmux panes
 
 ## [0.11.0] - 2026-02-01
 

--- a/rmpc/src/shared/terminal/mod.rs
+++ b/rmpc/src/shared/terminal/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::LazyLock;
+use std::sync::{LazyLock, OnceLock};
 
 use anyhow::Result;
 use crossterm::{
@@ -38,9 +38,10 @@ pub struct Terminal {
     emulator: Emulator,
     kitty_keyboard_protocol: bool,
     kitty_graphics: LazyLock<bool>,
-    sixel: LazyLock<bool>,
+    pub sixel: LazyLock<bool>,
     ueberzug_x11: LazyLock<bool>,
     ueberzug_wayland: LazyLock<bool>,
+    pub resolved_backend: OnceLock<ImageMethod>,
     zellij: bool,
 }
 
@@ -68,6 +69,7 @@ impl Terminal {
                 .inspect_err(|err| log::error!(err:?; "Failed to determine kitty graphics support"))
                 .unwrap_or_default()
         });
+        let resolved_backend = OnceLock::new();
 
         let ueberzug_x11: LazyLock<bool> = LazyLock::new(features::detect_ueberzug_x11);
         let ueberzug_wayland: LazyLock<bool> = LazyLock::new(features::detect_ueberzug_wayland);
@@ -81,6 +83,7 @@ impl Terminal {
             ueberzug_x11,
             ueberzug_wayland,
             zellij,
+            resolved_backend,
         }
     }
 
@@ -138,6 +141,7 @@ impl Terminal {
             ImageMethodFile::Auto => self.autodetect_image_backend().into(),
         };
 
+        self.resolved_backend.get_or_init(|| result);
         log::debug!(requested_backend:?, resolved_backend:? = result, tmux = *IS_TMUX; "Resolved image backend");
 
         result

--- a/rmpc/src/shared/tmux.rs
+++ b/rmpc/src/shared/tmux.rs
@@ -325,7 +325,14 @@ macro_rules! tmux_write {
 }
 macro_rules! tmux_write_bytes {
     ( $w:ident, $data:expr ) => {{
-        if *crate::tmux::IS_TMUX {
+        use crate::{config::album_art::ImageMethod, shared::terminal::TERMINAL};
+        let skip_passthrough = if let Some(backend) = TERMINAL.resolved_backend.get() {
+            matches!(backend, ImageMethod::Sixel) && *TERMINAL.sixel
+        } else {
+            false
+        };
+
+        if *crate::tmux::IS_TMUX && !skip_passthrough {
             $w.write_all("\x1bPtmux;".as_bytes())?;
 
             for b in $data {

--- a/rmpc/src/ui/image/sixel.rs
+++ b/rmpc/src/ui/image/sixel.rs
@@ -44,6 +44,15 @@ impl Backend for Sixel {
         mut data: Self::EncodedData,
         _ctx: &Ctx,
     ) -> Result<()> {
+        let tmux = tmux::is_inside_tmux();
+        let limit = *tmux::INPUT_BUFFER_LIMIT;
+        if tmux && data.content.len() > limit {
+            bail!(
+                "Image is {} bytes which is larger than your tmux's 'input-buffer-size'. Increase it and restart rmpc to display this image.",
+                data.content.len()
+            )
+        }
+
         log::debug!(bytes = data.content.len(); "transmitting data");
 
         // Adjust for tmux pane position if inside tmux
@@ -95,15 +104,10 @@ impl Backend for Sixel {
 
         let width = image.width();
         let height = image.height();
-        let tmux = tmux::is_inside_tmux();
 
         let mut buf = Vec::new();
 
-        if tmux {
-            write!(buf, "\x1bPtmux;\x1b\x1bP0;1;7q\"1;1;{};{}", image.width(), image.height())?;
-        } else {
-            write!(buf, "\x1bP0;1;7q\"1;1;{};{}", image.width(), image.height())?;
-        }
+        write!(buf, "\x1bP0;1;7q\"1;1;{};{}", image.width(), image.height())?;
 
         let image = image.to_rgba8();
         let quantized = NeuQuant::new(10, 256, image.as_raw());
@@ -132,24 +136,12 @@ impl Backend for Sixel {
                 repeat = 1;
             }
 
-            let limit = *tmux::INPUT_BUFFER_LIMIT;
-            if tmux && buf.len() > limit {
-                bail!(
-                    "Image is {} bytes which is larger than your tmux's 'input-buffer-size'. Increase it and restart rmpc to display this image.",
-                    buf.len()
-                )
-            }
-
             put_color(&mut buf, character, last_color.unwrap_or_default(), repeat)?;
 
             buf.push(if y % 6 == 5 { b'-' } else { b'$' });
         }
 
-        if tmux {
-            write!(buf, "\x1b\\\x1b\\")?;
-        } else {
-            write!(buf, "\x1b\\")?;
-        }
+        write!(buf, "\x1b\\")?;
 
         log::debug!(bytes = buf.len(), image_bytes = image.len(), elapsed:? = start.elapsed(); "encoded data");
         Ok(Data { content: VecDeque::from(buf), area: resized_area.area })


### PR DESCRIPTION
## Description

Skips tmux passthrough if and only if the resolved image backend == Sixel && DA1 for the underlying terminal reports sixel support

fixes https://github.com/mierak/rmpc/issues/1075

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
