### PR TITLE
fix: album art double rendering on config reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ keybinds
 - Sixel image disappearing when switching tmux panes
 - Improve responsivness when cava cava is starting/quitting, especially when reloading config
 - MPD's error no longer parsing command index into u8 which has insufficient space
+- AlbumArt no longer double rendering on config reload
 
 ## [0.11.0] - 2026-02-01
 

--- a/rmpc/src/core/config_watcher.rs
+++ b/rmpc/src/core/config_watcher.rs
@@ -53,6 +53,7 @@ pub(crate) fn init(
     let config_directory2 = config_directory.clone();
 
     let mut theme_name = theme_name;
+    let mut error_modal_shown = false;
     let mut watcher = new_debouncer(
         Duration::from_millis(500),
         None,
@@ -81,6 +82,7 @@ pub(crate) fn init(
                 let config = match read_config_file(&config_path) {
                     Ok(cfg) => cfg,
                     Err(err) => {
+                        error_modal_shown = true;
                         try_skip!(
                             event_tx.send(AppEvent::InfoModal {
                                 message: vec![
@@ -116,6 +118,7 @@ pub(crate) fn init(
                         match result {
                             Ok((theme_path, theme)) => (theme_path, theme),
                             Err(err) => {
+                                error_modal_shown = true;
                                 try_skip!(
                                     event_tx.send(AppEvent::InfoModal {
                                         message: vec![
@@ -138,6 +141,7 @@ pub(crate) fn init(
                 };
 
                 let Ok(config) = config.into_config(theme, None, None, true).inspect_err(|err| {
+                    error_modal_shown = true;
                     try_skip!(
                         event_tx.send(AppEvent::InfoModal {
                             message: vec![
@@ -166,11 +170,16 @@ pub(crate) fn init(
                     theme_name = None;
                 }
 
-                try_skip!(
-                    event_tx.send(AppEvent::UiAppEvent(crate::ui::UiAppEvent::PopConfigErrorModal)),
-                    "Failed to pop config error modal"
-                );
+                if error_modal_shown {
+                    error_modal_shown = false;
+                    try_skip!(
+                        event_tx
+                            .send(AppEvent::UiAppEvent(crate::ui::UiAppEvent::PopConfigErrorModal)),
+                        "Failed to pop config error modal"
+                    );
+                }
 
+                log::debug!("Config changed, sending event");
                 try_skip!(
                     event_tx.send(AppEvent::ConfigChanged {
                         config: Box::new(config),

--- a/rmpc/src/ui/mod.rs
+++ b/rmpc/src/ui/mod.rs
@@ -908,10 +908,10 @@ impl<'ui> Ui<'ui> {
                 self.modals
                     .retain(|m| m.replacement_id().is_none_or(|id| id != ERROR_CONFIG_MODAL_ID));
                 let new_len = self.modals.len();
-                if new_len == 0 {
-                    self.on_event(UiEvent::ModalClosed, ctx)?;
-                }
                 if original_len != new_len {
+                    if new_len == 0 {
+                        self.on_event(UiEvent::ModalClosed, ctx)?;
+                    }
                     ctx.render()?;
                 }
             }
@@ -919,10 +919,10 @@ impl<'ui> Ui<'ui> {
                 let original_len = self.modals.len();
                 self.modals.retain(|m| m.id() != id);
                 let new_len = self.modals.len();
-                if new_len == 0 {
-                    self.on_event(UiEvent::ModalClosed, ctx)?;
-                }
                 if original_len != new_len {
+                    if new_len == 0 {
+                        self.on_event(UiEvent::ModalClosed, ctx)?;
+                    }
                     ctx.render()?;
                 }
             }

--- a/rmpc/src/ui/panes/album_art.rs
+++ b/rmpc/src/ui/panes/album_art.rs
@@ -109,8 +109,9 @@ impl Pane for AlbumArtPane {
                 }
                 self.album_art.show_current(ctx)?;
             }
-            UiEvent::ConfigChanged if is_visible && !self.is_modal_open => {
-                self.album_art.show_current(ctx)?;
+            UiEvent::ConfigChanged => {
+                // Not needed to react, config change already executes hide()
+                // and before_show() pair
             }
             UiEvent::Exit => {
                 self.album_art.cleanup()?;


### PR DESCRIPTION
## Description

@NotMephisto sorry for ping, this should be yet another, this time a small improvement to the config reload, might help the stale, lingering, duplicated image being still shown that was on your video too 

### Related issues

### Checklist

- [x] All tests passed
- [x] Code has been formatted with rustfmt (nightly)
- [x] Code has been checked with clippy (stable)
- [x] [Documentation](https://github.com/rmpc-org/rmpc-org.github.io) has been updated (if needed)
- [x] Changelog has been updated
