### PR TITLE
fix: rmpcd - fetch album art for current song on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- rmpcd MPRIS not exposing album art for the song already playing at startup, only after the
+  first song change
 - `Bits()` reporting the channel count as bit depth during DSD playback. MPD formats DSD audio as
   `dsd64:2` or `384000:dsd:2`, neither of which parsed; DSD now reports its real sample rate,
   1 bit and the channel count, and the float bit depth marker (`f`) no longer breaks the other fields

--- a/rmpcd/src/main.rs
+++ b/rmpcd/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use rmpc_mpd::{
     commands::{IdleEvent, Status},
-    mpd_client::MpdClient,
+    mpd_client::{AlbumArtOrder, MpdClient},
 };
 use serde::Serialize;
 use serde_json::json;
@@ -22,6 +22,7 @@ use crate::{
     async_client::AsyncClient,
     ctx::Ctx,
     lua::{eval_config, plugin::PluginStore},
+    mpd_ext::MpdExt,
     paths::Paths,
     pkg::Lockfile,
 };
@@ -249,11 +250,18 @@ async fn run() -> Result<()> {
     let status = mpd.run(|c| c.get_status()).await?;
     let current_song = mpd.run(|c| c.get_current_song()).await?;
     let queue = mpd.run(|c| c.playlist_info()).await?.unwrap_or_default();
+    let album_art = match &current_song {
+        Some(song) => {
+            let uri = song.file.clone();
+            mpd.run(move |c| c.find_album_art(&uri, AlbumArtOrder::EmbeddedFirst)).await?
+        }
+        None => None,
+    };
     let ctx = Arc::new(RwLock::new(Ctx {
         current_song: current_song.clone(),
         status: status.clone(),
         queue,
-        album_art: None,
+        album_art,
         last_written_album_art_song_uri: None,
     }));
 


### PR DESCRIPTION
## Description

Reuse the same loop that runs on song change to populate Ctx.album_art at startup. Fixes the case where your mpris consumer shows no artwork for whatever track you had playing before you rebooted. 

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [ ] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [ ] Changelog has been updated

I'll add a changelog entry 