### PR TITLE
fix: change MPD error command index to usize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ keybinds
 - Adding a directory to the queue now orders its songs by `directories_sort` instead of relying on MPD's default order
 - `addyt` sometimes failing when files with identical file name already exists it the dir
 - Sixel image disappearing when switching tmux panes
+- MPD's error no longer parsing command index into u8 which has insufficient space
 
 ## [0.11.0] - 2026-02-01
 

--- a/rmpc-mpd/src/errors.rs
+++ b/rmpc-mpd/src/errors.rs
@@ -136,7 +136,7 @@ impl std::str::FromStr for ErrorCode {
 #[derive(Debug, PartialEq)]
 pub struct MpdFailureResponse {
     pub code: ErrorCode,
-    pub command_list_index: u8,
+    pub command_list_index: usize,
     pub command: String,
     pub message: String,
 }

--- a/rmpc/src/shared/mpd_client_ext.rs
+++ b/rmpc/src/shared/mpd_client_ext.rs
@@ -183,7 +183,7 @@ impl<T: MpdClient + MpdCommand + ProtoClient> MpdClientExt for T {
             match self.read_ok() {
                 Ok(()) => i = items_len,
                 Err(MpdError::Mpd(err)) => {
-                    i += 1 + err.command_list_index as usize;
+                    i += 1 + err.command_list_index;
                     errors += 1;
                 }
                 err => err?,


### PR DESCRIPTION
## Description

### Related issues

fixes #1085

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
